### PR TITLE
Fix CI workflow permissions to resolve 403 API error

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,6 +13,8 @@ on:
 
 permissions:
   contents: read
+  statuses: write
+  checks: write
 
 # A workflow run is made up of one or more jobs that can run sequentially
 # or in parallel


### PR DESCRIPTION
Add statuses:write and checks:write permissions to the linter workflow to allow super-linter to post commit statuses and check runs to GitHub. This resolves the "Failed to call GitHub Status API: 403" error.