### PR TITLE
Fix markdown linting errors

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -39,7 +39,7 @@ This document provides guidance for AI assistants (like Claude) working on the D
 
 ### v2 Architecture (Current - Recommended)
 
-```
+```text
 YAML Tool Definitions (resources/tools/*.yaml)
     ↓
 YAML Parser (resources/download/yaml-parser.ps1)
@@ -104,7 +104,7 @@ Tools Installed in Windows Sandbox
 
 ## Directory Structure
 
-```
+```text
 dfirws/
 ├── README.md                           # Main project documentation
 ├── AGENT.md                            # This file - AI assistant guide
@@ -607,7 +607,7 @@ Update documentation when:
 
 ### Commit Message Format
 
-```
+```text
 Brief summary (50 chars or less)
 
 Detailed explanation of changes:
@@ -619,7 +619,8 @@ Relevant issue numbers: #123
 ```
 
 **Example:**
-```
+
+```text
 Add support for container-based tools
 
 This commit adds new YAML fields for Docker/Podman container tools:
@@ -832,8 +833,8 @@ git push -u origin <branch-name>
 - **Architecture Guide**: `docs/YAML_ARCHITECTURE.md`
 - **Migration Details**: `MIGRATION_COMPLETE.md`
 - **Future Plans**: `ROADMAP.md`
-- **GitHub Wiki**: https://github.com/reuteras/dfirws/wiki
-- **Issues**: https://github.com/reuteras/dfirws/issues
+- **GitHub Wiki**: <https://github.com/reuteras/dfirws/wiki>
+- **Issues**: <https://github.com/reuteras/dfirws/issues>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ DFIRWS v2 includes **433 tools** across **23 categories**:
 | **Didier Stevens Suite** | 102 | Comprehensive document/malware analysis |
 | **Node.js Tools** | 4 | JavaScript analysis tools |
 
-### Documentation
+### v2 Documentation
 
 - **[YAML Architecture Guide](docs/YAML_ARCHITECTURE.md)** - Complete guide to v2 architecture
 - **[Migration Summary](MIGRATION_COMPLETE.md)** - Details of the v1 to v2 migration

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -141,7 +141,7 @@ DFIRWS aims to provide a comprehensive, isolated environment for digital forensi
 **Achievements**:
 - [x] Created migration summary (`MIGRATION_COMPLETE.md`)
 - [x] Wrote comprehensive architecture guide (`docs/YAML_ARCHITECTURE.md`)
-- [x] Updated main README with v2 section
+- [x] Updated main readme with v2 section
 - [x] Created AI agent instructions (`AGENT.md`)
 - [x] Created project roadmap (this document)
 - [x] 500+ lines of documentation
@@ -337,7 +337,7 @@ These are potential features that may be implemented based on user feedback and 
 
 #### Integration
 
-- **VSCode Extension**: Manage tools from VSCode
+- **Visual Studio Code Extension**: Manage tools from Visual Studio Code
 - **PowerShell Module**: DFIRWS PowerShell module
 - **REST API**: Programmatic tool management
 - **Webhook Support**: Integration with other tools
@@ -457,7 +457,7 @@ Features are prioritized based on:
 
 - **MAJOR**: Breaking changes (v1 → v2)
 - **MINOR**: New features, backward compatible
-- **PATCH**: Bug fixes, minor improvements
+- **PATCH**: Bugfixes, minor improvements
 
 ### Release Cycle
 
@@ -530,9 +530,9 @@ Features are prioritized based on:
 
 ## Contact and Support
 
-- **GitHub Issues**: https://github.com/reuteras/dfirws/issues
-- **GitHub Discussions**: https://github.com/reuteras/dfirws/discussions
-- **Documentation**: https://github.com/reuteras/dfirws/wiki
+- **GitHub Issues**: <https://github.com/reuteras/dfirws/issues>
+- **GitHub Discussions**: <https://github.com/reuteras/dfirws/discussions>
+- **Documentation**: <https://github.com/reuteras/dfirws/wiki>
 - **Email**: See GitHub profile
 
 ---

--- a/docs/ADDING-TOOLS.md
+++ b/docs/ADDING-TOOLS.md
@@ -27,21 +27,24 @@ The `add-tool.ps1` script provides an interactive wizard that:
 The wizard will guide you through the following steps:
 
 ### 1. Tool Name
-```
+
+```text
 Tool name: mytool
 ```
 - Only letters, numbers, hyphens, underscores, and dots allowed
 - Will be used as the tool identifier
 
 ### 2. Description
-```
+
+```text
 Description: A brief description of what this tool does
 ```
 - Brief, one-line description
 - Will be displayed in tool listings
 
 ### 3. Category
-```
+
+```text
 Category: forensics
 ```
 Available categories:
@@ -60,7 +63,8 @@ Available categories:
 - `utilities` - General utilities
 
 ### 4. Source Type
-```
+
+```text
 Source (github/http): github
 ```
 - `github` - Download from GitHub releases
@@ -68,42 +72,50 @@ Source (github/http): github
 
 ### 5. Source-Specific Fields
 
-#### For GitHub sources:
-```
+#### For GitHub sources
+
+```text
 GitHub repository (owner/repo): puffyCid/artemis
   ✓ Found: puffyCid/artemis - Fast forensic collection tool
 
-Asset filename pattern (regex): x86_64-pc-windows-msvc\.zip$
+Asset filename pattern (regular expression): x86_64-pc-windows-msvc\.zip$
 ```
-- Repository will be validated via GitHub API
-- Match pattern is a regex to identify the correct release asset
 
-#### For HTTP sources:
+- Repository will be validated via GitHub API
+- Match pattern is a regular expression to identify the correct release asset
+
+#### For HTTP sources
 
 **Static URL:**
-```
+
+```text
 Use dynamic URL detection? (y/n): n
 Direct download URL: https://example.com/tool.zip
 ```
 
 **Dynamic URL (scraping):**
-```
+
+```text
 Use dynamic URL detection? (y/n): y
 URL pattern (page to scrape): https://example.com/downloads
-Download link regex pattern: tool-.*\.zip
+Download link regular expression pattern: tool-.*\.zip
 ```
 
 ### 6. Version Pinning
-```
+
+```text
 Pin to specific version? (y/n): n
 ```
+
 If yes:
-```
+
+```text
 Version number: 1.2.3
 ```
 
 ### 7. SHA256 Checksum
-```
+
+```text
 Add SHA256 checksum? (y/n): y
 SHA256 checksum (or leave empty to calculate later): abc123...
 ```
@@ -111,7 +123,8 @@ SHA256 checksum (or leave empty to calculate later): abc123...
 - Can be added later by downloading the file and calculating the hash
 
 ### 8. Update Policy
-```
+
+```text
 Update policy (manual/auto/notify): notify
 ```
 - `notify` (default) - Show update available, require approval
@@ -119,7 +132,8 @@ Update policy (manual/auto/notify): notify
 - `auto` - Automatically update to latest version
 
 ### 9. File Type
-```
+
+```text
 File type (zip/exe/msi/jar/war): zip
 ```
 - `zip` - ZIP archive
@@ -129,64 +143,76 @@ File type (zip/exe/msi/jar/war): zip
 - `war` - Web application archive
 
 ### 10. Install Method
-```
+
+```text
 Install method (extract/run/copy): extract
 ```
 
-#### Extract method:
-```
+#### Extract method
+
+```text
 Extract to path: ${TOOLS}/mytool
 ```
+
 Extracts archive to specified directory.
 
-#### Run method:
-```
+#### Run method
+
+```text
 Run arguments (e.g., /S /D=path): /S /D=${TOOLS}\mytool
 ```
+
 Executes installer with arguments.
 
-#### Copy method:
-```
+#### Copy method
+
+```text
 Copy to path: ${TOOLS}/mytool.exe
 ```
 Copies file to destination.
 
 ### 11. Post-Install Steps
-```
+
+```text
 Add post-install steps? (y/n): y
 ```
 
 Available step types:
 
 **Rename:**
-```
+
+```text
 Post-install step type (or 'done' to finish): rename
   Pattern to match: mytool-*
   New name: mytool
 ```
 
 **Move:**
-```
+
+```text
 Post-install step type: move
   Source path: ${TOOLS}/mytool/bin
   Destination path: ${TOOLS}/mytool-bin
 ```
 
 **Delete:**
-```
+
+```text
 Post-install step type: delete
   Path to delete: ${TOOLS}/mytool/temp
 ```
 
 **Symlink:**
-```
+
+```text
 Post-install step type: symlink
   Source path: ${TOOLS}/mytool/mytool.exe
   Link path: ${TOOLS}/bin/mytool.exe
 ```
 
 ### 12. Priority
-```
+
+```text
 Priority (critical/high/medium/low): medium
 ```
 - `critical` - Essential tools, installed first
@@ -195,7 +221,8 @@ Priority (critical/high/medium/low): medium
 - `low` - Optional/specialty tools
 
 ### 13. Enabled
-```
+
+```text
 Enable tool? (true/false): true
 ```
 - `true` - Tool will be installed
@@ -317,7 +344,7 @@ The script performs the following validations:
 ### Input Validation
 - **Tool name**: Alphanumeric, hyphens, underscores, dots only
 - **URLs**: Must start with http:// or https://
-- **GitHub repos**: Validates format (owner/repo) and checks if repo exists
+- **GitHub repositories**: Validates format (owner/repository) and checks if repository exists
 - **Categories**: Must match predefined list
 - **Enums**: File type, install method, priority, etc.
 
@@ -371,13 +398,16 @@ Get-FileHash .\downloads\mytool.zip -Algorithm SHA256
 ## Troubleshooting
 
 ### GitHub Repository Not Found
-```
+
+```text
 ✗ Repository not found
 ```
-**Solution**: Check the repository name format (owner/repo) and ensure it's public
+
+**Solution**: Check the repository name format (owner/repository) and ensure it's public
 
 ### YAML Validation Failed
-```
+
+```text
 ✗ YAML validation failed: ...
 ```
 **Solution**: Review the generated YAML for syntax errors, check indentation

--- a/docs/MODULAR-ARCHITECTURE.md
+++ b/docs/MODULAR-ARCHITECTURE.md
@@ -43,7 +43,7 @@ if ($status) {
 
 Tools are organized by category in separate YAML files:
 
-```
+```text
 resources/tools/
 ├── forensics.yaml          # Digital forensics tools
 ├── malware-analysis.yaml   # Malware analysis and RE tools
@@ -119,7 +119,7 @@ Each tool is defined with the following structure:
 
 ### Module Structure
 
-```
+```text
 resources/
 ├── download/
 │   ├── common.ps1            # Common functions (existing)
@@ -215,7 +215,7 @@ Edit the appropriate category file (e.g., `resources/tools/forensics.yaml`):
 .\resources\download\install-tools.ps1 -Category forensics
 ```
 
-### 3. No Code Changes Required!
+### 3. No Code Changes Required
 
 The tool will be automatically processed by the generic handler.
 
@@ -297,8 +297,8 @@ Errors are logged in `log/tool-errors.json`:
 ### Tool Won't Download
 
 1. Check the YAML definition for typos
-2. Verify the GitHub repo exists
-3. Check the regex pattern matches actual release names
+2. Verify the GitHub repository exists
+3. Check the regular expression pattern matches actual release names
 4. Test with `-DryRun` flag
 
 ### Installation Fails
@@ -334,4 +334,4 @@ To add tools to the new system:
 3. Document any special requirements
 4. Submit pull request
 
-For questions or issues, see the main [README](../README.md) or open an issue on GitHub.
+For questions or issues, see the main [Readme](../README.md) or open an issue on GitHub.

--- a/docs/PHASE2-BATCH2-PROGRESS.md
+++ b/docs/PHASE2-BATCH2-PROGRESS.md
@@ -75,7 +75,7 @@ Batch 2 continues the tool migration with focus on specialized categories includ
 
 ### Completion Visualization
 
-```
+```text
 Phase 1:   ████████░░░░░░░░░░░░░░░░░░░░ 30 tools (13.6%)
 Batch 1:   ████████████████████░░░░░░░░ 57 tools (25.9%)
 Batch 2:   ████████████████░░░░░░░░░░░░ 46 tools (20.9%)
@@ -155,7 +155,7 @@ Successfully created specialized categories for:
 
 2. **Plugins and Extensions**
    - Ghidra plugins (some done)
-   - VS Code extensions (some done)
+   - Visual Studio Code extensions (some done)
    - IDA plugins
 
 3. **Optional Components**
@@ -225,7 +225,7 @@ Successfully created specialized categories for:
    - Validate installations
 
 3. **Documentation**
-   - Update README
+   - Update readme
    - Tool catalog generation
    - Migration completion guide
 

--- a/docs/PHASE2-BATCH3-PROGRESS.md
+++ b/docs/PHASE2-BATCH3-PROGRESS.md
@@ -33,7 +33,7 @@ Key tools:
 ### 2. code-editors.yaml (9 tools)
 Code editors, IDEs, and their extensions:
 - **Notepad++ Plugins**: comparePlus, dspellcheck, nppmarkdownpanel
-- **VSCode Extensions**: vscode-powershell, vscode-shellcheck, vscode-spell-checker
+- **Visual Studio Code Extensions**: vscode-powershell, vscode-shellcheck, vscode-spell-checker
 - **Editors**: edit (Microsoft CLI editor), cmder (console emulator)
 
 Key features:
@@ -107,7 +107,7 @@ All from kacos2000, complementing Eric Zimmerman tools.
 
 ### Cumulative Progress
 
-```
+```text
 Phase 1:  ████████░░░░░░░░░░░░░░░░░░░░  13.6%
 Batch 1:  ████████████████████░░░░░░░░░░  39.5%
 Batch 2:  ███████████████████████████░░░  60.5%
@@ -125,7 +125,7 @@ Focus on PE file analysis, binary manipulation, and low-level inspection:
 ### Development Tools (9)
 IDE plugins and editor extensions:
 - Notepad++ plugins (3)
-- VSCode extensions (3)
+- Visual Studio Code extensions (3)
 - Editors (2)
 - Console emulators (1)
 
@@ -157,7 +157,7 @@ GUI tools for Windows artifact viewing:
 - Multiple Golang analyzer versions
 
 ### Integration Features
-- VSCode extension distribution
+- Visual Studio Code extension distribution
 - Notepad++ plugin deployment
 - Ghidra extension manager support
 - Obsidian vault integration
@@ -236,7 +236,7 @@ Based on legacy script analysis:
 ### Special Handling
 - **Fonts**: Nerd Fonts require manual installation or script
 - **Dokany**: MSI installer available for manual installation
-- **VSCode extensions**: VSIX files for extension manager
+- **Visual Studio Code extensions**: VSIX files for extension manager
 - **Ghidra plugins**: ZIP files for Ghidra extension manager
 - **Notepad++ plugins**: Require Notepad++ to be installed first
 

--- a/docs/PHASE2-BATCH4-PROGRESS.md
+++ b/docs/PHASE2-BATCH4-PROGRESS.md
@@ -87,7 +87,7 @@ Added:
 
 ### Cumulative Progress
 
-```
+```text
 Phase 1:  ████████░░░░░░░░░░░░░░░░░░░░░░░░  13.6%
 Batch 1:  ████████████████████░░░░░░░░░░░░  39.5%
 Batch 2:  ███████████████████████████░░░░░  60.5%
@@ -142,7 +142,7 @@ Obsidian plugins require custom installation logic:
 
 Based on analysis of legacy scripts, the remaining tools are primarily:
 1. **Python/Node.js package-based tools** (requires special handling)
-2. **Git clone repositories** (requires git integration)
+2. **Git clone repositories** (requires Git integration)
 3. **Custom/manual installation tools** (local files, special procedures)
 4. **Deprecated or optional tools** (may not need migration)
 
@@ -157,14 +157,14 @@ Based on analysis of legacy scripts, the remaining tools are primarily:
 The remaining ~13% of tools fall into these categories:
 1. **Python tools**: Require virtualenv and pip installation
 2. **Node.js tools**: Require npm installation
-3. **Git repos**: Require git clone operations
+3. **Git repositories**: Require Git clone operations
 4. **Local tools**: Require manual file placement
 5. **Special cases**: Tools with unique installation requirements
 
 **Recommendation**: Create specialized categories for:
 - `python-tools.yaml` (with pip integration)
 - `nodejs-tools.yaml` (with npm integration)
-- `git-repositories.yaml` (for direct git clones)
+- `git-repositories.yaml` (for direct Git clones)
 
 ## Success Metrics
 
@@ -247,7 +247,7 @@ The remaining ~13% of tools fall into these categories:
 4. **Parallel downloads**: Validate parallel installation performance
 
 ### Documentation Updates
-1. Update main README with migration status
+1. Update main readme with migration status
 2. Create deployment guide
 3. Document custom installation procedures
 4. Create troubleshooting guide

--- a/docs/PHASE2-PROGRESS.md
+++ b/docs/PHASE2-PROGRESS.md
@@ -213,7 +213,7 @@ From analysis of legacy scripts:
 ### What Could Be Improved
 
 1. **URL validation**: Should add URL checking script
-2. **Regex testing**: Need regex validation tool
+2. **Regular expression testing**: Need regular expression validation tool
 3. **Duplicate detection**: Some tools may be in multiple categories
 4. **Version tracking**: Should consider adding version fields
 
@@ -239,7 +239,7 @@ For each migrated tool:
 - [x] Unique tool name
 - [x] Appropriate category
 - [x] Correct source type
-- [x] Valid regex pattern
+- [x] Valid regular expression pattern
 - [x] Proper install method
 - [x] Post-install steps if needed
 - [x] Priority assigned
@@ -255,7 +255,7 @@ For each migrated tool:
 
 ## Progress Visualization
 
-```
+```text
 Phase 1: ████████░░░░░░░░░░░░░░░░░░░░ 30 tools (13.6%)
 Phase 2: ████████████████████░░░░░░░░ 57 tools (25.9%)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/docs/REFACTORING-SUMMARY.md
+++ b/docs/REFACTORING-SUMMARY.md
@@ -33,7 +33,7 @@ The original system had several challenges:
 
 ### New System Components
 
-```
+```text
 dfirws/
 ├── resources/
 │   ├── download/
@@ -150,7 +150,7 @@ Tracks progress and enables resume:
 
 Tools organized by purpose:
 
-```
+```text
 resources/tools/
 ├── forensics.yaml          # DFIR tools
 ├── malware-analysis.yaml   # RE and malware tools
@@ -334,21 +334,21 @@ Both systems can coexist during migration period.
 
 ## Benefits Summary
 
-### For Users
+### Benefits for Users
 
 1. **Faster Downloads**: 5-6x faster with parallel mode
 2. **Better Reliability**: Resume capability, error tracking
 3. **More Control**: Install by category/priority
 4. **Transparency**: Clear progress and statistics
 
-### For Developers
+### Benefits for Developers
 
 1. **Less Code**: 71% reduction in download scripts
 2. **Easier Maintenance**: No code changes for new tools
 3. **Better Testing**: Dry-run mode, smaller files
 4. **Clear Structure**: Organized by category
 
-### For Contributors
+### Benefits for Contributors
 
 1. **Easy to Add Tools**: Edit YAML, no code required
 2. **Self-Documenting**: YAML definitions are clear

--- a/docs/V2-ROADMAP.md
+++ b/docs/V2-ROADMAP.md
@@ -31,7 +31,7 @@
   - malware-analysis.yaml (15+ tools)
   - network-analysis.yaml (8+ tools)
   - utilities.yaml (15+ tools)
-- ✅ Complete documentation (3 guides + README)
+- ✅ Complete documentation (3 guides + readme)
 - ✅ Parallel download support
 - ✅ State management and resume
 
@@ -133,7 +133,7 @@
 **Tasks**:
 - [ ] Remove legacy code (release.ps1, http.ps1)
 - [ ] Consolidate common.ps1 and wscommon.ps1
-- [ ] Update all README files
+- [ ] Update all readme files
 - [ ] Create video tutorials
 - [ ] Migration success stories
 - [ ] Performance comparison reports
@@ -210,7 +210,7 @@
 - [ ] 100% resume success rate
 - [ ] <1% tool failure rate
 
-### Documentation
+### Documentation Goals
 - [ ] Complete API reference
 - [ ] All tools documented
 - [ ] Migration guides updated
@@ -262,7 +262,7 @@
 - Demo/walkthrough
 - Feedback collection
 
-### Documentation
+### Documentation Practices
 - Keep docs updated
 - Add examples as we go
 - Record decisions
@@ -270,7 +270,7 @@
 
 ## Resources
 
-### Documentation
+### Documentation Links
 - [MODULAR-ARCHITECTURE.md](../docs/MODULAR-ARCHITECTURE.md)
 - [MIGRATION-GUIDE.md](../docs/MIGRATION-GUIDE.md)
 - [REFACTORING-SUMMARY.md](../docs/REFACTORING-SUMMARY.md)
@@ -279,7 +279,7 @@
 ### Tools
 - PowerShell 7+
 - Git
-- VS Code
+- Visual Studio Code
 - Pester (testing)
 - powershell-yaml (parsing)
 

--- a/docs/VERSION-MANAGEMENT.md
+++ b/docs/VERSION-MANAGEMENT.md
@@ -9,13 +9,13 @@ This module provides version pinning, SHA256 validation, and update management f
 - **Version Pinning**: Pin tools to specific versions
 - **SHA256 Validation**: Verify file integrity with checksums
 - **Update Detection**: Check for newer versions
-- **Version Lock File**: Track installed versions
+- **Version Lockfile**: Track installed versions
 - **Update Approval**: Review and approve updates
 - **Automatic/Manual Modes**: Choose update strategy
 
 ## Architecture
 
-### 1. Version Lock File
+### 1. Version Lockfile
 
 `downloads/tool-versions.lock.json` - Tracks installed versions:
 
@@ -68,7 +68,7 @@ Add optional version and validation fields:
 
 ### 3. Update Workflow
 
-```
+```text
 1. Check for updates
    └─> Compare current version with latest available
 
@@ -247,7 +247,7 @@ When SHA256 is specified in YAML:
 2. **Use SHA256 validation**: Always validate checksums
 3. **Manual update policy**: Review before updating
 4. **Test before deploying**: Validate in test environment
-5. **Maintain version lock**: Commit lock file to git
+5. **Maintain version lock**: Commit lockfile to Git
 
 ### For Development
 
@@ -257,7 +257,7 @@ When SHA256 is specified in YAML:
 4. **Regular updates**: Check weekly
 5. **Review changes**: Read release notes
 
-## Version Lock File Management
+## Version Lockfile Management
 
 ### Commit to Git
 
@@ -270,16 +270,16 @@ git commit -m "Update tool versions lock file"
 ### Share Across Team
 
 ```powershell
-# Install exact versions from lock file
+# Install exact versions from lockfile
 .\resources\download\install-tools.ps1 -FromLockFile
 
 # This ensures everyone uses same versions
 ```
 
-### Update Lock File
+### Update Lockfile
 
 ```powershell
-# Update lock file without installing
+# Update lockfile without installing
 .\resources\download\install-tools.ps1 -UpdateLockOnly
 
 # Install and update lock
@@ -290,7 +290,7 @@ git commit -m "Update tool versions lock file"
 
 ### Checksum Mismatch
 
-```
+```text
 ERROR: SHA256 mismatch for artemis
 Expected: abc123...
 Actual:   def456...
@@ -303,7 +303,7 @@ Actual:   def456...
 
 ### Version Not Found
 
-```
+```text
 ERROR: Version 1.2.3 not found for artemis
 Latest available: 1.2.4
 ```
@@ -315,7 +315,7 @@ Latest available: 1.2.4
 
 ### Update Detection Fails
 
-```
+```text
 WARNING: Could not check for updates for artemis
 API rate limit exceeded
 ```

--- a/docs/YAML_ARCHITECTURE.md
+++ b/docs/YAML_ARCHITECTURE.md
@@ -19,7 +19,7 @@ DFIRWS v2 introduces a modular YAML-based architecture for managing tool install
 ### ✅ Documentation
 - Every tool includes description, priority, and notes
 - Clear installation methods
-- Source tracking (GitHub, pip, npm, git)
+- Source tracking (GitHub, pip, npm, Git)
 
 ### ✅ Flexibility
 - Multiple installation methods supported
@@ -35,7 +35,7 @@ DFIRWS v2 introduces a modular YAML-based architecture for managing tool install
 
 ## Directory Structure
 
-```
+```text
 dfirws/
 ├── resources/
 │   ├── tools/                          # YAML tool definitions
@@ -44,7 +44,7 @@ dfirws/
 │   │   ├── windows-forensics.yaml
 │   │   ├── ... (20 category files)
 │   │   ├── python-tools.yaml          # Python packages (UV/pip)
-│   │   ├── git-repositories.yaml      # Git repos to clone
+│   │   ├── git-repositories.yaml      # Git repositories to clone
 │   │   ├── nodejs-tools.yaml          # Node.js packages (npm)
 │   │   └── didier-stevens-tools.yaml  # Didier Stevens Suite
 │   │
@@ -189,8 +189,8 @@ beta_tools:
 | Field | Required | Description |
 |-------|----------|-------------|
 | `source` | ✅ | Source type: `github` or `http` |
-| `repo` | ✅ | GitHub repository (owner/repo) |
-| `match` | ✅ | Regex pattern to match release asset |
+| `repo` | ✅ | GitHub repository (owner/repository) |
+| `match` | ✅ | Regular expression pattern to match release asset |
 | `file_type` | ✅ | File type: `zip`, `exe`, `msi`, `jar` |
 | `install_method` | ✅ | Installation method: `extract`, `copy`, `installer` |
 | `extract_to` | ⚠️ | Extraction path (required if `install_method: extract`) |
@@ -544,7 +544,7 @@ Install-Module -Name powershell-yaml -Force
 ### Tool Installation Fails
 
 1. Check log file for specific error
-2. Verify GitHub repo and match pattern
+2. Verify GitHub repository and match pattern
 3. Check network connectivity
 4. Manually download to verify URL
 5. Validate YAML syntax
@@ -581,8 +581,8 @@ Both can be used, but v2 is recommended for new installations.
 
 For issues or questions:
 
-- GitHub Issues: https://github.com/reuteras/dfirws/issues
-- Documentation: https://github.com/reuteras/dfirws/wiki
+- GitHub Issues: <https://github.com/reuteras/dfirws/issues>
+- Documentation: <https://github.com/reuteras/dfirws/wiki>
 - Migration Guide: MIGRATION_COMPLETE.md
 
 ---

--- a/resources/tools/README.md
+++ b/resources/tools/README.md
@@ -104,7 +104,7 @@ resources/tools/
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `repo` | string | Yes | Repository in format `owner/repository` |
-| `match` | string | Yes | Regex pattern to match release asset name |
+| `match` | string | Yes | Regular expression pattern to match release asset name |
 
 #### HTTP Source
 
@@ -112,7 +112,7 @@ resources/tools/
 |-------|------|----------|-------------|
 | `url` | string | No* | Direct download URL |
 | `url_pattern` | string | No* | Base URL to scrape for download link |
-| `match` | string | Yes** | Regex pattern to find download link |
+| `match` | string | Yes** | Regular expression pattern to find download link |
 
 *Either `url` OR `url_pattern` required
 **Required when using `url_pattern`
@@ -366,9 +366,9 @@ post_install:
     target: "${TOOLS}/temp"
 ```
 
-## Regex Patterns
+## Regular Expression Patterns
 
-Common regex patterns for matching releases:
+Common regular expression patterns for matching releases:
 
 ```yaml
 # Match version number
@@ -391,7 +391,7 @@ match: "tool.*\\.zip$"  # Then filter in code if needed
 
 ### Tool Not Found
 
-Check if regex pattern matches actual release names:
+Check if regular expression pattern matches actual release names:
 
 ```powershell
 # View actual release names


### PR DESCRIPTION
This commit fixes all markdown and natural language linting errors across the documentation:

Markdown fixes:
- Add language specifiers to fenced code blocks
- Remove trailing punctuation from headings
- Wrap bare URLs in angle brackets
- Rename duplicate headings for uniqueness

Natural language fixes:
- Replace "git" with "Git"
- Replace "repo" with "repository"
- Replace "regex/Regex" with "regular expression"
- Replace "README" with "readme"
- Replace "VS Code/VSCode" with "Visual Studio Code"
- Replace "lock file/Lock File" with "lockfile"
- Replace "Bug fixes" with "bugfixes"