### PR TITLE
Replace -ErrorAction with try/catch in ShowCounts

### DIFF
--- a/resources/download/install-all-tools-v2.ps1
+++ b/resources/download/install-all-tools-v2.ps1
@@ -75,16 +75,16 @@ if ($ShowCounts) {
     Write-Output "`nStandard GitHub Release Tools: $standardToolCount"
 
     # Count specialized tools
-    $pythonTools = Import-PythonToolsDefinition -ErrorAction SilentlyContinue
+    try { $pythonTools = Import-PythonToolsDefinition } catch { $pythonTools = @() }
     Write-Output "Python Tools: $($pythonTools.Count)"
 
-    $gitRepos = Import-GitRepositoriesDefinition -ErrorAction SilentlyContinue
+    try { $gitRepos = Import-GitRepositoriesDefinition } catch { $gitRepos = @() }
     Write-Output "Git Repositories: $($gitRepos.Count)"
 
-    $nodejsTools = Import-NodeJsToolsDefinition -ErrorAction SilentlyContinue
+    try { $nodejsTools = Import-NodeJsToolsDefinition } catch { $nodejsTools = @() }
     Write-Output "Node.js Tools: $($nodejsTools.Count)"
 
-    $didierTools = Import-DidierStevensToolsDefinition -ErrorAction SilentlyContinue
+    try { $didierTools = Import-DidierStevensToolsDefinition } catch { $didierTools = @() }
     Write-Output "Didier Stevens Tools: $($didierTools.Count)"
 
     $totalTools = $standardToolCount + $pythonTools.Count + $gitRepos.Count + $nodejsTools.Count + $didierTools.Count


### PR DESCRIPTION
Works around PowerShell MetadataError when calling Import-*Definition functions with -ErrorAction parameter. Uses try/catch blocks instead which achieve the same result without triggering the parsing error.