### PR TITLE
Remove [CmdletBinding()] again - linter re-added it

### DIFF
--- a/resources/download/yaml-parser.ps1
+++ b/resources/download/yaml-parser.ps1
@@ -105,7 +105,6 @@ function Import-PythonToolsDefinition {
     .PARAMETER Path
         Path to python-tools.yaml file
     #>
-    [CmdletBinding()]
     param(
         [Parameter(Mandatory=$false)]
         [string]$Path = "${PSScriptRoot}\..\tools\python-tools.yaml"
@@ -242,7 +241,6 @@ function Import-GitRepositoriesDefinition {
     .PARAMETER Path
         Path to git-repositories.yaml file
     #>
-    [CmdletBinding()]
     param(
         [Parameter(Mandatory=$false)]
         [string]$Path = "${PSScriptRoot}\..\tools\git-repositories.yaml"
@@ -329,7 +327,6 @@ function Import-NodeJsToolsDefinition {
     .PARAMETER Path
         Path to nodejs-tools.yaml file
     #>
-    [CmdletBinding()]
     param(
         [Parameter(Mandatory=$false)]
         [string]$Path = "${PSScriptRoot}\..\tools\nodejs-tools.yaml"
@@ -416,7 +413,6 @@ function Import-DidierStevensToolsDefinition {
     .PARAMETER Path
         Path to didier-stevens-tools.yaml file
     #>
-    [CmdletBinding()]
     param(
         [Parameter(Mandatory=$false)]
         [string]$Path = "${PSScriptRoot}\..\tools\didier-stevens-tools.yaml"


### PR DESCRIPTION
The linter re-added [CmdletBinding()] after the previous PR was merged. This causes PowerShell 5.1 MetadataError when calling these functions.

Removes [CmdletBinding()] from all four Import-*Definition functions:
- Import-PythonToolsDefinition
- Import-GitRepositoriesDefinition
- Import-NodeJsToolsDefinition
- Import-DidierStevensToolsDefinition