### PR TITLE
Remove Parameter attributes to fix PowerShell parser bug

### DIFF
--- a/resources/download/yaml-parser.ps1
+++ b/resources/download/yaml-parser.ps1
@@ -106,7 +106,6 @@ function Import-PythonToolsDefinition {
         Path to python-tools.yaml file
     #>
     param(
-        [Parameter(Mandatory=$false)]
         [string]$Path = "${PSScriptRoot}\..\tools\python-tools.yaml"
     )
 
@@ -242,7 +241,6 @@ function Import-GitRepositoriesDefinition {
         Path to git-repositories.yaml file
     #>
     param(
-        [Parameter(Mandatory=$false)]
         [string]$Path = "${PSScriptRoot}\..\tools\git-repositories.yaml"
     )
 
@@ -328,7 +326,6 @@ function Import-NodeJsToolsDefinition {
         Path to nodejs-tools.yaml file
     #>
     param(
-        [Parameter(Mandatory=$false)]
         [string]$Path = "${PSScriptRoot}\..\tools\nodejs-tools.yaml"
     )
 
@@ -414,7 +411,6 @@ function Import-DidierStevensToolsDefinition {
         Path to didier-stevens-tools.yaml file
     #>
     param(
-        [Parameter(Mandatory=$false)]
         [string]$Path = "${PSScriptRoot}\..\tools\didier-stevens-tools.yaml"
     )
 


### PR DESCRIPTION
Removes [Parameter(Mandatory=$false)] attributes from all four Import-*Definition functions. PowerShell 5.1 appears to have a parser bug where even basic parameter attributes can trigger MetadataErrors when functions are dot-sourced and called from within scripts.

This simplifies the param blocks to just:
param([string]$Path = "...")

Which should avoid triggering the PowerShell 5.1 parser bug.