### PR TITLE
Fix YAML parser and tool counting

### DIFF
--- a/resources/download/install-all-tools-v2.ps1
+++ b/resources/download/install-all-tools-v2.ps1
@@ -63,8 +63,9 @@ if ($ShowCounts) {
     Write-Output "========================================`n"
 
     # Count standard tools
-    $standardToolFiles = Get-ChildItem -Path ".\resources\tools" -Filter "*.yaml" `
-        -Exclude "python-tools.yaml","git-repositories.yaml","nodejs-tools.yaml","didier-stevens-tools.yaml"
+    $allToolFiles = Get-ChildItem -Path ".\resources\tools" -Filter "*.yaml"
+    $excludeFiles = @("python-tools.yaml", "git-repositories.yaml", "nodejs-tools.yaml", "didier-stevens-tools.yaml")
+    $standardToolFiles = $allToolFiles | Where-Object { $excludeFiles -notcontains $_.Name }
     $standardToolCount = 0
     foreach ($file in $standardToolFiles) {
         $count = (Get-Content $file.FullName | Select-String -Pattern "^\s+-\s+name:").Count

--- a/resources/download/yaml-parser.ps1
+++ b/resources/download/yaml-parser.ps1
@@ -368,7 +368,8 @@ function Import-NodeJsToolsDefinition {
                 continue
             }
 
-            if ($trimmed -match "^notes:") {
+            # Only stop at root-level notes: (no leading spaces in original line)
+            if ($line -match "^notes:" -and -not $line.StartsWith(" ")) {
                 $inTools = $false
                 continue
             }
@@ -497,7 +498,8 @@ function Import-DidierStevensToolsDefinition {
                 continue
             }
 
-            if ($trimmed -match "^notes:") {
+            # Only stop at root-level notes: (no leading spaces in original line)
+            if ($line -match "^notes:" -and -not $line.StartsWith(" ")) {
                 $inTools = $false
                 continue
             }


### PR DESCRIPTION
Two critical fixes:

1. Fixed -Exclude parameter not working in Get-ChildItem
   - Changed from using -Exclude to Where-Object filtering
   - Now correctly excludes specialized tool files

2. Fixed YAML parser stopping at indented 'notes:' fields
   - Parser was stopping when it hit 'notes:' inside tool definitions
   - Now only stops at root-level 'notes:' (no leading spaces)
   - Fixes Node.js tools (was 1, now should be 4)
   - Fixes Didier Stevens tools (was 2, now should be 102)