### PR TITLE
Add -DownloadOnly mode to v2 YAML-based installation system

### DIFF
--- a/downloadFiles.ps1
+++ b/downloadFiles.ps1
@@ -244,7 +244,7 @@ if ($all -or $MSYS2.IsPresent) {
 
 if ($all -or $Release.IsPresent) {
     Write-DateLog "Download releases from GitHub (v2 YAML-based)."
-    .\resources\download\install-all-tools-v2.ps1 -StandardTools
+    .\resources\download\install-all-tools-v2.ps1 -StandardTools -DownloadOnly
 }
 
 if ($all -or $Http.IsPresent) {
@@ -258,13 +258,13 @@ if ($all -or $Http.IsPresent) {
 
 if ($all -or $Node.IsPresent) {
     Write-Output "" > .\log\node.txt
-    Write-DateLog "Setup Node and install npm packages (v2 YAML-based)."
-    .\resources\download\install-all-tools-v2.ps1 -NodeJsTools
+    Write-DateLog "Download Node packages (v2 YAML-based)."
+    .\resources\download\install-all-tools-v2.ps1 -NodeJsTools -DownloadOnly
 }
 
 if ($all -or $Git.IsPresent) {
-    Write-DateLog "Download and update git repositories (v2 YAML-based)"
-    .\resources\download\install-all-tools-v2.ps1 -GitRepos
+    Write-DateLog "Download git repositories (v2 YAML-based)"
+    .\resources\download\install-all-tools-v2.ps1 -GitRepos -DownloadOnly
 }
 
 if ($all -or $GoLang.IsPresent) {
@@ -275,8 +275,8 @@ if ($all -or $GoLang.IsPresent) {
 
 if ($all -or $Python.IsPresent) {
     Write-Output "" > .\log\python.txt
-    Write-DateLog "Setup Python and install packages (v2 YAML-based)."
-    .\resources\download\install-all-tools-v2.ps1 -PythonTools
+    Write-DateLog "Download Python packages (v2 YAML-based)."
+    .\resources\download\install-all-tools-v2.ps1 -PythonTools -DownloadOnly
 }
 
 if ($all -or $Rust.IsPresent) {
@@ -287,7 +287,7 @@ if ($all -or $Rust.IsPresent) {
 
 if ($all -or $Didier.IsPresent) {
     Write-DateLog "Download Didier Stevens tools (v2 YAML-based)."
-    .\resources\download\install-all-tools-v2.ps1 -DidierStevensTools
+    .\resources\download\install-all-tools-v2.ps1 -DidierStevensTools -DownloadOnly
 }
 
 if ($all -or $Winget.IsPresent) {

--- a/resources/download/install-all-tools-v2.ps1
+++ b/resources/download/install-all-tools-v2.ps1
@@ -37,7 +37,10 @@ param(
     [Switch]$DryRun,
 
     [Parameter(HelpMessage = "Show tool counts by category")]
-    [Switch]$ShowCounts
+    [Switch]$ShowCounts,
+
+    [Parameter(HelpMessage = "Download only without installing")]
+    [Switch]$DownloadOnly
 )
 
 # Import common modules
@@ -168,6 +171,10 @@ if ($installStandard) {
 
     if ($DryRun) {
         $params.DryRun = $true
+    }
+
+    if ($DownloadOnly) {
+        $params.DownloadOnly = $true
     }
 
     # Call the existing install-tools.ps1

--- a/resources/download/tool-handler.ps1
+++ b/resources/download/tool-handler.ps1
@@ -127,6 +127,9 @@ function Install-ToolFromDefinition {
 
     .PARAMETER ValidateChecksum
         If specified, validate SHA256 checksum after download
+
+    .PARAMETER DownloadOnly
+        If specified, only download the tool without installing it
     #>
     param(
         [Parameter(Mandatory=$true)]
@@ -136,7 +139,10 @@ function Install-ToolFromDefinition {
         [switch]$DryRun,
 
         [Parameter(Mandatory=$false)]
-        [switch]$ValidateChecksum
+        [switch]$ValidateChecksum,
+
+        [Parameter(Mandatory=$false)]
+        [switch]$DownloadOnly
     )
 
     $toolName = $ToolDefinition.name
@@ -160,6 +166,12 @@ function Install-ToolFromDefinition {
     if (-not $downloaded) {
         Write-Error "Failed to download $toolName"
         return $false
+    }
+
+    # If DownloadOnly mode, skip installation and post-install steps
+    if ($DownloadOnly) {
+        Write-SynchronizedLog "Successfully downloaded: $toolName (download-only mode)"
+        return $true
     }
 
     # Install the tool based on install method


### PR DESCRIPTION
CRITICAL FIX for v2 branch: The downloadFiles.ps1 script was calling install-all-tools-v2.ps1 which was INSTALLING tools on the host instead of just downloading them. Tools should only be downloaded during the download phase and installed inside the sandbox during setup.

Changes:
========

1. tool-handler.ps1:
   - Added -DownloadOnly parameter to Install-ToolFromDefinition
   - When -DownloadOnly is set, download files but skip:
     * Install-ToolBinary (extraction/copying to ${TOOLS})
     * Invoke-PostInstallSteps

2. install-tools.ps1:
   - Added -DownloadOnly parameter
   - Propagates to Install-ToolFromDefinition in both:
     * Sequential installation path
     * Parallel installation path (PowerShell 7+ and PS 5.1 jobs)

3. install-all-tools-v2.ps1:
   - Added -DownloadOnly parameter
   - Passes to install-tools.ps1 when set

4. downloadFiles.ps1:
   - Added -DownloadOnly flag to ALL v2 installer calls: * -StandardTools (GitHub releases) * -NodeJsTools (npm packages) * -GitRepos (git repositories) * -PythonTools (pip packages) * -DidierStevensTools
   - Updated log messages to say "Download" not "Install"

Impact:
=======
With these changes, running downloadFiles.ps1 will now: ✅ Only download files to downloads/ directory
✅ NOT extract archives to C:\Tools on host
✅ NOT copy executables to C:\Tools\bin on host
✅ NOT run post-install steps on host

All installation (extraction, copying, post-install) will happen inside the sandbox during the setup phase when the v2 installers are called WITHOUT the -DownloadOnly flag.

This fixes the issue where downloadFiles.ps1 was showing: "Installing Standard GitHub Release Tools" and trying to install 363 tools on the host system.