### PR TITLE
Fix YAML parser to handle escape sequences correctly

### DIFF
--- a/resources/download/yaml-parser.ps1
+++ b/resources/download/yaml-parser.ps1
@@ -76,6 +76,10 @@ function Import-ToolDefinition {
         } elseif ($currentTool -and $trimmed -match "^\s*(\w+):\s*(.+)") {
             $key = $matches[1]
             $value = $matches[2].Trim('"').Trim("'")
+            # Handle YAML escape sequences
+            $value = $value -replace '\\\\', '\'  # Convert \\ to \
+            $value = $value -replace '\\n', "`n"  # Convert \n to newline
+            $value = $value -replace '\\t', "`t"  # Convert \t to tab
             $currentTool | Add-Member -NotePropertyName $key -NotePropertyValue $value -Force
         }
     }


### PR DESCRIPTION
BUGFIX: The manual YAML parser was not converting YAML escape sequences when parsing tool definitions. This caused regex patterns in match fields to fail because double backslashes (\\) were not being converted to single backslashes (\).

Issue:
------
When YAML tool definitions contained:
  match: "DitExplorer.*\\.zip$"

The parser was reading this as the literal string:
  DitExplorer.*\\.zip$  (with two backslashes)

But it should be converted to:
  DitExplorer.*\.zip$   (with one backslash)

This caused Get-GitHubRelease to fail matching release files because the regex was looking for a literal backslash character instead of an escaped dot.

Tools affected:
---------------
- ditexplorer (match: "DitExplorer.*\\.zip$")
- bloodhound (match: "BloodHound-win32-x64\\.zip$")
- sharphound (match: "SharpHound.*\\.zip$")
- And potentially many others with regex patterns

Fix:
----
Updated yaml-parser.ps1 to convert YAML escape sequences:
- \\\\ -> \ (escaped backslash)
- \\n -> newline
- \\t -> tab

Now the manual YAML parser correctly handles escape sequences like the powershell-yaml module would.

Testing:
--------
After this fix, the pattern "DitExplorer.*\\.zip$" in YAML will correctly become "DitExplorer.*\.zip$" in the parsed regex, which will match files like "DitExplorer-win64-release.zip".