### PR TITLE
Fix file type validation in tool-handler

### DIFF
--- a/resources/download/tool-handler.ps1
+++ b/resources/download/tool-handler.ps1
@@ -225,6 +225,16 @@ function Get-ToolBinary {
     }
 
     try {
+        # Convert file_type to file command output for validation
+        $fileCheckString = switch ($ToolDefinition.file_type) {
+            "zip" { "Zip archive data" }
+            "exe" { "PE32" }
+            "msi" { "Composite Document File V2 Document" }
+            "jar" { "Java archive data" }
+            "war" { "Java archive data" }
+            default { "" }
+        }
+
         switch ($source) {
             "github" {
                 Write-SynchronizedLog "Downloading $toolName from GitHub: $($ToolDefinition.repo)"
@@ -237,13 +247,13 @@ function Get-ToolBinary {
                         -path $filePath `
                         -match $ToolDefinition.match `
                         -version $versionToInstall `
-                        -check $ToolDefinition.file_type
+                        -check $fileCheckString
                 } else {
                     $status = Get-GitHubRelease `
                         -repo $ToolDefinition.repo `
                         -path $filePath `
                         -match $ToolDefinition.match `
-                        -check $ToolDefinition.file_type
+                        -check $fileCheckString
                 }
 
                 # Validate SHA256 if specified and download succeeded
@@ -279,7 +289,7 @@ function Get-ToolBinary {
                 $status = Get-FileFromUri `
                     -uri $url `
                     -FilePath $filePath `
-                    -check $ToolDefinition.file_type
+                    -check $fileCheckString
 
                 # Validate SHA256 if specified and download succeeded
                 if ($status -and $ToolDefinition.sha256 -and $ValidateChecksum) {


### PR DESCRIPTION
BUGFIX: The tool-handler was passing the YAML file_type value (e.g., "zip", "exe") directly to Get-FileFromUri's -check parameter, but Get-FileFromUri expects the actual output from the 'file' command for validation.

Issue:
------
When downloading files, tool-handler.ps1 called:
  Get-GitHubRelease -check $ToolDefinition.file_type

Where file_type="zip", but Get-FileFromUri expects strings like:
  -check "Zip archive data"

This caused file type validation to fail because the downloaded file would be identified as "Zip archive data" by the file command, but the check was looking for the literal string "zip".

Tools affected:
---------------
- ALL tools using the v2 YAML-based system
- Particularly noticeable with ditexplorer, bloodhound, sharphound, pingcastle

Fix:
----
Added a conversion mapping in tool-handler.ps1 Get-ToolBinary function:
  file_type: "zip" → check: "Zip archive data"
  file_type: "exe" → check: "PE32"
  file_type: "msi" → check: "Composite Document File V2 Document"
  file_type: "jar" → check: "Java archive data"
  file_type: "war" → check: "Java archive data"

Now both GitHub and HTTP source downloads properly validate file types using the expected file command output strings.

Root cause:
-----------
The v2 YAML system simplified file_type to user-friendly values like "zip" and "exe", but didn't convert them to the file command output format that the legacy Get-FileFromUri function expects.