### PR TITLE
Restore extraction operations and fix v2 DownloadOnly mode

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,274 @@
+# DFIRWS Architecture Documentation
+
+## Download vs Installation Architecture
+
+### Overview
+
+DFIRWS uses a two-phase approach to tool deployment:
+1. **Download/Preparation Phase** (runs on HOST)
+2. **Installation Phase** (runs in SANDBOX)
+
+This separation ensures that the host system remains clean while preparing all tools for fast sandbox deployment.
+
+### Phase 1: Download/Preparation (HOST)
+
+**Script**: `downloadFiles.ps1`
+
+**Location**: Runs on the host Windows system
+
+**What it does**:
+- Downloads tool binaries to `downloads/` directory
+- Extracts archives to `mount/Tools/` directory
+- Copies executables to appropriate locations in `mount/Tools/`
+- Renames/moves files within `mount/Tools/` as needed
+- **Does NOT run installers** (MSI/EXE files)
+
+**Why `mount/Tools/`**:
+- This directory is mapped to `C:\Tools` inside the Windows Sandbox
+- Pre-extracting here means tools are immediately available when sandbox starts
+- Significantly speeds up sandbox initialization
+
+**Key Scripts**:
+- `resources/download/http.ps1` - Legacy download script with extraction logic
+- `resources/download/release.ps1` - GitHub releases download (deprecated on v2)
+- `resources/download/winget.ps1` - Winget-based downloads
+- `resources/download/install-all-tools-v2.ps1 -DownloadOnly` - V2 YAML system in download mode
+
+### Phase 2: Installation (SANDBOX)
+
+**Script**: `dfirws-install.ps1`
+
+**Location**: Runs inside Windows Sandbox
+
+**What it does**:
+- Runs installer files (MSI/EXE) that require actual installation
+- Configures Windows-level settings
+- Installs system-wide tools (Visual Studio Code, Java, etc.)
+
+**Why separate**:
+- Installers modify registry, system directories, and require admin privileges
+- These operations should only happen inside the disposable sandbox
+- Keeps the host system clean
+
+### V2 YAML System Architecture
+
+#### Download Mode (`-DownloadOnly`)
+
+When `downloadFiles.ps1` calls the v2 system with `-DownloadOnly` flag:
+
+```powershell
+.\resources\download\install-all-tools-v2.ps1 -StandardTools -DownloadOnly
+```
+
+**Behavior**:
+- ✅ Downloads binaries to `downloads/`
+- ✅ **Extracts** archives to `mount/Tools/` (install_method: extract)
+- ✅ **Copies** executables to `mount/Tools/bin/` (install_method: copy)
+- ✅ **Runs post-install steps** (rename, move, etc.)
+- ❌ **Skips installers** (install_method: installer)
+
+**Example YAML**:
+```yaml
+# This WILL run in DownloadOnly mode (extraction to mount/Tools)
+- name: ripgrep
+  install_method: extract
+  extract_to: "${TOOLS}/ripgrep"
+  post_install:
+    - type: rename
+      pattern: "ripgrep-*"
+      target: "ripgrep"
+
+# This will be SKIPPED in DownloadOnly mode (installer)
+- name: 7zip
+  install_method: installer
+  installer_args: "/qn /norestart"
+```
+
+#### Normal Mode (in Sandbox)
+
+When `dfirws-install.ps1` calls the v2 system WITHOUT `-DownloadOnly`:
+
+```powershell
+.\resources\download\install-all-tools-v2.ps1 -StandardTools
+```
+
+**Behavior**:
+- ✅ Downloads binaries (if not already downloaded)
+- ✅ Extracts archives
+- ✅ Copies files
+- ✅ **Runs installers** (MSI/EXE)
+- ✅ Runs all post-install steps
+
+### Install Methods in V2 YAML
+
+#### `install_method: extract`
+Extracts archives to a directory in `mount/Tools`.
+
+**Runs in**: DownloadOnly ✅ | Normal ✅
+
+**Example**:
+```yaml
+- name: sysinternals
+  file_type: zip
+  install_method: extract
+  extract_to: "${TOOLS}/sysinternals"
+```
+
+**What happens**:
+```powershell
+# Runs on HOST during download phase
+& "7z.exe" x -aoa downloads/sysinternals.zip -o"mount/Tools/sysinternals"
+```
+
+#### `install_method: copy`
+Copies a single file to a location in `mount/Tools`.
+
+**Runs in**: DownloadOnly ✅ | Normal ✅
+
+**Example**:
+```yaml
+- name: fx
+  file_type: exe
+  install_method: copy
+  copy_to: "${TOOLS}/bin/fx.exe"
+```
+
+**What happens**:
+```powershell
+# Runs on HOST during download phase
+Copy-Item downloads/fx.exe mount/Tools/bin/fx.exe
+```
+
+#### `install_method: installer`
+Runs an MSI or EXE installer.
+
+**Runs in**: DownloadOnly ❌ | Normal ✅
+
+**Example**:
+```yaml
+- name: 7zip
+  file_type: msi
+  install_method: installer
+  installer_args: "/qn /norestart"
+```
+
+**What happens**:
+```powershell
+# Runs ONLY in SANDBOX during installation phase
+msiexec /i downloads/7zip.msi /qn /norestart
+```
+
+### Post-Install Steps
+
+Post-install steps (rename, copy, move, remove) run for ALL methods including in `-DownloadOnly` mode when the install_method is `extract` or `copy`.
+
+**Common operations**:
+```yaml
+post_install:
+  # Rename version-specific folders to consistent names
+  - type: rename
+    pattern: "tool-v1.2.3-*"
+    target: "tool"
+
+  # Copy executables to bin directory
+  - type: copy
+    source: "${TOOLS}/tool/tool.exe"
+    target: "${TOOLS}/bin/tool.exe"
+
+  # Remove unnecessary files
+  - type: remove
+    target: "${TOOLS}/tool/readme.txt"
+```
+
+### Directory Structure
+
+```
+dfirws/
+├── downloads/              # Downloaded binaries (not committed)
+│   ├── sysinternals.zip
+│   ├── vscode.exe
+│   └── ...
+│
+├── mount/                  # Mounted into sandbox as C:\
+│   └── Tools/              # Becomes C:\Tools in sandbox
+│       ├── bin/            # Executables
+│       ├── sysinternals/   # Extracted tools
+│       ├── pestudio/
+│       └── ...
+│
+└── resources/
+    ├── download/           # Download scripts
+    │   ├── http.ps1        # Legacy: Download + extract to mount/Tools
+    │   ├── common.ps1      # Shared download functions
+    │   ├── tool-handler.ps1    # V2 YAML processor
+    │   └── install-all-tools-v2.ps1
+    │
+    └── tools/              # V2 YAML definitions
+        ├── utilities.yaml
+        ├── forensics.yaml
+        └── ...
+```
+
+### Workflow Summary
+
+**On the HOST** (before starting sandbox):
+```
+downloadFiles.ps1
+  └─> http.ps1: Download + extract to mount/Tools
+  └─> V2 system with -DownloadOnly:
+       └─> Download binaries
+       └─> Extract to mount/Tools
+       └─> Copy files to mount/Tools
+       └─> Skip installers
+```
+
+**Result**: `mount/Tools/` contains all pre-extracted tools
+
+**In the SANDBOX** (after sandbox starts):
+```
+dfirws-install.ps1
+  └─> V2 system without -DownloadOnly:
+       └─> Run installers (MSI/EXE)
+       └─> Configure system settings
+```
+
+**Result**: System-wide tools installed (Visual Studio Code, Java, etc.)
+
+### Key Principles
+
+1. **Host stays clean**: No installers run on host, only downloads and extractions
+2. **Fast sandbox startup**: Pre-extracted tools in mount/Tools are immediately available
+3. **Installers only in sandbox**: MSI/EXE installers run only in disposable sandbox environment
+4. **Separation of concerns**: Download logic separate from installation logic
+
+### Migration from Legacy to V2
+
+**Legacy system** (http.ps1, release.ps1):
+- Mixed download and extraction in PowerShell scripts
+- Special cases hardcoded for each tool
+- Difficult to maintain
+
+**V2 YAML system**:
+- Declarative tool definitions
+- Generic installation logic
+- Easy to add new tools
+- Clear separation via `-DownloadOnly` flag
+
+**Both systems currently coexist**:
+- Legacy scripts handle tools not yet migrated to YAML
+- V2 YAML system handles newer tools
+- Comments in http.ps1 indicate which tools moved to V2 (e.g., "NOW HANDLED BY V2 YAML")
+
+### Common Gotchas
+
+1. **Don't run installers in download scripts**: Use `-DownloadOnly` mode
+2. **Don't skip extraction in DownloadOnly mode**: Tools need to be in mount/Tools
+3. **Variables**:
+   - `${TOOLS}` = `.\mount\Tools` (on host) or `C:\Tools` (in sandbox)
+   - `${SETUP_PATH}` = `.\downloads`
+   - `${SANDBOX_TOOLS}` = `C:\Tools` (sandbox only)
+
+4. **File type validation**: The `-check` parameter expects file command output:
+   - `"Zip archive data"` (not "zip")
+   - `"PE32"` (not "exe")
+   - `"Composite Document File V2 Document"` (not "msi")

--- a/resources/download/http.ps1
+++ b/resources/download/http.ps1
@@ -62,6 +62,12 @@ $status = Get-FileFromUri -uri "https://raw.githubusercontent.com/SwiftOnSecurit
 
 # Get Sysinternals Suite
 $status = Get-FileFromUri -uri "https://download.sysinternals.com/files/SysinternalsSuite.zip" -FilePath ".\downloads\sysinternals.zip" -check "Zip archive data"
+if ($status) {
+    if (Test-Path -Path "${TOOLS}\sysinternals") {
+        Remove-Item -Recurse -Force "${TOOLS}\sysinternals" | Out-Null 2>&1
+    }
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\sysinternals.zip" -o"${TOOLS}\sysinternals" | Out-Null
+}
 
 # Get exiftool - NOW HANDLED BY V2 YAML (utilities.yaml)
 # Removed duplicate - use: .\downloadFiles.ps1 -Release
@@ -82,9 +88,21 @@ if ($status) {
 
 # Get pestudio
 $status = Get-FileFromUri -uri "https://www.winitor.com/tools/pestudio/current/pestudio.zip" -FilePath ".\downloads\pestudio.zip" -check "Zip archive data"
+if ($status) {
+    if (Test-Path -Path "${TOOLS}\pestudio") {
+        Remove-Item -Recurse -Force "${TOOLS}\pestudio" | Out-Null 2>&1
+    }
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\pestudio.zip" -o"${TOOLS}" | Out-Null
+}
 
 # Get HxD
 $status = Get-FileFromUri -uri "https://mh-nexus.de/downloads/HxDSetup.zip" -FilePath ".\downloads\hxd.zip" -check "Zip archive data"
+if ($status) {
+    if (Test-Path -Path "${TOOLS}\hxd") {
+        Remove-Item -Recurse -Force "${TOOLS}\hxd" | Out-Null 2>&1
+    }
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\hxd.zip" -o"${TOOLS}\hxd" | Out-Null
+}
 
 # Get trid and triddefs - NOW HANDLED BY V2 YAML (document-analysis.yaml)
 # Removed duplicates - use: .\downloadFiles.ps1 -Release
@@ -107,9 +125,21 @@ $status = Get-FileFromUri -uri "https://malcat.fr/latest/malcat_win313_lite.zip"
 
 # Get ssview
 $status = Get-FileFromUri -uri "https://www.mitec.cz/Downloads/SSView.zip" -FilePath ".\downloads\ssview.zip" -check "Zip archive data"
+if ($status) {
+    if (Test-Path -Path "${TOOLS}\ssview") {
+        Remove-Item -Recurse -Force "${TOOLS}\ssview" | Out-Null 2>&1
+    }
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\ssview.zip" -o"${TOOLS}\ssview" | Out-Null
+}
 
 # FullEventLogView
 $status = Get-FileFromUri -uri "https://www.nirsoft.net/utils/fulleventlogview-x64.zip" -FilePath ".\downloads\logview.zip" -check "Zip archive data"
+if ($status) {
+    if (Test-Path -Path "${TOOLS}\FullEventLogView") {
+        Remove-Item -Recurse -Force "${TOOLS}\FullEventLogView" | Out-Null 2>&1
+    }
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\logview.zip" -o"${TOOLS}\FullEventLogView" | Out-Null
+}
 
 # pstwalker - NOW HANDLED BY V2 YAML (email-forensics.yaml)
 # Removed duplicate - use: .\downloadFiles.ps1 -Release
@@ -127,6 +157,12 @@ if ($status) {
 
 # Win API Search
 $status = Get-FileFromUri -uri "https://dennisbabkin.com/php/downloads/WinApiSearch.zip" -FilePath ".\downloads\WinApiSearch.zip" -check "Zip archive data"
+if ($status) {
+    if (Test-Path -Path "${TOOLS}\WinApiSearch") {
+        Remove-Item -Recurse -Force "${TOOLS}\WinApiSearch" | Out-Null 2>&1
+    }
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\WinApiSearch.zip" -o"${TOOLS}\WinApiSearch" | Out-Null
+}
 
 # Capa integration with Ghidra - installed during start
 $status = Get-FileFromUri -uri "https://raw.githubusercontent.com/mandiant/capa/master/capa/ghidra/capa_explorer.py" -FilePath ".\downloads\capa_explorer.py" -check "ASCII text"
@@ -150,24 +186,113 @@ $status = Get-FileFromUri -uri "https://github.com/Velocidex/velociraptor-docs/r
 
 # Mail Viewer
 $status = Get-FileFromUri -uri "https://www.mitec.cz/Downloads/MailView.zip" -FilePath ".\downloads\mailview.zip" -check "Zip archive data"
+if ($status) {
+    if (Test-Path -Path "${TOOLS}\MailView") {
+        Remove-Item -Recurse -Force "${TOOLS}\MailView" | Out-Null 2>&1
+    }
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\mailview.zip" -o"${TOOLS}\MailView" | Out-Null
+}
 
 # Volatility Workbench 3
 $status = Get-FileFromUri -uri "https://www.osforensics.com/downloads/VolatilityWorkbench.zip" -FilePath ".\downloads\volatilityworkbench.zip" -check "Zip archive data"
+if ($status) {
+    if (Test-Path -Path "${TOOLS}\VolatilityWorkbench") {
+        Remove-Item -Recurse -Force "${TOOLS}\VolatilityWorkbench" | Out-Null 2>&1
+    }
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\volatilityworkbench.zip" -o"${TOOLS}\VolatilityWorkbench" | Out-Null
+}
 
 # Volatility Workbench 2
 $status = Get-FileFromUri -uri "https://www.osforensics.com/downloads/VolatilityWorkbench-v2.1.zip" -FilePath ".\downloads\volatilityworkbench2.zip" -check "Zip archive data"
+if ($status) {
+    if (Test-Path -Path "${TOOLS}\VolatilityWorkbench2") {
+        Remove-Item -Recurse -Force "${TOOLS}\VolatilityWorkbench2" | Out-Null 2>&1
+    }
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\volatilityworkbench2.zip" -o"${TOOLS}\VolatilityWorkbench2" | Out-Null
+}
 
 # Volatility Workbench 2 Profiles
 $status = Get-FileFromUri -uri "https://www.osforensics.com/downloads/Collection.zip" -FilePath ".\downloads\volatilityworkbench2profiles.zip" -check "Zip archive data"
 
 # Nirsoft tools
+New-Item -Path "${TOOLS}\nirsoft" -ItemType Directory -Force | Out-Null
+if (Test-Path -Path "${TOOLS}\ntemp") {
+    Remove-Item -Recurse -Force "${TOOLS}\ntemp" | Out-Null 2>&1
+}
+
 $status = Get-FileFromUri -uri "https://www.nirsoft.net/utils/lastactivityview.zip" -FilePath ".\downloads\lastactivityview.zip" -check "Zip archive data"
+if ($status) {
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\lastactivityview.zip" -o"${TOOLS}\ntemp" | Out-Null
+    if (Test-Path -Path ${TOOLS}\ntemp\readme.txt) {
+        Copy-Item "${TOOLS}\ntemp\readme.txt" "${TOOLS}\ntemp\lastactivityview.txt"
+    }
+    Copy-Item ${TOOLS}\ntemp\* "${TOOLS}\nirsoft"
+    Remove-Item -Recurse -Force "${TOOLS}\ntemp" | Out-Null 2>&1
+}
+
 $status = Get-FileFromUri -uri "https://www.nirsoft.net/utils/iecv.zip" -FilePath ".\downloads\iecookiesview.zip" -check "Zip archive data"
+if ($status) {
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\iecookiesview.zip" -o"${TOOLS}\ntemp" | Out-Null
+    if (Test-Path -Path ${TOOLS}\ntemp\readme.txt) {
+        Copy-Item "${TOOLS}\ntemp\readme.txt" "${TOOLS}\ntemp\iecookiesview.txt"
+    }
+    Copy-Item ${TOOLS}\ntemp\* "${TOOLS}\nirsoft"
+    Remove-Item -Recurse -Force "${TOOLS}\ntemp" | Out-Null 2>&1
+}
+
 $status = Get-FileFromUri -uri "https://www.nirsoft.net/utils/mzcv-x64.zip" -FilePath ".\downloads\MZCookiesView.zip" -check "Zip archive data"
+if ($status) {
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\MZCookiesView.zip" -o"${TOOLS}\ntemp" | Out-Null
+    if (Test-Path -Path "${TOOLS}\ntemp\readme.txt") {
+        Copy-Item "${TOOLS}\ntemp\readme.txt" "${TOOLS}\ntemp\MZCookiesView.txt"
+    }
+    Copy-Item ${TOOLS}\ntemp\* "${TOOLS}\nirsoft"
+    Remove-Item -Recurse -Force "${TOOLS}\ntemp" | Out-Null 2>&1
+}
+
 $status = Get-FileFromUri -uri "https://www.nirsoft.net/utils/chromecacheview.zip" -FilePath ".\downloads\chromecacheview.zip" -check "Zip archive data"
+if ($status) {
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\chromecacheview.zip" -o"${TOOLS}\ntemp" | Out-Null
+    if (Test-Path -Path "${TOOLS}\ntemp\readme.txt") {
+        Copy-Item "${TOOLS}\ntemp\readme.txt" "${TOOLS}\ntemp\chromecacheview.txt"
+    }
+    Copy-Item ${TOOLS}\ntemp\* "${TOOLS}\nirsoft"
+    Remove-Item -Recurse -Force "${TOOLS}\ntemp" | Out-Null 2>&1
+}
+
 $status = Get-FileFromUri -uri "https://www.nirsoft.net/utils/mzcacheview.zip" -FilePath ".\downloads\mzcacheview.zip" -check "Zip archive data"
+if ($status) {
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\mzcacheview.zip" -o"${TOOLS}\ntemp" | Out-Null
+    if (Test-Path -Path ${TOOLS}\ntemp\readme.txt) {
+        Copy-Item "${TOOLS}\ntemp\readme.txt" "${TOOLS}\ntemp\mzcacheview.txt"
+    }
+    Copy-Item ${TOOLS}\ntemp\* "${TOOLS}\nirsoft"
+    Remove-Item -Recurse -Force "${TOOLS}\ntemp" | Out-Null 2>&1
+}
+
 $status = Get-FileFromUri -uri "https://www.nirsoft.net/utils/iecacheview.zip" -FilePath ".\downloads\iecacheview.zip" -check "Zip archive data"
+if ($status) {
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\iecacheview.zip" -o"${TOOLS}\ntemp" | Out-Null
+    if (Test-Path -Path "${TOOLS}\ntemp\readme.txt") {
+        Copy-Item "${TOOLS}\ntemp\readme.txt" "${TOOLS}\ntemp\iecacheview.txt"
+    }
+    Copy-Item ${TOOLS}\ntemp\* "${TOOLS}\nirsoft"
+    Remove-Item -Recurse -Force "${TOOLS}\ntemp" | Out-Null
+}
+
 $status = Get-FileFromUri -uri "https://www.nirsoft.net/utils/browsinghistoryview-x64.zip" -FilePath ".\downloads\browsinghistoryview.zip" -check "Zip archive data"
+if ($status) {
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\browsinghistoryview.zip" -o"${TOOLS}\ntemp" | Out-Null
+    if (Test-Path -Path "${TOOLS}\ntemp\readme.txt") {
+        Copy-Item "${TOOLS}\ntemp\readme.txt" "${TOOLS}\ntemp\browsinghistoryview.txt"
+    }
+    Copy-Item ${TOOLS}\ntemp\* "${TOOLS}\nirsoft"
+    Remove-Item -Recurse -Force "${TOOLS}\ntemp" | Out-Null 2>&1
+}
+
+if (Test-Path -Path "${TOOLS}\nirsoft\readme.txt") {
+    Remove-Item -Force "${TOOLS}\nirsoft\readme.txt" | Out-Null 2>&1
+}
 
 # Get winpmem
 $status = Get-FileFromUri -uri "https://github.com/Velocidex/c-aff4/raw/master/tools/pmem/resources/winpmem/winpmem_64.sys" -FilePath ".\downloads\winpmem_64.sys" -check "PE32"
@@ -185,6 +310,14 @@ $status = Get-FileFromUri -uri "https://www.torproject.org$TorBrowserUrl" -FileP
 # DCode
 $DCodeUrl = Get-DownloadUrlFromPage -Url "https://www.digital-detective.net/dcode/" -RegEx "https://www.digital-detective.net/download/download[^']+"
 $status = Get-FileFromUri -uri "${DCodeURL}" -FilePath ".\downloads\dcode.zip" -check "Zip archive data"
+if ($status) {
+    if (Test-Path -Path ${SETUP_PATH}\dcode) {
+        Remove-Item -Recurse -Force ${SETUP_PATH}\dcode | Out-Null 2>&1
+    }
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\dcode.zip" -o"${SETUP_PATH}\dcode" | Out-Null
+    Start-Sleep -Seconds 3
+    Move-Item ${SETUP_PATH}\dcode\Dcode-* "${SETUP_PATH}\dcode\dcode.exe" | Out-Null
+}
 
 # Veracrypt - manual installation
 $VeracryptUrl = Get-DownloadUrlFromPage -Url "https://www.veracrypt.fr/en/Downloads.html" -RegEx 'https://[^"]+VeraCrypt_Setup[^"]+.msi'
@@ -200,9 +333,21 @@ $status = Get-FileFromUri -uri "https://neo4j.com/artifact.php?name=neo4j-commun
 
 # recbin
 $status = Get-FileFromUri -uri "https://github.com/keydet89/Tools/raw/refs/heads/master/exe/recbin.exe" -FilePath ".\downloads\recbin.exe" -check "PE32"
+if ($status) {
+    if (Test-Path -Path "${TOOLS}\bin\recbin.exe") {
+        Remove-Item -Force "${TOOLS}\bin\recbin.exe" | Out-Null 2>&1
+    }
+    Copy-Item ".\downloads\recbin.exe" "${TOOLS}\bin\recbin.exe"
+}
 
 # capa Explorer web
 $status = Get-FileFromUri -uri "https://mandiant.github.io/capa/explorer/capa-explorer-web.zip" -FilePath ".\downloads\capa-explorer-web.zip" -check "Zip archive data"
+if ($status) {
+    if (Test-Path -Path "${TOOLS}\capa-explorer-web") {
+        Remove-Item -Recurse -Force "${TOOLS}\capa-explorer-web" | Out-Null 2>&1
+    }
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\capa-explorer-web.zip" -o"${TOOLS}" | Out-Null
+}
 
 # https://www.libreoffice.org/download/download-libreoffice/ - LibreOffice - installed during start
 $LibreOfficeVersionDownloadPage = Get-DownloadUrlFromPage -Url "https://www.libreoffice.org/download/download-libreoffice/" -RegEx 'https://[^"]+.msi'
@@ -216,6 +361,12 @@ $status = Get-FileFromUri -uri "https://npcap.com/${NpcapVersion}" -FilePath ".\
 # https://www.sqlite.org/download.html - SQLite
 $SQLiteVersion = Get-DownloadUrlFromPage -Url "https://sqlite.org/download.html" -RegEx '[0-9]+/sqlite-tools-win-x64-[^"]+.zip'
 $status = Get-FileFromUri -uri "https://sqlite.org/${SQLiteVersion}" -FilePath ".\downloads\sqlite.zip" -CheckURL "Yes" -check "Zip archive data"
+if ($status) {
+    if (Test-Path -Path "${TOOLS}\sqlite") {
+        Remove-Item -Recurse -Force "${TOOLS}\sqlite" | Out-Null 2>&1
+    }
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\sqlite.zip" -o"${TOOLS}\sqlite" | Out-Null
+}
 
 # OpenVPN - manual installation
 $status = Get-FileFromUri -uri "https://openvpn.net/downloads/openvpn-connect-v3-windows.msi" -FilePath ".\downloads\openvpn.msi" -check "Composite Document File V2 Document"
@@ -223,18 +374,44 @@ $status = Get-FileFromUri -uri "https://openvpn.net/downloads/openvpn-connect-v3
 # https://downloads.digitalcorpora.org/downloads/bulk_extractor - bulk_extractor
 $digitalcorpora_url = "https://digitalcorpora.s3.amazonaws.com/downloads/bulk_extractor/bulk_extractor-2.0.0-windows.zip"
 $status = Get-FileFromUri -uri "${digitalcorpora_url}" -FilePath ".\downloads\bulk_extractor.zip" -CheckURL "Yes" -check "Zip archive data"
+if ($status) {
+    if (Test-Path -Path "${TOOLS}\bulk_extractor") {
+        Remove-Item -Recurse -Force "${TOOLS}\bulk_extractor" | Out-Null 2>&1
+    }
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\bulk_extractor.zip" -o"${TOOLS}\bulk_extractor" | Out-Null
+}
 
 # https://cert.at/en/downloads/software/software-densityscout - DensityScout
 $densityscout_url = Get-DownloadUrlFromPage -url "https://cert.at/en/downloads/software/software-densityscout" -RegEx '[^"]+windows.zip'
 $status = Get-FileFromUri -uri "${densityscout_url}" -FilePath ".\downloads\DensityScout.zip" -CheckURL "Yes" -check "Zip archive data"
+if ($status) {
+    if (Test-Path -Path "${TOOLS}\bin\densityscout.exe") {
+        Remove-Item -Recurse -Force "${TOOLS}\bin\densityscout.exe" | Out-Null 2>&1
+    }
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\DensityScout.zip" -o"${TOOLS}" | Out-Null
+    Start-Sleep -Seconds 3
+    Move-Item "${TOOLS}\win64\densityscout.exe" "${TOOLS}\bin\densityscout.exe"
+}
 
 # https://nmap.org/download.html - Nmap
 $nmap_url = Get-DownloadUrlFromPage -url "https://nmap.org/download.html" -RegEx 'https[^"]+setup.exe'
 $status = Get-FileFromUri -uri "${nmap_url}" -FilePath ".\downloads\nmap.exe" -CheckURL "Yes" -check "PE32"
+if ($status) {
+    if (Test-Path -Path "${TOOLS}\nmap") {
+        Remove-Item -Recurse -Force "${TOOLS}\nmap" | Out-Null 2>&1
+    }
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\nmap.exe" -o"${TOOLS}\nmap" | Out-Null
+}
 
 # https://flatassembler.net/download.php - FASM
 $flatassembler_version = Get-DownloadUrlFromPage -url "https://flatassembler.net/download.php" -RegEx 'fasmw[^"]+zip'
 $status = Get-FileFromUri -uri "https://flatassembler.net/${flatassembler_version}" -FilePath ".\downloads\fasm.zip" -CheckURL "Yes" -check "Zip archive data"
+if ($status) {
+    if (Test-Path -Path "${TOOLS}\fasm") {
+        Remove-Item -Recurse -Force "${TOOLS}\fasm" | Out-Null 2>&1
+    }
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\fasm.zip" -o"${TOOLS}\fasm" | Out-Null
+}
 
 # Terminal for Windows - automatically installed during start
 $status = Get-FileFromUri -uri "https://aka.ms/terminal-canary-zip-x64" -FilePath ".\downloads\terminal.zip" -CheckURL "Yes" -check "Zip archive data"
@@ -242,10 +419,24 @@ $status = Get-FileFromUri -uri "https://aka.ms/terminal-canary-zip-x64" -FilePat
 # https://procdot.com/downloadprocdotbinaries.htm - Procdot
 $procdot_path = Get-DownloadUrlFromPage -url "https://procdot.com/downloadprocdotbinaries.htm" -RegEx 'download[^"]+windows.zip'
 $status = Get-FileFromUri -uri "https://procdot.com/${procdot_path}" -FilePath ".\downloads\procdot.zip" -CheckURL "Yes" -check "Zip archive data"
+if ($status) {
+    if (Test-Path -Path "${TOOLS}\procdot") {
+        Remove-Item -Recurse -Force "${TOOLS}\procdot" | Out-Null 2>&1
+    }
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -pprocdot -aoa "${SETUP_PATH}\procdot.zip" -o"${TOOLS}\procdot" | Out-Null
+}
 
 # https://codeberg.org/hrbrmstr/geolocus-cli/releases - Geolocus CLI
 $geolocus_url = Get-DownloadUrlFromPage -url "https://codeberg.org/hrbrmstr/geolocus-cli/releases" -RegEx 'https://[^"]*geolocus-cli-windows\.exe\.zip' -last
 $status = Get-FileFromUri -uri "${geolocus_url}" -FilePath ".\downloads\geolocus.zip" -CheckURL "Yes" -check "Zip archive data"
+if ($status) {
+    if (Test-Path -Path "${TOOLS}\geolocus") {
+        Remove-Item -Recurse -Force "${TOOLS}\geolocus" | Out-Null 2>&1
+    }
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\geolocus.zip" -o"${TOOLS}\geolocus" | Out-Null
+    Copy-Item "${TOOLS}\geolocus\geolocus-cli-windows.exe" -Destination "${TOOLS}\bin\geolocus-cli.exe" -Force
+    Remove-Item -Recurse -Force "${TOOLS}\geolocus\__MACOSX" | Out-Null 2>&1
+}
 
 # https://www.graphviz.org/download/ - Graphviz - available for manual installation
 $graphviz_url = Get-DownloadUrlFromPage -url "https://www.graphviz.org/download/" -RegEx 'https://[^"]+win64.exe'
@@ -257,21 +448,50 @@ $status = Get-FileFromUri -uri "http://www.rohitab.com/download/api-monitor-v2r1
 # https://gluonhq.com/products/javafx/ - JavaFX 21
 $javafx_version = Get-DownloadUrlFromPage -url "https://gluonhq.com/products/javafx/" -RegEx '21\.[0-9.]+'
 $status = Get-FileFromUri -uri "https://download2.gluonhq.com/openjfx/${javafx_version}/openjfx-${javafx_version}_windows-x64_bin-sdk.zip" -FilePath ".\downloads\openjfx.zip" -CheckURL "Yes" -check "Zip archive data"
+if ($status) {
+    if (Test-Path -Path "${TOOLS}\javafx-sdk") {
+        Remove-Item -Recurse -Force "${TOOLS}\javafx-sdk" | Out-Null 2>&1
+    }
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\openjfx.zip" -o"${TOOLS}" | Out-Null
+    Start-Sleep -Seconds 3
+    Move-Item ${TOOLS}\javafx-sdk-* "${TOOLS}\javafx-sdk"
+}
 
 # https://bitbucket.org/iBotPeaches/apktool/downloads/ - apktool
 $apktool_version = Get-DownloadUrlFromPage -url "https://apktool.org/" -RegEx 'apktool_[^"]+'
 $status = Get-FileFromUri -uri "https://bitbucket.org/iBotPeaches/apktool/downloads/${apktool_version}" -FilePath ".\downloads\apktool.jar" -CheckURL "Yes" -check "Zip archive data"
+if ($status) {
+    Copy-Item ".\downloads\apktool.jar" "${TOOLS}\bin\apktool.jar" -Force
+    Copy-Item "setup\utils\apktool.bat" "${TOOLS}\bin\apktool.bat" -Force
+}
 
 # https://windows.php.net/download - PHP 8
 $PHP_URL = Get-DownloadUrlFromPage -Url "https://windows.php.net/download" -RegEx '/downloads/releases/php-8.[.0-9]+-nts-Win32-vs16-x64.zip'
 $status = Get-FileFromUri -uri "https://windows.php.net${PHP_URL}" -FilePath ".\downloads\php.zip" -CheckURL "Yes" -check "Zip archive data"
+if ($status) {
+    if (Test-Path -Path "${TOOLS}\php") {
+        Remove-Item -Recurse -Force "${TOOLS}\php" | Out-Null 2>&1
+    }
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\php.zip" -o"${TOOLS}\php" | Out-Null
+}
 
 # https://hashcat.net/hashcat/ - hashcat
 $hashcat_version = Get-DownloadUrlFromPage -url "https://hashcat.net/hashcat/" -RegEx 'fil[^"]+\.7z'
 $status = Get-FileFromUri -uri "https://hashcat.net/${hashcat_version}" -FilePath ".\downloads\hashcat.7z" -CheckURL "Yes" -check "7-zip archive data"
+if ($status) {
+    if (Test-Path -Path "${TOOLS}\hashcat") {
+        Remove-Item -Recurse -Force "${TOOLS}\hashcat" | Out-Null 2>&1
+    }
+    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\hashcat.7z" -o"${TOOLS}" | Out-Null
+    Start-Sleep -Seconds 3
+    Move-Item ${TOOLS}\hashcat-* "${TOOLS}\hashcat" | Out-Null
+}
 
 # vmss2core
 $status = Get-FileFromUri -uri "https://archive.org/download/flings.vmware.com/Flings/Vmss2core/vmss2core-sb-8456865.exe" -FilePath ".\downloads\vmss2core.exe" -CheckURL "Yes" -check "PE32"
+if ($status) {
+    Copy-Item ".\downloads\vmss2core.exe" "${TOOLS}\bin\vmss2core.exe" -Force
+}
 
 # Drivers for hashcat
 $intel_driver = Get-DownloadUrlFromPage -url "https://www.intel.com/content/www/us/en/developer/articles/technical/intel-cpu-runtime-for-opencl-applications-with-sycl-support.html" -RegEx 'https://[^"]+\.exe'
@@ -290,4 +510,17 @@ $status = Get-FileFromUri -uri "https://artifacts.elastic.co/downloads/beats/pac
 $status = Get-FileFromUri -uri "https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-${ELK_VERSION}-windows-x86_64.zip" -FilePath ".\downloads\heartbeat.zip" -CheckURL "Yes" -check "Zip archive data"
 $status = Get-FileFromUri -uri "https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-${ELK_VERSION}-windows-x86_64.zip" -FilePath ".\downloads\auditbeat.zip" -CheckURL "Yes" -check "Zip archive data"
 $status = Get-FileFromUri -uri "https://artifacts.elastic.co/downloads/beats/winlogbeat/winlogbeat-${ELK_VERSION}-windows-x86_64.zip" -FilePath ".\downloads\winlogbeat.zip" -CheckURL "Yes" -check "Zip archive data"
+
+# Remove unused files and directories
+if (Test-Path -Path "${TOOLS}\win32") {
+    Remove-Item -Recurse -Force "${TOOLS}\win32" | Out-Null 2>&1
+}
+
+if (Test-Path -Path "${TOOLS}\win64") {
+    Remove-Item -Recurse -Force "${TOOLS}\win64" | Out-Null 2>&1
+}
+
+if (Test-Path -Path "${TOOLS}\license.txt") {
+    Remove-Item -Force "${TOOLS}\license.txt"
+}
 


### PR DESCRIPTION
This fixes a critical misunderstanding about the download vs installation architecture. The correct behavior is:

HOST (download phase):
- Download binaries to downloads/
- Extract archives to mount/Tools/ (mapped to C:\Tools in sandbox)
- Copy/move/rename files within mount/Tools/
- DO NOT run installers (MSI/EXE)

SANDBOX (installation phase):
- Run installers (MSI/EXE) that require system installation
- Configure Windows-level settings

Changes:
1. resources/download/http.ps1
   - Restored ALL extraction operations to mount/Tools
   - Restored copy/move/rename operations for proper tool preparation
   - These operations prepare the mounted directory for sandbox use

2. resources/download/tool-handler.ps1
   - Fixed -DownloadOnly mode to still extract/copy but skip installers
   - install_method: extract/copy now runs in -DownloadOnly mode
   - install_method: installer is skipped in -DownloadOnly mode
   - Post-install steps (rename, move) still run for extract/copy methods

3. agents.md
   - New architecture documentation explaining download vs install phases
   - Documents the two-phase approach and why it exists
   - Explains V2 YAML install methods and -DownloadOnly behavior
   - Provides directory structure and workflow summary

The key insight: Extracting to mount/Tools is NOT "installing on the host"
- it's preparing the mounted directory that becomes C:\Tools in the sandbox. This speeds up sandbox startup significantly.