### PR TITLE
Fix variable expansion and YAML escape sequence handling

### DIFF
--- a/resources/tools/active-directory.yaml
+++ b/resources/tools/active-directory.yaml
@@ -33,9 +33,9 @@ tools:
 
   # BloodHound - AD attack path analysis
   - name: bloodhound
-    description: Active Directory attack path analysis and visualization
+    description: Active Directory attack path analysis and visualization (Legacy v4.x)
     source: github
-    repo: BloodHoundAD/BloodHound
+    repo: SpecterOps/BloodHound-Legacy
     match: "BloodHound-win32-x64\\.zip$"
     file_type: zip
     install_method: extract
@@ -46,12 +46,13 @@ tools:
         target: "BloodHound"
     enabled: true
     priority: high
+    notes: Using Legacy version (v4.x) - BloodHound v8+ is a different architecture
 
   # SharpHound - BloodHound data collector
   - name: sharphound
     description: BloodHound data collector for Active Directory
     source: github
-    repo: BloodHoundAD/SharpHound
+    repo: SpecterOps/SharpHound
     match: "SharpHound.*\\.zip$"
     file_type: zip
     install_method: extract


### PR DESCRIPTION
This fixes three critical issues discovered during testing:

1. Variable Expansion in Expand-EnvironmentVariables
   - Changed $TOOLS to $script:TOOLS to access script-scoped variables
   - Changed $SETUP_PATH to $script:SETUP_PATH
   - Added $script:SANDBOX_TOOLS support
   - Fixes error: "Could not find a part of the path '..\\bin\adalanche.exe'"

2. Escape Sequence Conversion for powershell-yaml Module
   - Added escape sequence conversion when using powershell-yaml module
   - Previously only worked in fallback parser
   - Converts \\\\ to \\ in regex patterns (e.g., DitExplorer.*\\.zip$)
   - Fixes error: "No matching release asset found...with pattern '.*\\\\.zip$'"

3. Updated BloodHound Repositories
   - Changed BloodHoundAD/BloodHound to SpecterOps/BloodHound-Legacy
   - Changed BloodHoundAD/SharpHound to SpecterOps/SharpHound
   - BloodHound project moved to SpecterOps organization
   - Using Legacy v4.x since v8+ has different architecture

The escape sequence handling now works consistently whether powershell-yaml module is installed or the fallback parser is used.