### PR TITLE
Fix property assignment in escape sequence conversion

### DIFF
--- a/resources/download/tool-handler.ps1
+++ b/resources/download/tool-handler.ps1
@@ -57,9 +57,10 @@ function Import-ToolDefinitions {
                     # Fix escape sequences in string properties (especially match patterns)
                     foreach ($prop in $tool.PSObject.Properties) {
                         if ($prop.Value -is [string]) {
-                            $prop.Value = $prop.Value -replace '\\\\', '\'  # Convert \\ to \
-                            $prop.Value = $prop.Value -replace '\\n', "`n"  # Convert \n to newline
-                            $prop.Value = $prop.Value -replace '\\t', "`t"  # Convert \t to tab
+                            $fixedValue = $prop.Value -replace '\\\\', '\'  # Convert \\ to \
+                            $fixedValue = $fixedValue -replace '\\n', "`n"  # Convert \n to newline
+                            $fixedValue = $fixedValue -replace '\\t', "`t"  # Convert \t to tab
+                            $tool.$($prop.Name) = $fixedValue
                         }
                     }
 
@@ -503,10 +504,15 @@ function Expand-EnvironmentVariables {
         [string]$Path
     )
 
-    # Replace common variables using script scope
-    $expanded = $Path -replace '\$\{TOOLS\}', $script:TOOLS
-    $expanded = $expanded -replace '\$\{SETUP_PATH\}', $script:SETUP_PATH
-    $expanded = $expanded -replace '\$\{SANDBOX_TOOLS\}', $script:SANDBOX_TOOLS
+    # Import common.ps1 variables if not already loaded
+    if (-not $TOOLS) {
+        . "$PSScriptRoot\common.ps1"
+    }
+
+    # Replace common variables
+    $expanded = $Path -replace '\$\{TOOLS\}', $TOOLS
+    $expanded = $expanded -replace '\$\{SETUP_PATH\}', $SETUP_PATH
+    $expanded = $expanded -replace '\$\{SANDBOX_TOOLS\}', $SANDBOX_TOOLS
 
     return $expanded
 }


### PR DESCRIPTION
The previous fix for escape sequence conversion in the powershell-yaml path was not actually updating the tool properties. It was assigning to $prop.Value which doesn't modify the underlying object.

Changes:
1. Fixed escape sequence conversion to properly update tool properties
   - Create $fixedValue variable first
   - Assign to $tool.$($prop.Name) to actually update the object
   - This ensures patterns like 'DitExplorer.*\\.zip$' become 'DitExplorer.*\.zip$'

2. Fixed Expand-EnvironmentVariables variable access
   - Removed $script: prefix which doesn't work with dot-sourced variables
   - Added check to source common.ps1 if $TOOLS not defined
   - Now correctly expands ${TOOLS}, ${SETUP_PATH}, ${SANDBOX_TOOLS}

This fixes:
- Patterns still showing double backslash
- Copy paths showing as just '/bin/tool.exe' without mount/Tools prefix