### PR TITLE
Fix variable scope issue in Expand-EnvironmentVariables

### DIFF
--- a/resources/download/tool-handler.ps1
+++ b/resources/download/tool-handler.ps1
@@ -10,6 +10,12 @@ $script:TOOLS_DEFINITIONS_PATH = ".\resources\tools"
 # Import common functions
 . ".\resources\download\common.ps1"
 
+# Capture common.ps1 variables into script scope for use in functions
+$script:TOOLS = $TOOLS
+$script:SETUP_PATH = $SETUP_PATH
+$script:SANDBOX_TOOLS = $SANDBOX_TOOLS
+$script:WSDFIR_TEMP = $WSDFIR_TEMP
+
 #region YAML Parsing
 
 function Import-ToolDefinitions {
@@ -504,15 +510,10 @@ function Expand-EnvironmentVariables {
         [string]$Path
     )
 
-    # Import common.ps1 variables if not already loaded
-    if (-not $TOOLS) {
-        . "$PSScriptRoot\common.ps1"
-    }
-
-    # Replace common variables
-    $expanded = $Path -replace '\$\{TOOLS\}', $TOOLS
-    $expanded = $expanded -replace '\$\{SETUP_PATH\}', $SETUP_PATH
-    $expanded = $expanded -replace '\$\{SANDBOX_TOOLS\}', $SANDBOX_TOOLS
+    # Replace common variables using script-scoped variables
+    $expanded = $Path -replace '\$\{TOOLS\}', $script:TOOLS
+    $expanded = $expanded -replace '\$\{SETUP_PATH\}', $script:SETUP_PATH
+    $expanded = $expanded -replace '\$\{SANDBOX_TOOLS\}', $script:SANDBOX_TOOLS
 
     return $expanded
 }


### PR DESCRIPTION
The Expand-EnvironmentVariables function was unable to access variables from common.ps1 because of PowerShell's dot-sourcing scope behavior.

When tool-handler.ps1 is dot-sourced by another script (like install-all-tools-v2.ps1), the variables from common.ps1 don't end up in tool-handler.ps1's script scope - they end up in the caller's scope.

Changes:
1. Added explicit $script: variable assignments after dot-sourcing common.ps1
   - $script:TOOLS = $TOOLS
   - $script:SETUP_PATH = $SETUP_PATH
   - $script:SANDBOX_TOOLS = $SANDBOX_TOOLS
   - $script:WSDFIR_TEMP = $WSDFIR_TEMP

2. Updated Expand-EnvironmentVariables to use $script: scope
   - Changed $TOOLS to $script:TOOLS
   - Changed $SETUP_PATH to $script:SETUP_PATH
   - Changed $SANDBOX_TOOLS to $script:SANDBOX_TOOLS
   - Removed the conditional dot-sourcing logic

This fixes the issue where paths were showing as empty strings followed by the relative path (e.g., "/bin/adalanche.exe" instead of ".\mount\Tools/bin/adalanche.exe").