### PR TITLE
Add fallback mechanism for variable expansion

### DIFF
--- a/resources/download/tool-handler.ps1
+++ b/resources/download/tool-handler.ps1
@@ -510,10 +510,35 @@ function Expand-EnvironmentVariables {
         [string]$Path
     )
 
-    # Replace common variables using script-scoped variables
-    $expanded = $Path -replace '\$\{TOOLS\}', $script:TOOLS
-    $expanded = $expanded -replace '\$\{SETUP_PATH\}', $script:SETUP_PATH
-    $expanded = $expanded -replace '\$\{SANDBOX_TOOLS\}', $script:SANDBOX_TOOLS
+    # Try to get variables from various scopes, with fallback to defaults
+    $toolsPath = if ($script:TOOLS) {
+        $script:TOOLS
+    } elseif (Get-Variable -Name TOOLS -ValueOnly -ErrorAction SilentlyContinue) {
+        Get-Variable -Name TOOLS -ValueOnly
+    } else {
+        ".\mount\Tools"
+    }
+
+    $setupPath = if ($script:SETUP_PATH) {
+        $script:SETUP_PATH
+    } elseif (Get-Variable -Name SETUP_PATH -ValueOnly -ErrorAction SilentlyContinue) {
+        Get-Variable -Name SETUP_PATH -ValueOnly
+    } else {
+        ".\downloads"
+    }
+
+    $sandboxTools = if ($script:SANDBOX_TOOLS) {
+        $script:SANDBOX_TOOLS
+    } elseif (Get-Variable -Name SANDBOX_TOOLS -ValueOnly -ErrorAction SilentlyContinue) {
+        Get-Variable -Name SANDBOX_TOOLS -ValueOnly
+    } else {
+        "C:\Tools"
+    }
+
+    # Replace common variables
+    $expanded = $Path -replace '\$\{TOOLS\}', $toolsPath
+    $expanded = $expanded -replace '\$\{SETUP_PATH\}', $setupPath
+    $expanded = $expanded -replace '\$\{SANDBOX_TOOLS\}', $sandboxTools
 
     return $expanded
 }


### PR DESCRIPTION
The previous variable scoping fix wasn't working because when tool-handler.ps1 is dot-sourced by another script, the assignment '$script:TOOLS = $TOOLS' evaluates $TOOLS in the current scope which may not have access to common.ps1's variables yet.

Changes to Expand-EnvironmentVariables:
1. Try $script:TOOLS first (if set in script scope)
2. Fall back to Get-Variable -Name TOOLS (searches parent scopes)
3. Fall back to hardcoded defaults if neither works:
   - TOOLS: ".\mount\Tools"
   - SETUP_PATH: ".\downloads"
   - SANDBOX_TOOLS: "C:\Tools"

This multi-level fallback ensures variables are found regardless of:
- How the module is loaded (dot-sourced vs imported)
- Order of execution
- Scope visibility issues

Fixes paths showing as just "\bin\adalanche.exe" instead of the full ".\mount\Tools\bin\adalanche.exe".