### PR TITLE
Convert Didier Stevens tools to standard YAML format

### DIFF
--- a/resources/tools/didier-stevens-tools.yaml
+++ b/resources/tools/didier-stevens-tools.yaml
@@ -9,579 +9,1135 @@ schema_version: "1.0"
 category: didier-stevens-tools
 description: Didier Stevens' comprehensive Python toolkit for malware analysis and forensics
 
-# Main suite from DidierStevensSuite repository
-main_suite:
-  source: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/"
-  destination: "${TOOLS}/DidierStevens/"
-  tools:
-    # PDF Analysis Tools
-    - name: pdf-parser.py
-      description: Parse and analyze PDF files for malicious content
-      category_type: document-analysis
-      priority: critical
-      notes: Core tool for PDF malware analysis
-
-    - name: pdfid.py
-      description: Scan PDF files for suspicious keywords and structure
-      category_type: document-analysis
-      priority: critical
-      notes: Quick triage tool for suspicious PDFs
-
-    - name: pdfid.ini
-      description: Configuration file for pdfid.py
-      category_type: document-analysis
-      priority: critical
-
-    - name: pdftool.py
-      description: Swiss army knife tool for PDF analysis
-      category_type: document-analysis
-      priority: high
-
-    # Office Document Analysis Tools
-    - name: oledump.py
-      description: Analyze OLE files (Office documents) for VBA macros
-      category_type: document-analysis
-      priority: critical
-      notes: Essential tool for Office malware analysis
-
-    - name: rtfdump.py
-      description: Analyze RTF files for malicious content
-      category_type: document-analysis
-      priority: high
-
-    - name: decompress_rtf.py
-      description: Decompress compressed RTF content
-      category_type: document-analysis
-      priority: medium
-
-    - name: emldump.py
-      description: Analyze email files
-      category_type: document-analysis
-      priority: high
-
-    - name: zipdump.py
-      description: Analyze ZIP files and Office Open XML documents
-      category_type: document-analysis
-      priority: high
-
-    - name: xmldump.py
-      description: Analyze XML files
-      category_type: document-analysis
-      priority: medium
-
-    - name: jpegdump.py
-      description: Analyze JPEG files for embedded content
-      category_type: document-analysis
-      priority: medium
-
-    # OLE Plugins (for oledump.py)
-    - name: plugin_biff.py
-      description: BIFF record analysis plugin
-      category_type: document-analysis
-      priority: medium
-
-    - name: plugin_clsid.py
-      description: CLSID identification plugin
-      category_type: document-analysis
-      priority: medium
-
-    - name: plugin_dridex.py
-      description: Dridex malware detection plugin
-      category_type: document-analysis
-      priority: medium
-
-    - name: plugin_dttm.py
-      description: Timestamp analysis plugin
-      category_type: document-analysis
-      priority: low
-
-    - name: plugin_embeddedfile.py
-      description: Embedded file extraction plugin
-      category_type: document-analysis
-      priority: high
-
-    - name: plugin_hifo.py
-      description: HIFO structure analysis plugin
-      category_type: document-analysis
-      priority: low
-
-    - name: plugin_http_heuristics.py
-      description: HTTP URL detection plugin
-      category_type: document-analysis
-      priority: medium
-
-    - name: plugin_hyperlink.py
-      description: Hyperlink extraction plugin
-      category_type: document-analysis
-      priority: medium
-
-    - name: plugin_jumplist.py
-      description: Jump list analysis plugin
-      category_type: document-analysis
-      priority: low
-
-    - name: plugin_linear.py
-      description: Linear stream analysis plugin
-      category_type: document-analysis
-      priority: low
-
-    - name: plugin_list
-      description: "Plugin list file for oledump.py"
-      category_type: document-analysis
-      priority: low
-
-    - name: plugin_metadata.py
-      description: Document metadata extraction plugin
-      category_type: document-analysis
-      priority: medium
-
-    - name: plugin_msg_summary.py
-      description: MSG file summary plugin
-      category_type: document-analysis
-      priority: medium
-
-    - name: plugin_msg.py
-      description: MSG file analysis plugin
-      category_type: document-analysis
-      priority: medium
-
-    - name: plugin_msi.py
-      description: MSI file analysis plugin
-      category_type: document-analysis
-      priority: medium
-
-    - name: plugin_msi_info.py
-      description: MSI information extraction plugin
-      category_type: document-analysis
-      priority: medium
-
-    - name: plugin_nameobfuscation.py
-      description: Name obfuscation detection plugin
-      category_type: document-analysis
-      priority: high
-
-    - name: plugin_office_crypto.py
-      description: Office encryption detection plugin
-      category_type: document-analysis
-      priority: high
-
-    - name: plugin_olestreams.py
-      description: OLE stream analysis plugin
-      category_type: document-analysis
-      priority: medium
-
-    - name: plugin_pcode_dumper.py
-      description: P-code dumper plugin
-      category_type: document-analysis
-      priority: high
-
-    - name: plugin_ppt.py
-      description: PowerPoint analysis plugin
-      category_type: document-analysis
-      priority: medium
-
-    - name: plugin_str_sub.py
-      description: String substitution plugin
-      category_type: document-analysis
-      priority: low
-
-    - name: plugin_stream_o.py
-      description: Stream object analysis plugin
-      category_type: document-analysis
-      priority: low
-
-    - name: plugin_stream_sample.py
-      description: Sample stream plugin
-      category_type: document-analysis
-      priority: low
-
-    - name: plugin_triage.py
-      description: Quick triage plugin
-      category_type: document-analysis
-      priority: high
-
-    - name: plugin_vba_dco.py
-      description: VBA DCO analysis plugin
-      category_type: document-analysis
-      priority: medium
-
-    - name: plugin_vba_dir.py
-      description: VBA directory analysis plugin
-      category_type: document-analysis
-      priority: medium
-
-    - name: plugin_vba_routines.py
-      description: VBA routine extraction plugin
-      category_type: document-analysis
-      priority: medium
-
-    - name: plugin_vba_summary.py
-      description: VBA summary plugin
-      category_type: document-analysis
-      priority: high
-
-    - name: plugin_vba.py
-      description: VBA analysis plugin
-      category_type: document-analysis
-      priority: high
-
-    - name: plugin_vbaproject.py
-      description: VBA project analysis plugin
-      category_type: document-analysis
-      priority: medium
-
-    - name: plugin_version_vba.py
-      description: VBA version detection plugin
-      category_type: document-analysis
-      priority: low
-
-    # Binary Analysis and Encoding Tools
-    - name: base64dump.py
-      description: Search and decode Base64 strings in files
-      category_type: binary-analysis
-      priority: high
-      notes: Essential for finding encoded malicious content
-
-    - name: byte-stats.py
-      description: Calculate byte statistics for files
-      category_type: binary-analysis
-      priority: medium
-
-    - name: pecheck.py
-      description: Check PE file structure
-      category_type: binary-analysis
-      priority: high
-
-    - name: hex-to-bin.py
-      description: Convert hexadecimal to binary
-      category_type: utilities
-      priority: medium
-
-    - name: numbers-to-hex.py
-      description: Convert numbers to hexadecimal
-      category_type: utilities
-      priority: low
-
-    - name: numbers-to-string.py
-      description: Convert numbers to strings
-      category_type: utilities
-      priority: low
-
-    - name: format-bytes.py
-      description: Format byte sequences for analysis
-      category_type: utilities
-      priority: medium
-
-    - name: find-file-in-file.py
-      description: Find embedded files within files
-      category_type: binary-analysis
-      priority: high
-
-    # Cryptography and Hashing Tools
-    - name: cipher-tool.py
-      description: Cipher analysis and manipulation tool
-      category_type: cryptography
-      priority: high
-
-    - name: xor-kpa.py
-      description: XOR known plaintext attack
-      category_type: cryptography
-      priority: high
-      notes: Recover XOR keys from known plaintext
-
-    - name: xorsearch.py
-      description: Search for XOR encoded strings
-      category_type: cryptography
-      priority: high
-
-    - name: hash.py
-      description: Calculate various hash types
-      category_type: utilities
-      priority: high
-
-    - name: nsrl.py
-      description: NSRL hash database lookup
-      category_type: utilities
-      priority: medium
-
-    - name: ssdeep.py
-      description: Fuzzy hashing tool
-      category_type: utilities
-      priority: medium
-
-    - name: msoffcrypto-crack.py
-      description: Microsoft Office password cracking
-      category_type: cryptography
-      priority: medium
-
-    # JavaScript and Script Analysis
-    - name: js-ascii.exe
-      description: JavaScript ASCII decoder
-      category_type: malware-analysis
-      priority: medium
-
-    - name: js-file.exe
-      description: JavaScript file analyzer
-      category_type: malware-analysis
-      priority: medium
-
-    - name: decode-vbe.py
-      description: Decode VBScript encoded files
-      category_type: malware-analysis
-      priority: high
-
-    # Decoders
-    - name: decoder_add1.py
-      description: Add 1 decoder
-      category_type: utilities
-      priority: low
-
-    - name: decoder_ah.py
-      description: ASCII hex decoder
-      category_type: utilities
-      priority: low
-
-    - name: decoder_chr.py
-      description: Character decoder
-      category_type: utilities
-      priority: low
-
-    - name: decoder_rol1.py
-      description: Rotate left 1 decoder
-      category_type: utilities
-      priority: low
-
-    - name: decoder_xor1.py
-      description: XOR 1 decoder
-      category_type: utilities
-      priority: low
-
-    # String and Text Processing Tools
-    - name: strings.py
-      description: Enhanced strings extraction tool
-      category_type: utilities
-      priority: high
-
-    - name: re-search.py
-      description: Regular expression search tool
-      category_type: utilities
-      priority: high
-
-    - name: reextra.py
-      description: Extended regular expression library
-      category_type: utilities
-      priority: medium
-
-    - name: count.py
-      description: Count occurrences in data
-      category_type: utilities
-      priority: medium
-
-    - name: translate.py
-      description: Character translation tool
-      category_type: utilities
-      priority: medium
-
-    - name: sortcanon.py
-      description: Sort and canonicalize data
-      category_type: utilities
-      priority: low
-
-    # Data Processing Tools
-    - name: cut-bytes.py
-      description: Cut byte ranges from files
-      category_type: utilities
-      priority: medium
-
-    - name: headtail.py
-      description: Display head and tail of files
-      category_type: utilities
-      priority: medium
-
-    - name: split.py
-      description: Split files
-      category_type: utilities
-      priority: low
-
-    - name: split-overlap.py
-      description: Split files with overlap
-      category_type: utilities
-      priority: low
-
-    - name: teeplus.py
-      description: Enhanced tee functionality
-      category_type: utilities
-      priority: low
-
-    # CSV and Statistics Tools
-    - name: csv-stats.py
-      description: CSV statistics calculator
-      category_type: data-analysis
-      priority: medium
-
-    - name: sets.py
-      description: Set operations on data
-      category_type: data-analysis
-      priority: low
-
-    # JSON Tools
-    - name: myjson-filter.py
-      description: Filter JSON data
-      category_type: data-analysis
-      priority: medium
-
-    - name: myjson-transform.py
-      description: Transform JSON data
-      category_type: data-analysis
-      priority: medium
-
-    # File Identification Tools
-    - name: file-magic.py
-      description: File type identification via magic bytes
-      category_type: utilities
-      priority: high
-
-    - name: file-magic.def
-      description: Magic byte definitions
-      category_type: utilities
-      priority: high
-
-    # CobaltStrike Tools
-    - name: cs-analyze-processdump.py
-      description: Analyze CobaltStrike process dumps
-      category_type: malware-analysis
-      priority: medium
-
-    - name: cs-decrypt-metadata.py
-      description: Decrypt CobaltStrike metadata
-      category_type: malware-analysis
-      priority: medium
-
-    - name: cs-extract-key.py
-      description: Extract CobaltStrike keys
-      category_type: malware-analysis
-      priority: medium
-
-    # Specialized Tools
-    - name: 1768.py
-      description: CVE-2017-1768 analysis tool
-      category_type: malware-analysis
-      priority: low
-
-    - name: 1768.json
-      description: Configuration for 1768.py
-      category_type: malware-analysis
-      priority: low
-
-    - name: amsiscan.py
-      description: AMSI (Anti-Malware Scan Interface) scanner
-      category_type: utilities
-      priority: medium
-
-    - name: defuzzer.py
-      description: Defuzz obfuscated data
-      category_type: malware-analysis
-      priority: high
-
-    - name: disitool.py
-      description: DISI file analysis tool
-      category_type: utilities
-      priority: low
-
-    - name: myipaddress.py
-      description: IP address utility
-      category_type: utilities
-      priority: low
-
-    - name: what-is-new.py
-      description: Check for tool updates
-      category_type: utilities
-      priority: low
-
-    # Processing Frameworks
-    - name: process-binary-file.py
-      description: Binary file processing framework
-      category_type: utilities
-      priority: high
-
-    - name: process-text-file.py
-      description: Text file processing framework
-      category_type: utilities
-      priority: high
-
-    - name: python-per-line.py
-      description: Execute Python code per line
-      category_type: utilities
-      priority: medium
-
-    - name: python-per-line.library
-      description: Library for python-per-line.py
-      category_type: utilities
-      priority: medium
-
-    # Support Files
-    - name: libnspr4.dll
-      description: Netscape Portable Runtime library
-      category_type: utilities
-      priority: low
-
-# Beta tools from Beta repository
-beta_tools:
-  source: "https://raw.githubusercontent.com/DidierStevens/Beta/master/"
-  destination: "${TOOLS}/DidierStevens/"
-  tools:
-    - name: metatool.py
-      description: Metadata analysis tool (beta)
-      category_type: document-analysis
-      priority: medium
-      notes: Beta version, may have experimental features
-
-    - name: onedump.py
-      description: OneNote file dump tool (beta)
-      category_type: document-analysis
-      priority: medium
-      notes: Beta version for OneNote analysis
-
-    - name: pngdump.py
-      description: PNG file analysis tool (beta)
-      category_type: document-analysis
-      priority: medium
-      notes: Beta version for PNG analysis
-
-    - name: xlsbdump.py
-      description: XLSB (Excel Binary) file analysis tool (beta)
-      category_type: document-analysis
-      priority: medium
-      notes: Beta version for XLSB analysis
-
-notes: |
-  Didier Stevens Tools Suite is a comprehensive collection of Python scripts
-  for malware analysis, document forensics, and binary analysis.
-
-  Key tool categories:
-  - PDF Analysis: pdf-parser.py, pdfid.py, pdftool.py
-  - Office Documents: oledump.py with 30+ plugins
-  - Email Analysis: emldump.py
-  - Binary Analysis: base64dump.py, pecheck.py, strings.py
-  - Cryptography: xorsearch.py, xor-kpa.py, cipher-tool.py
-  - File Formats: rtfdump.py, zipdump.py, xmldump.py, jpegdump.py
-  - Utilities: Many data processing and analysis utilities
-
-  Installation:
-  - All tools downloaded directly from GitHub
-  - Main suite: 99 files from DidierStevensSuite repository
-  - Beta tools: 4 files from Beta repository
-  - Total: 103 files
-
-  Requirements:
-  - Python 3.x
-  - Virtual environment at C:\venv\default
-  - Some tools have additional dependencies
-
-  The suite is installed to: ${TOOLS}/DidierStevens/
-
-  Author: Didier Stevens (https://blog.didierstevens.com)
-  Main repo: https://github.com/DidierStevens/DidierStevensSuite
-  Beta repo: https://github.com/DidierStevens/Beta
-
-  Total tools: 103 (99 main + 4 beta)
+tools:
+  # Parse and analyze PDF files for malicious content
+  - name: pdf-parser.py
+    description: Parse and analyze PDF files for malicious content
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/pdf-parser.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/pdf-parser.py"
+    enabled: true
+    priority: critical
+    notes: Core tool for PDF malware analysis
+
+  # Scan PDF files for suspicious keywords and structure
+  - name: pdfid.py
+    description: Scan PDF files for suspicious keywords and structure
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/pdfid.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/pdfid.py"
+    enabled: true
+    priority: critical
+    notes: Quick triage tool for suspicious PDFs
+
+  # Configuration file for pdfid.py
+  - name: pdfid.ini
+    description: Configuration file for pdfid.py
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/pdfid.ini"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/pdfid.ini"
+    enabled: true
+    priority: critical
+
+  # Swiss army knife tool for PDF analysis
+  - name: pdftool.py
+    description: Swiss army knife tool for PDF analysis
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/pdftool.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/pdftool.py"
+    enabled: true
+    priority: high
+
+  # Analyze OLE files (Office documents) for VBA macros
+  - name: oledump.py
+    description: Analyze OLE files (Office documents) for VBA macros
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/oledump.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/oledump.py"
+    enabled: true
+    priority: critical
+    notes: Essential tool for Office malware analysis
+
+  # Analyze RTF files for malicious content
+  - name: rtfdump.py
+    description: Analyze RTF files for malicious content
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/rtfdump.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/rtfdump.py"
+    enabled: true
+    priority: high
+
+  # Decompress compressed RTF content
+  - name: decompress_rtf.py
+    description: Decompress compressed RTF content
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/decompress_rtf.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/decompress_rtf.py"
+    enabled: true
+    priority: medium
+
+  # Analyze email files
+  - name: emldump.py
+    description: Analyze email files
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/emldump.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/emldump.py"
+    enabled: true
+    priority: high
+
+  # Analyze ZIP files and Office Open XML documents
+  - name: zipdump.py
+    description: Analyze ZIP files and Office Open XML documents
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/zipdump.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/zipdump.py"
+    enabled: true
+    priority: high
+
+  # Analyze XML files
+  - name: xmldump.py
+    description: Analyze XML files
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/xmldump.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/xmldump.py"
+    enabled: true
+    priority: medium
+
+  # Analyze JPEG files for embedded content
+  - name: jpegdump.py
+    description: Analyze JPEG files for embedded content
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/jpegdump.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/jpegdump.py"
+    enabled: true
+    priority: medium
+
+  # BIFF record analysis plugin
+  - name: plugin_biff.py
+    description: BIFF record analysis plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_biff.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_biff.py"
+    enabled: true
+    priority: medium
+
+  # CLSID identification plugin
+  - name: plugin_clsid.py
+    description: CLSID identification plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_clsid.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_clsid.py"
+    enabled: true
+    priority: medium
+
+  # Dridex malware detection plugin
+  - name: plugin_dridex.py
+    description: Dridex malware detection plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_dridex.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_dridex.py"
+    enabled: true
+    priority: medium
+
+  # Timestamp analysis plugin
+  - name: plugin_dttm.py
+    description: Timestamp analysis plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_dttm.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_dttm.py"
+    enabled: true
+    priority: low
+
+  # Embedded file extraction plugin
+  - name: plugin_embeddedfile.py
+    description: Embedded file extraction plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_embeddedfile.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_embeddedfile.py"
+    enabled: true
+    priority: high
+
+  # HIFO structure analysis plugin
+  - name: plugin_hifo.py
+    description: HIFO structure analysis plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_hifo.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_hifo.py"
+    enabled: true
+    priority: low
+
+  # HTTP URL detection plugin
+  - name: plugin_http_heuristics.py
+    description: HTTP URL detection plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_http_heuristics.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_http_heuristics.py"
+    enabled: true
+    priority: medium
+
+  # Hyperlink extraction plugin
+  - name: plugin_hyperlink.py
+    description: Hyperlink extraction plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_hyperlink.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_hyperlink.py"
+    enabled: true
+    priority: medium
+
+  # Jump list analysis plugin
+  - name: plugin_jumplist.py
+    description: Jump list analysis plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_jumplist.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_jumplist.py"
+    enabled: true
+    priority: low
+
+  # Linear stream analysis plugin
+  - name: plugin_linear.py
+    description: Linear stream analysis plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_linear.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_linear.py"
+    enabled: true
+    priority: low
+
+  # "Plugin list file for oledump.py"
+  - name: plugin_list
+    description: "Plugin list file for oledump.py"
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_list"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_list"
+    enabled: true
+    priority: low
+
+  # Document metadata extraction plugin
+  - name: plugin_metadata.py
+    description: Document metadata extraction plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_metadata.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_metadata.py"
+    enabled: true
+    priority: medium
+
+  # MSG file summary plugin
+  - name: plugin_msg_summary.py
+    description: MSG file summary plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_msg_summary.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_msg_summary.py"
+    enabled: true
+    priority: medium
+
+  # MSG file analysis plugin
+  - name: plugin_msg.py
+    description: MSG file analysis plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_msg.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_msg.py"
+    enabled: true
+    priority: medium
+
+  # MSI file analysis plugin
+  - name: plugin_msi.py
+    description: MSI file analysis plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_msi.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_msi.py"
+    enabled: true
+    priority: medium
+
+  # MSI information extraction plugin
+  - name: plugin_msi_info.py
+    description: MSI information extraction plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_msi_info.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_msi_info.py"
+    enabled: true
+    priority: medium
+
+  # Name obfuscation detection plugin
+  - name: plugin_nameobfuscation.py
+    description: Name obfuscation detection plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_nameobfuscation.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_nameobfuscation.py"
+    enabled: true
+    priority: high
+
+  # Office encryption detection plugin
+  - name: plugin_office_crypto.py
+    description: Office encryption detection plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_office_crypto.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_office_crypto.py"
+    enabled: true
+    priority: high
+
+  # OLE stream analysis plugin
+  - name: plugin_olestreams.py
+    description: OLE stream analysis plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_olestreams.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_olestreams.py"
+    enabled: true
+    priority: medium
+
+  # P-code dumper plugin
+  - name: plugin_pcode_dumper.py
+    description: P-code dumper plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_pcode_dumper.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_pcode_dumper.py"
+    enabled: true
+    priority: high
+
+  # PowerPoint analysis plugin
+  - name: plugin_ppt.py
+    description: PowerPoint analysis plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_ppt.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_ppt.py"
+    enabled: true
+    priority: medium
+
+  # String substitution plugin
+  - name: plugin_str_sub.py
+    description: String substitution plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_str_sub.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_str_sub.py"
+    enabled: true
+    priority: low
+
+  # Stream object analysis plugin
+  - name: plugin_stream_o.py
+    description: Stream object analysis plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_stream_o.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_stream_o.py"
+    enabled: true
+    priority: low
+
+  # Sample stream plugin
+  - name: plugin_stream_sample.py
+    description: Sample stream plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_stream_sample.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_stream_sample.py"
+    enabled: true
+    priority: low
+
+  # Quick triage plugin
+  - name: plugin_triage.py
+    description: Quick triage plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_triage.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_triage.py"
+    enabled: true
+    priority: high
+
+  # VBA DCO analysis plugin
+  - name: plugin_vba_dco.py
+    description: VBA DCO analysis plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_vba_dco.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_vba_dco.py"
+    enabled: true
+    priority: medium
+
+  # VBA directory analysis plugin
+  - name: plugin_vba_dir.py
+    description: VBA directory analysis plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_vba_dir.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_vba_dir.py"
+    enabled: true
+    priority: medium
+
+  # VBA routine extraction plugin
+  - name: plugin_vba_routines.py
+    description: VBA routine extraction plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_vba_routines.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_vba_routines.py"
+    enabled: true
+    priority: medium
+
+  # VBA summary plugin
+  - name: plugin_vba_summary.py
+    description: VBA summary plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_vba_summary.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_vba_summary.py"
+    enabled: true
+    priority: high
+
+  # VBA analysis plugin
+  - name: plugin_vba.py
+    description: VBA analysis plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_vba.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_vba.py"
+    enabled: true
+    priority: high
+
+  # VBA project analysis plugin
+  - name: plugin_vbaproject.py
+    description: VBA project analysis plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_vbaproject.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_vbaproject.py"
+    enabled: true
+    priority: medium
+
+  # VBA version detection plugin
+  - name: plugin_version_vba.py
+    description: VBA version detection plugin
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/plugin_version_vba.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/plugin_version_vba.py"
+    enabled: true
+    priority: low
+
+  # Search and decode Base64 strings in files
+  - name: base64dump.py
+    description: Search and decode Base64 strings in files
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/base64dump.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/base64dump.py"
+    enabled: true
+    priority: high
+    notes: Essential for finding encoded malicious content
+
+  # Calculate byte statistics for files
+  - name: byte-stats.py
+    description: Calculate byte statistics for files
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/byte-stats.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/byte-stats.py"
+    enabled: true
+    priority: medium
+
+  # Check PE file structure
+  - name: pecheck.py
+    description: Check PE file structure
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/pecheck.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/pecheck.py"
+    enabled: true
+    priority: high
+
+  # Convert hexadecimal to binary
+  - name: hex-to-bin.py
+    description: Convert hexadecimal to binary
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/hex-to-bin.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/hex-to-bin.py"
+    enabled: true
+    priority: medium
+
+  # Convert numbers to hexadecimal
+  - name: numbers-to-hex.py
+    description: Convert numbers to hexadecimal
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/numbers-to-hex.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/numbers-to-hex.py"
+    enabled: true
+    priority: low
+
+  # Convert numbers to strings
+  - name: numbers-to-string.py
+    description: Convert numbers to strings
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/numbers-to-string.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/numbers-to-string.py"
+    enabled: true
+    priority: low
+
+  # Format byte sequences for analysis
+  - name: format-bytes.py
+    description: Format byte sequences for analysis
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/format-bytes.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/format-bytes.py"
+    enabled: true
+    priority: medium
+
+  # Find embedded files within files
+  - name: find-file-in-file.py
+    description: Find embedded files within files
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/find-file-in-file.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/find-file-in-file.py"
+    enabled: true
+    priority: high
+
+  # Cipher analysis and manipulation tool
+  - name: cipher-tool.py
+    description: Cipher analysis and manipulation tool
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/cipher-tool.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/cipher-tool.py"
+    enabled: true
+    priority: high
+
+  # XOR known plaintext attack
+  - name: xor-kpa.py
+    description: XOR known plaintext attack
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/xor-kpa.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/xor-kpa.py"
+    enabled: true
+    priority: high
+    notes: Recover XOR keys from known plaintext
+
+  # Search for XOR encoded strings
+  - name: xorsearch.py
+    description: Search for XOR encoded strings
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/xorsearch.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/xorsearch.py"
+    enabled: true
+    priority: high
+
+  # Calculate various hash types
+  - name: hash.py
+    description: Calculate various hash types
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/hash.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/hash.py"
+    enabled: true
+    priority: high
+
+  # NSRL hash database lookup
+  - name: nsrl.py
+    description: NSRL hash database lookup
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/nsrl.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/nsrl.py"
+    enabled: true
+    priority: medium
+
+  # Fuzzy hashing tool
+  - name: ssdeep.py
+    description: Fuzzy hashing tool
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/ssdeep.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/ssdeep.py"
+    enabled: true
+    priority: medium
+
+  # Microsoft Office password cracking
+  - name: msoffcrypto-crack.py
+    description: Microsoft Office password cracking
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/msoffcrypto-crack.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/msoffcrypto-crack.py"
+    enabled: true
+    priority: medium
+
+  # JavaScript ASCII decoder
+  - name: js-ascii.exe
+    description: JavaScript ASCII decoder
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/js-ascii.exe"
+    file_type: exe
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/js-ascii.exe"
+    enabled: true
+    priority: medium
+
+  # JavaScript file analyzer
+  - name: js-file.exe
+    description: JavaScript file analyzer
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/js-file.exe"
+    file_type: exe
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/js-file.exe"
+    enabled: true
+    priority: medium
+
+  # Decode VBScript encoded files
+  - name: decode-vbe.py
+    description: Decode VBScript encoded files
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/decode-vbe.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/decode-vbe.py"
+    enabled: true
+    priority: high
+
+  # Add 1 decoder
+  - name: decoder_add1.py
+    description: Add 1 decoder
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/decoder_add1.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/decoder_add1.py"
+    enabled: true
+    priority: low
+
+  # ASCII hex decoder
+  - name: decoder_ah.py
+    description: ASCII hex decoder
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/decoder_ah.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/decoder_ah.py"
+    enabled: true
+    priority: low
+
+  # Character decoder
+  - name: decoder_chr.py
+    description: Character decoder
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/decoder_chr.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/decoder_chr.py"
+    enabled: true
+    priority: low
+
+  # Rotate left 1 decoder
+  - name: decoder_rol1.py
+    description: Rotate left 1 decoder
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/decoder_rol1.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/decoder_rol1.py"
+    enabled: true
+    priority: low
+
+  # XOR 1 decoder
+  - name: decoder_xor1.py
+    description: XOR 1 decoder
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/decoder_xor1.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/decoder_xor1.py"
+    enabled: true
+    priority: low
+
+  # Enhanced strings extraction tool
+  - name: strings.py
+    description: Enhanced strings extraction tool
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/strings.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/strings.py"
+    enabled: true
+    priority: high
+
+  # Regular expression search tool
+  - name: re-search.py
+    description: Regular expression search tool
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/re-search.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/re-search.py"
+    enabled: true
+    priority: high
+
+  # Extended regular expression library
+  - name: reextra.py
+    description: Extended regular expression library
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/reextra.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/reextra.py"
+    enabled: true
+    priority: medium
+
+  # Count occurrences in data
+  - name: count.py
+    description: Count occurrences in data
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/count.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/count.py"
+    enabled: true
+    priority: medium
+
+  # Character translation tool
+  - name: translate.py
+    description: Character translation tool
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/translate.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/translate.py"
+    enabled: true
+    priority: medium
+
+  # Sort and canonicalize data
+  - name: sortcanon.py
+    description: Sort and canonicalize data
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/sortcanon.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/sortcanon.py"
+    enabled: true
+    priority: low
+
+  # Cut byte ranges from files
+  - name: cut-bytes.py
+    description: Cut byte ranges from files
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/cut-bytes.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/cut-bytes.py"
+    enabled: true
+    priority: medium
+
+  # Display head and tail of files
+  - name: headtail.py
+    description: Display head and tail of files
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/headtail.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/headtail.py"
+    enabled: true
+    priority: medium
+
+  # Split files
+  - name: split.py
+    description: Split files
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/split.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/split.py"
+    enabled: true
+    priority: low
+
+  # Split files with overlap
+  - name: split-overlap.py
+    description: Split files with overlap
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/split-overlap.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/split-overlap.py"
+    enabled: true
+    priority: low
+
+  # Enhanced tee functionality
+  - name: teeplus.py
+    description: Enhanced tee functionality
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/teeplus.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/teeplus.py"
+    enabled: true
+    priority: low
+
+  # CSV statistics calculator
+  - name: csv-stats.py
+    description: CSV statistics calculator
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/csv-stats.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/csv-stats.py"
+    enabled: true
+    priority: medium
+
+  # Set operations on data
+  - name: sets.py
+    description: Set operations on data
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/sets.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/sets.py"
+    enabled: true
+    priority: low
+
+  # Filter JSON data
+  - name: myjson-filter.py
+    description: Filter JSON data
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/myjson-filter.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/myjson-filter.py"
+    enabled: true
+    priority: medium
+
+  # Transform JSON data
+  - name: myjson-transform.py
+    description: Transform JSON data
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/myjson-transform.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/myjson-transform.py"
+    enabled: true
+    priority: medium
+
+  # File type identification via magic bytes
+  - name: file-magic.py
+    description: File type identification via magic bytes
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/file-magic.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/file-magic.py"
+    enabled: true
+    priority: high
+
+  # Magic byte definitions
+  - name: file-magic.def
+    description: Magic byte definitions
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/file-magic.def"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/file-magic.def"
+    enabled: true
+    priority: high
+
+  # Analyze CobaltStrike process dumps
+  - name: cs-analyze-processdump.py
+    description: Analyze CobaltStrike process dumps
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/cs-analyze-processdump.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/cs-analyze-processdump.py"
+    enabled: true
+    priority: medium
+
+  # Decrypt CobaltStrike metadata
+  - name: cs-decrypt-metadata.py
+    description: Decrypt CobaltStrike metadata
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/cs-decrypt-metadata.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/cs-decrypt-metadata.py"
+    enabled: true
+    priority: medium
+
+  # Extract CobaltStrike keys
+  - name: cs-extract-key.py
+    description: Extract CobaltStrike keys
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/cs-extract-key.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/cs-extract-key.py"
+    enabled: true
+    priority: medium
+
+  # CVE-2017-1768 analysis tool
+  - name: 1768.py
+    description: CVE-2017-1768 analysis tool
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/1768.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/1768.py"
+    enabled: true
+    priority: low
+
+  # Configuration for 1768.py
+  - name: 1768.json
+    description: Configuration for 1768.py
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/1768.json"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/1768.json"
+    enabled: true
+    priority: low
+
+  # AMSI (Anti-Malware Scan Interface) scanner
+  - name: amsiscan.py
+    description: AMSI (Anti-Malware Scan Interface) scanner
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/amsiscan.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/amsiscan.py"
+    enabled: true
+    priority: medium
+
+  # Defuzz obfuscated data
+  - name: defuzzer.py
+    description: Defuzz obfuscated data
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/defuzzer.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/defuzzer.py"
+    enabled: true
+    priority: high
+
+  # DISI file analysis tool
+  - name: disitool.py
+    description: DISI file analysis tool
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/disitool.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/disitool.py"
+    enabled: true
+    priority: low
+
+  # IP address utility
+  - name: myipaddress.py
+    description: IP address utility
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/myipaddress.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/myipaddress.py"
+    enabled: true
+    priority: low
+
+  # Check for tool updates
+  - name: what-is-new.py
+    description: Check for tool updates
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/what-is-new.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/what-is-new.py"
+    enabled: true
+    priority: low
+
+  # Binary file processing framework
+  - name: process-binary-file.py
+    description: Binary file processing framework
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/process-binary-file.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/process-binary-file.py"
+    enabled: true
+    priority: high
+
+  # Text file processing framework
+  - name: process-text-file.py
+    description: Text file processing framework
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/process-text-file.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/process-text-file.py"
+    enabled: true
+    priority: high
+
+  # Execute Python code per line
+  - name: python-per-line.py
+    description: Execute Python code per line
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/python-per-line.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/python-per-line.py"
+    enabled: true
+    priority: medium
+
+  # Library for python-per-line.py
+  - name: python-per-line.library
+    description: Library for python-per-line.py
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/python-per-line.library"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/python-per-line.library"
+    enabled: true
+    priority: medium
+
+  # Netscape Portable Runtime library
+  - name: libnspr4.dll
+    description: Netscape Portable Runtime library
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/DidierStevensSuite/master/libnspr4.dll"
+    file_type: dll
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/libnspr4.dll"
+    enabled: true
+    priority: low
+
+  # Metadata analysis tool (beta)
+  - name: metatool.py
+    description: Metadata analysis tool (beta)
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/Beta/master/metatool.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/metatool.py"
+    enabled: true
+    priority: medium
+    notes: Beta version, may have experimental features
+
+  # OneNote file dump tool (beta)
+  - name: onedump.py
+    description: OneNote file dump tool (beta)
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/Beta/master/onedump.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/onedump.py"
+    enabled: true
+    priority: medium
+    notes: Beta version for OneNote analysis
+
+  # PNG file analysis tool (beta)
+  - name: pngdump.py
+    description: PNG file analysis tool (beta)
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/Beta/master/pngdump.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/pngdump.py"
+    enabled: true
+    priority: medium
+    notes: Beta version for PNG analysis
+
+  # XLSB (Excel Binary) file analysis tool (beta)
+  - name: xlsbdump.py
+    description: XLSB (Excel Binary) file analysis tool (beta)
+    source: http
+    url: "https://raw.githubusercontent.com/DidierStevens/Beta/master/xlsbdump.py"
+    file_type: text
+    install_method: copy
+    copy_to: "${TOOLS}/DidierStevens/xlsbdump.py"
+    enabled: true
+    priority: medium
+    notes: Beta version for XLSB analysis
+


### PR DESCRIPTION
The didier-stevens-tools.yaml file had a custom structure with `main_suite` and `beta_tools` sections that was incompatible with the tool-handler.

Converted 102 tools to the standard format:
- 98 tools from DidierStevensSuite repository (main)
- 4 tools from Beta repository (beta)

Each tool now has:
- source: http
- url: Full GitHub raw URL
- file_type: text (for Python scripts, config files)
- install_method: copy
- copy_to: ${TOOLS}/DidierStevens/[filename]

This fixes the ~100 "Unknown source type" errors that were occurring during downloads.