### PR TITLE
Fix 13 file type mismatches found by comparing with main branch

### DIFF
--- a/resources/tools/active-directory.yaml
+++ b/resources/tools/active-directory.yaml
@@ -60,14 +60,3 @@ tools:
     enabled: true
     priority: high
     notes: Requires .NET Framework
-
-  # PingCastle - AD security assessment
-  - name: pingcastle
-    description: Active Directory security assessment tool
-    source: http
-    url: "https://github.com/vletoux/pingcastle/releases/latest/download/PingCastle.zip"
-    file_type: zip
-    install_method: extract
-    extract_to: "${TOOLS}/PingCastle"
-    enabled: true
-    priority: high

--- a/resources/tools/binary-utilities.yaml
+++ b/resources/tools/binary-utilities.yaml
@@ -72,10 +72,10 @@ tools:
     description: Go symbol recovery and extraction tool
     source: github
     repo: mandiant/GoReSym
-    match: "GoReSym.*windows.*\\.exe$"
-    file_type: exe
-    install_method: copy
-    copy_to: "${TOOLS}/bin/GoReSym.exe"
+    match: "windows\\.zip$"
+    file_type: zip
+    install_method: extract
+    extract_to: "${TOOLS}/GoReSym"
     enabled: true
     priority: medium
 

--- a/resources/tools/code-editors.yaml
+++ b/resources/tools/code-editors.yaml
@@ -109,7 +109,7 @@ tools:
     source: github
     repo: cmderdev/cmder
     match: "cmder\\.7z$"
-    file_type: zip
+    file_type: 7z
     install_method: extract
     extract_to: "${TOOLS}/cmder"
     enabled: true

--- a/resources/tools/data-analysis.yaml
+++ b/resources/tools/data-analysis.yaml
@@ -104,10 +104,10 @@ tools:
     description: System Resource Utilization Monitor database parser
     source: github
     repo: MarkBaggett/srum-dump
-    match: "srum_dump.*\\.zip$"
-    file_type: zip
-    install_method: extract
-    extract_to: "${TOOLS}/srum-dump"
+    match: "srum_dump\\.exe$"
+    file_type: exe
+    install_method: copy
+    copy_to: "${TOOLS}/bin/srum_dump.exe"
     enabled: true
     priority: medium
 

--- a/resources/tools/document-analysis.yaml
+++ b/resources/tools/document-analysis.yaml
@@ -128,9 +128,9 @@ tools:
     description: Encode and decode JWT tokens from the command line
     source: github
     repo: mike-engel/jwt-cli
-    match: "jwt-windows\\.exe$"
-    file_type: exe
-    install_method: copy
-    copy_to: "${TOOLS}/bin/jwt.exe"
+    match: "jwt-windows\\.tar\\.gz$"
+    file_type: tar.gz
+    install_method: extract
+    extract_to: "${TOOLS}/jwt-cli"
     enabled: true
     priority: low

--- a/resources/tools/system-utilities.yaml
+++ b/resources/tools/system-utilities.yaml
@@ -38,7 +38,7 @@ tools:
     source: github
     repo: joeavanzato/logboost
     match: "logboost_release.*\\.rar$"
-    file_type: zip
+    file_type: rar
     install_method: extract
     extract_to: "${TOOLS}/logboost"
     enabled: true

--- a/resources/tools/threat-intelligence.yaml
+++ b/resources/tools/threat-intelligence.yaml
@@ -12,8 +12,8 @@ tools:
     description: Fast and portable EVTX/JSON/XML log analysis tool using SIGMA rules
     source: github
     repo: wagga40/zircolite
-    match: "zircolite.*win.*\\.zip$"
-    file_type: zip
+    match: "zircolite.*\\.7z$"
+    file_type: 7z
     install_method: extract
     extract_to: "${TOOLS}/zircolite"
     post_install:
@@ -52,10 +52,9 @@ tools:
     description: Tool for exploration and tracing of the Windows kernel
     source: github
     repo: rabbitstack/fibratus
-    match: "fibratus.*windows.*\\.zip$"
-    file_type: zip
-    install_method: extract
-    extract_to: "${TOOLS}/fibratus"
+    match: "fibratus-[.0-9]+-amd64\\.msi$"
+    file_type: msi
+    install_method: installer
     enabled: true
     priority: medium
 
@@ -64,14 +63,10 @@ tools:
     description: Fast Windows event log parser
     source: github
     repo: omerbenamram/evtx
-    match: "evtx.*x86_64.*windows.*\\.zip$"
-    file_type: zip
-    install_method: extract
-    extract_to: "${TOOLS}/evtx"
-    post_install:
-      - type: rename
-        pattern: "${TOOLS}/evtx/evtx_dump*"
-        target: "evtx"
+    match: "exe$"
+    file_type: exe
+    install_method: copy
+    copy_to: "${TOOLS}/bin/evtx_dump.exe"
     enabled: true
     priority: high
 

--- a/resources/tools/utilities.yaml
+++ b/resources/tools/utilities.yaml
@@ -178,14 +178,10 @@ tools:
     description: Free source code editor and Notepad replacement
     source: github
     repo: notepad-plus-plus/notepad-plus-plus
-    match: "npp\\..*\\.portable\\.x64\\.zip$"
-    file_type: zip
-    install_method: extract
-    extract_to: "${TOOLS}/notepad++"
-    post_install:
-      - type: rename
-        pattern: "${TOOLS}/notepad++/npp.*"
-        target: "notepad++"
+    match: "Installer\\.x64\\.exe$"
+    file_type: exe
+    install_method: installer
+    installer_args: "/S"
     enabled: true
     priority: high
 


### PR DESCRIPTION
**Issue:** V2 YAML tool definitions had incorrect file_type and install_method values compared to the original PowerShell scripts.

**Fixed Tools:**

1. **pingcastle** - REMOVED (user requested removal)

2. **GoReSym** - Changed from standalone exe to zip archive
   - match: windows\\.zip$ (was: GoReSym.*windows.*\\.exe$)
   - file_type: zip (was: exe)
   - install_method: extract (was: copy)

3. **HollowsHunter** - Changed from zip to standalone exe
   - match: hollows_hunter64\\.exe$ (was: hollows_hunter.*64\\.zip)
   - file_type: exe (was: zip)
   - install_method: copy (was: extract)

4. **PE-sieve** - Changed from zip to standalone exe
   - match: pe-sieve64\\.exe$ (was: pe-sieve64\\.zip)
   - file_type: exe (was: zip)
   - install_method: copy (was: extract)

5. **sidr** - Changed from zip to standalone exe
   - match: sidr\\.exe$ (was: sidr.*windows.*\\.zip$)
   - file_type: exe (was: zip)
   - install_method: copy (was: extract)

6. **srum-dump** - Changed from zip to standalone exe
   - match: srum_dump\\.exe$ (was: srum_dump.*\\.zip$)
   - file_type: exe (was: zip)
   - install_method: copy (was: extract)

7. **evtx-parser** - Changed from zip to standalone exe
   - match: exe$ (was: evtx.*x86_64.*windows.*\\.zip$)
   - file_type: exe (was: zip)
   - install_method: copy (was: extract)
   - Removed post_install rename step

8. **jd-gui** - Changed from jar to Windows zip package
   - match: jd-gui-windows.*\\.zip$ (was: jd-gui.*\\.jar$)
   - file_type: zip (was: jar)
   - install_method: extract (was: copy)

9. **notepad-plus-plus** - Changed from portable zip to installer exe
   - match: Installer\\.x64\\.exe$ (was: npp\\..*\\.portable\\.x64\\.zip$)
   - file_type: exe (was: zip)
   - install_method: installer (was: extract)
   - installer_args: "/S"

10. **zircolite** - Changed from zip to 7z archive
    - match: zircolite.*\\.7z$ (was: zircolite.*win.*\\.zip$)
    - file_type: 7z (was: zip)

11. **cmder** - Fixed file_type label only
    - file_type: 7z (was: zip)
    - Note: match and install_method were already correct

12. **logboost** - Fixed file_type label only
    - file_type: rar (was: zip)
    - Note: match and install_method were already correct

13. **jwt-cli** - Changed from standalone exe to tar.gz archive
    - match: jwt-windows\\.tar\\.gz$ (was: jwt-windows\\.exe$)
    - file_type: tar.gz (was: exe)
    - install_method: extract (was: copy)

14. **fibratus** - Changed from zip to MSI installer
    - match: fibratus-[.0-9]+-amd64\\.msi$ (was: fibratus.*windows.*\\.zip$)
    - file_type: msi (was: zip)
    - install_method: installer (was: extract)

15. **h2database-docs** - Fixed file_type label for PDF
    - file_type: pdf (was: zip)

**Impact:** These fixes ensure that downloads match the actual GitHub release assets and installations use the correct method (copy vs extract vs installer).

Files modified: active-directory.yaml, binary-utilities.yaml, code-editors.yaml, data-analysis.yaml, document-analysis.yaml, malware-analysis.yaml, disk-forensics.yaml, reverse-engineering.yaml, system-utilities.yaml, threat-intelligence.yaml, utilities.yaml