### PR TITLE
Fix match patterns for readpe, elfparser-ng, takajo, loki, and remove…

### DIFF
--- a/resources/tools/binary-utilities.yaml
+++ b/resources/tools/binary-utilities.yaml
@@ -84,10 +84,14 @@ tools:
     description: PE file reader and analyzer
     source: github
     repo: mentebinaria/readpe
-    match: "readpe.*windows.*\\.zip$"
+    match: "win\\.zip$"
     file_type: zip
     install_method: extract
-    extract_to: "${TOOLS}/readpe"
+    extract_to: "${TOOLS}"
+    post_install:
+      - type: rename
+        pattern: "${TOOLS}/pev*"
+        target: "pev"
     enabled: true
     priority: medium
 
@@ -131,8 +135,8 @@ tools:
   - name: elfparser-ng
     description: ELF binary file parser and analyzer
     source: github
-    repo: e-m-b-a/elfparser-ng
-    match: "elfparser-ng.*windows.*\\.zip$"
+    repo: mentebinaria/elfparser-ng
+    match: "win64\\.zip$"
     file_type: zip
     install_method: extract
     extract_to: "${TOOLS}/elfparser-ng"

--- a/resources/tools/data-analysis.yaml
+++ b/resources/tools/data-analysis.yaml
@@ -44,7 +44,7 @@ tools:
     description: Analyzer for Hayabusa results
     source: github
     repo: Yamato-Security/takajo
-    match: "takajo.*windows.*\\.zip$"
+    match: "win-x64\\.zip$"
     file_type: zip
     install_method: extract
     extract_to: "${TOOLS}/takajo"
@@ -76,7 +76,7 @@ tools:
     description: Simple IOC and YARA scanner
     source: github
     repo: Neo23x0/Loki
-    match: "loki.*win.*\\.zip$"
+    match: "loki.*\\.zip$"
     file_type: zip
     install_method: extract
     extract_to: "${TOOLS}/loki"

--- a/resources/tools/document-analysis.yaml
+++ b/resources/tools/document-analysis.yaml
@@ -76,18 +76,6 @@ tools:
       Requires Python 3.
       Related to GitHub issue #118
 
-  # elfparser - ELF file parser
-  - name: elfparser
-    description: ELF binary parser
-    source: github
-    repo: mentebinaria/elfparser-ng
-    match: "elfparser.*\\.zip$"
-    file_type: zip
-    install_method: extract
-    extract_to: "${TOOLS}/elfparser"
-    enabled: true
-    priority: medium
-
   # Malcat - Malware analysis tool
   - name: malcat
     description: Feature-rich hexadecimal editor / disassembler for malware analysis


### PR DESCRIPTION
… duplicate

**Root Cause:** Match patterns incorrectly used "windows" when actual GitHub release files use "win", "win64", or "win-x64".

**Fixed Tools:**

1. **readpe** (binary-utilities.yaml)
   - Match: "win\\.zip$" (was: "readpe.*windows.*\\.zip$")
   - Extract to: "${TOOLS}" (was: "${TOOLS}/readpe")
   - Added post_install rename: pev* → pev
   - Issue: Files are named "pev-X.XX-win.zip", not "readpe-*-windows.zip"

2. **elfparser-ng** (binary-utilities.yaml)
   - Repository: mentebinaria/elfparser-ng (was: e-m-b-a/elfparser-ng)
   - Match: "win64\\.zip$" (was: "elfparser-ng.*windows.*\\.zip$")
   - Issue: Wrong repository AND files contain "win64" not "windows"

3. **takajo** (data-analysis.yaml)
   - Match: "win-x64\\.zip$" (was: "takajo.*windows.*\\.zip$")
   - Issue: Files are named "takajo-X.XX.X-win-x64.zip"

4. **loki** (data-analysis.yaml)
   - Match: "loki.*\\.zip$" (was: "loki.*win.*\\.zip$")
   - Issue: Files are named "loki_X.XX.X.zip" (no "win" in filename)

5. **Removed duplicate elfparser** (document-analysis.yaml)
   - Duplicate of elfparser-ng in binary-utilities.yaml
   - Same repo but different tool name and wrong match pattern
   - Removed to avoid conflicts

**Note:** gollum was reported as failing but configuration is correct. Failure likely due to network/rate limiting issues, not configuration.

These match pattern issues were systematic - likely from an incorrect assumption that all Windows releases contain "windows" in the filename.