### PR TITLE
Claude/fix download script v2

### DIFF
--- a/resources/download/common.ps1
+++ b/resources/download/common.ps1
@@ -45,6 +45,9 @@ function Get-FileFromUri {
         $filePathHash = ""
     }
 
+    # Save original FilePath before transformation for potential retry
+    $OriginalFilePath = $FilePath
+
     # Remove any leading '..' from the file path and set up temporary file path and final file path
     $CleanPath = $FilePath -replace "^..", ""
     $TmpFilePath= "$PSScriptRoot\..\..\tmp\$CleanPath"
@@ -190,8 +193,8 @@ function Get-FileFromUri {
         } else {
             Write-SynchronizedLog "Etag matched but file missing - removing etag and retrying download"
             Remove-Item -Force "${ETAG_FILE}" -ErrorAction SilentlyContinue
-            # Retry the download without etag
-            return Get-FileFromUri -Uri $Uri -FilePath $FilePath -check $check -CheckURL "Yes"
+            # Retry the download without etag using original FilePath parameter
+            return Get-FileFromUri -Uri $Uri -FilePath $OriginalFilePath -check $check -CheckURL "Yes"
         }
     }
     $ProgressPreference = 'Continue'


### PR DESCRIPTION
**Problem:**
When retrying download after etag mismatch with missing file, the recursive call to Get-FileFromUri caused infinite path expansion:

.\downloads\file.zip
→ C:\...\download\..\..\downloads\file.zip  (1st transformation) → C:\...\download\..\..\C:\...\download\..\..\downloads\file.zip (2nd) → (continues infinitely)

**Root Cause:**
1. Get-FileFromUri transforms input $FilePath from relative to absolute
2. Retry logic called Get-FileFromUri recursively with transformed path
3. Function transformed the already-transformed path again
4. Each recursive call added another layer of path segments

**Fix:**
Save the original $FilePath parameter BEFORE transformation:
- $OriginalFilePath = $FilePath (at line 49)
- Use $OriginalFilePath in recursive call (at line 197)

This ensures the recursive call receives the same input format as the original call, preventing path accumulation.

**Impact:**
Fixes download retry for tools where etag cache exists but file was deleted (like sqlite after manual cleanup).