### PR TITLE
Claude/fix download script v2

### DIFF
--- a/resources/tools/data-analysis.yaml
+++ b/resources/tools/data-analysis.yaml
@@ -178,7 +178,7 @@ tools:
     source: http
     url: "https://www.sqlite.org/download.html"
     url_pattern: "https://www.sqlite.org/download.html"
-    match: "sqlite-tools-win.*\\.zip"
+    match: "sqlite-tools-win-x64.*\\.zip"
     file_type: zip
     install_method: extract
     extract_to: "${TOOLS}/sqlite"


### PR DESCRIPTION
**Issue 1: SQLite downloading ARM64 instead of x64**
- Match pattern "sqlite-tools-win.*\\.zip" matched both x64 and arm64
- Alphabetically, arm64 comes first, so it was selected
- Changed to: "sqlite-tools-win-x64.*\\.zip"

**Issue 2: Infinite retry loop**
When etag matched but file was missing, the retry logic would loop infinitely because:
1. Etag matched → no file downloaded (304 response)
2. Detected file missing → removed etag and retried
3. Retry with CheckURL="Yes" → but download still failed
4. Looped back to step 1 infinitely

**Fix:**
Added RetryDepth parameter to track recursion depth:
- Default: RetryDepth = 0 (first attempt)
- After first retry: RetryDepth = 1
- If RetryDepth >= 1: Stop retrying and return error
- Maximum of 1 retry attempt

This prevents infinite loops while still allowing one legitimate retry when the etag cache is stale.

**Why downloads might fail even with CheckURL="Yes":**
- Server returns 304 Not Modified based on Last-Modified header
- Network issues or rate limiting
- File not actually available despite being in the download page

With the depth limit, we now fail gracefully instead of looping forever.