### PR TITLE
Add logging for resolved download URLs and remove FTK Imager

### DIFF
--- a/resources/download/tool-handler.ps1
+++ b/resources/download/tool-handler.ps1
@@ -311,6 +311,8 @@ function Get-ToolBinary {
                         Write-Error "Could not determine download URL for $toolName"
                         return $false
                     }
+
+                    Write-SynchronizedLog "Resolved download URL: $url"
                 } else {
                     $url = $ToolDefinition.url
                 }

--- a/resources/tools/disk-forensics.yaml
+++ b/resources/tools/disk-forensics.yaml
@@ -23,18 +23,6 @@ tools:
     enabled: true
     priority: high
 
-  # FTK Imager Lite - Disk imaging tool
-  - name: ftk-imager
-    description: Disk imaging and analysis tool from AccessData
-    source: http
-    url: "https://d1kpmuwb7gvu1i.cloudfront.net/AccessData_FTK_Imager_Lite_3.1.1.zip"
-    file_type: zip
-    install_method: extract
-    extract_to: "${TOOLS}/FTKImager"
-    enabled: true
-    priority: high
-    notes: May need to update URL for latest version
-
   # Arsenal Image Mounter - Disk image mounter
   - name: arsenal-image-mounter
     description: Virtual SCSI adapter for mounting disk images


### PR DESCRIPTION
- Add log message showing resolved URL when using url_pattern in HTTP downloads
- Remove ftk-imager from disk-forensics.yaml as requested