### PR TITLE
Add MkDocs GitHub Pages workflow

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -1,0 +1,52 @@
+name: Build and Deploy MkDocs
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install MkDocs
+        run: |
+          python -m pip install --upgrade pip
+          pip install mkdocs-material
+
+      - name: Build site
+        run: mkdocs build --config-file setup/mkdocs/mkdocs.yml --site-dir setup/mkdocs/site
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: setup/mkdocs/site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Motivation
- Provide an automated GitHub Actions workflow to build the MkDocs site in `setup/mkdocs` and publish it to GitHub Pages.

### Description
- Add `.github/workflows/mkdocs.yml` which runs on `push` to `main` and on `workflow_dispatch` for manual runs.
- The workflow checks out the repo, sets up Python (`actions/setup-python@v5`), installs `mkdocs-material`, and runs `mkdocs build --config-file setup/mkdocs/mkdocs.yml --site-dir setup/mkdocs/site`.
- The built site is uploaded with `actions/upload-pages-artifact@v3` and deployed using `actions/deploy-pages@v4`, with permissions `contents: read`, `pages: write`, and `id-token: write` and a `pages` concurrency group.

### Testing
- No automated tests were run locally; this is a CI-only workflow.
- The workflow will execute in GitHub Actions when pushed to `main` or run via the manual `workflow_dispatch` trigger.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698344dd3690832ea86ec52469236fb6)