### PR TITLE
Fix mkdocs nav parsing to handle list items correctly

### DIFF
--- a/scripts/generate-tools-docs.py
+++ b/scripts/generate-tools-docs.py
@@ -219,7 +219,7 @@ def update_mkdocs_nav(config_path: Path, docs_root: Path) -> None:
                 continue
             before.append(line)
             continue
-        if re.match(r"^\S", line):
+        if re.match(r"^\S", line) and not line.startswith("- "):
             in_nav = False
             after.append(line)
 


### PR DESCRIPTION
## Summary
Fixed a bug in the mkdocs navigation parsing logic where list items (lines starting with "- ") were incorrectly being treated as the end of the navigation section.

## Changes
- Modified the condition in `update_mkdocs_nav()` to exclude lines starting with "- " from triggering the end of the navigation block
- The parser now correctly recognizes that list items are part of the navigation structure and should not prematurely exit the `in_nav` state

## Details
The original regex `r"^\S"` matches any line starting with a non-whitespace character. This was too broad and caused list items (which start with "- ") to be misclassified as non-navigation content. By adding an explicit check `and not line.startswith("- ")`, the parser now properly handles markdown list items within the navigation section.

https://claude.ai/code/session_01MSdcvDivNGnHM9kACM73dj