### PR TITLE
Add tool definition templates to release, winget, and python scripts

### DIFF
--- a/resources/download/python.ps1
+++ b/resources/download/python.ps1
@@ -1,4 +1,5 @@
 . ".\resources\download\common.ps1"
+$TOOL_DEFINITIONS = @()
 
 $ROOT_PATH = "${PWD}"
 
@@ -34,3 +35,1610 @@ Get-ChildItem -Path "${ROOT_PATH}\mount\venv\default\Scripts","${ROOT_PATH}\moun
 Get-ChildItem -Exclude *.* .\mount\venv\bin\ | ForEach-Object { Move-Item "$_" "$_.py" }
 
 Write-DateLog "Pip packages done." >> "${ROOT_PATH}\log\python.txt"
+
+#
+# Tool definitions for documentation generation.
+# Fill in the dfirws-specific fields below. Auto-extracted metadata (Homepage,
+# Vendor, License) comes from the PyPI API via extract-tool-metadata.py.
+#
+
+$TOOL_DEFINITIONS += @{
+    Name = "dfir_ntfs"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "binary-refinery"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "regipy"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "peepdf-3"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "mkdocs"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "autoit-ripper"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "cart"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "chepy"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "csvkit"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "deep_translator"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "docx2txt"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "extract-msg"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "flatten_json"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "frida-tools"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "ghidrecomp"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "ghidriff"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "grip"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "hachoir"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "jpterm"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "jsbeautifier"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "jupyterlab"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "litecli"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "LnkParse3"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "magika"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "maldump"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "malwarebazaar"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "markitdown"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "minidump"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "mkyara"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "msoffcrypto-tool"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "mwcp"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "name-that-hash"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "netaddr"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "numpy"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "oletools"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "pcode2code"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "pdfalyzer"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "protodeep"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "ptpython"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "pwncat"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "pyghidra"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "pyOneNote"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "pypng"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "rexi"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "scapy"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "shodan"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "stego-lsb"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "sqlit-tui"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "time-decode"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "toolong"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "unpy2exe"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "visidata"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "xlrd"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "XLMMacroDeobfuscator"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "XlsxWriter"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "acquire"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "aiodns"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "aiohttp"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Aspose.Email-for-Python-via-Net"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "BeautifulSoup4"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "bitstruct"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "compressed_rtf"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "dissect"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "dissect.target"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "dnslib"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "flow.record"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "geoip2"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "cabarchive"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "dotnetfile"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "dpkt"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "elasticsearch"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "evtx"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "graphviz"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "javaobj-py3"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "keystone-engine"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "lief"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "matplotlib"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "msticpy"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "neo4j"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "networkx"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "olefile"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "openpyxl"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "orjson"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "paramiko"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "pathlab"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "pefile"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "peutils"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "pfp"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "ppdeep"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "prettytable"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "pyasn1"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "pycares"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "pycryptodome"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "pydivert"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "pypdf"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "pyshark"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "PySocks"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "python-docx"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "python-dotenv"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "python-magic"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "python-registry"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "pyvis"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "pyzipper"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "requests"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "rzpipe"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "sigma-cli"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "pysigma-backend-elasticsearch"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "pySigma-backend-loki"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "pysigma-backend-splunk"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "pysigma-backend-sqlite"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "pysigma-pipeline-sysmon"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "pysigma-pipeline-windows"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "simplejson"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "termcolor"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "textsearch"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "tomlkit"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "treelib"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "unicorn"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "xxhash"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "yara-python"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "dfir-unfurl"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "hexdump"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "maclookup"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+New-CreateToolFiles -ToolDefinitions $TOOL_DEFINITIONS -Source "python"

--- a/resources/download/release.ps1
+++ b/resources/download/release.ps1
@@ -1,4 +1,5 @@
 . ".\resources\download\common.ps1"
+$TOOL_DEFINITIONS = @()
 
 # artemis
 $status = Get-GitHubRelease -repo "puffyCid/artemis" -path "${SETUP_PATH}\artemis.zip" -match "x86_64-pc-windows-msvc.zip$" -check "Zip archive data"
@@ -964,3 +965,1545 @@ $status = Get-GitHubRelease -repo "javalent/admonitions" -path "${SETUP_PATH}\ob
 $status = Get-GitHubRelease -repo "George-debug/obsidian-timeline" -path "${SETUP_PATH}\obsidian-plugins\obsidian-timeline\main.js" -match "main.js" -check "JavaScript source"
 $status = Get-GitHubRelease -repo "George-debug/obsidian-timeline" -path "${SETUP_PATH}\obsidian-plugins\obsidian-timeline\manifest.json" -match "manifest.json" -check "JSON text data"
 $status = Get-GitHubRelease -repo "George-debug/obsidian-timeline" -path "${SETUP_PATH}\obsidian-plugins\obsidian-timeline\styles.css" -match "styles.css" -check "ASCII text"
+
+#
+# Tool definitions for documentation generation.
+# Fill in the dfirws-specific fields below. Auto-extracted metadata (Homepage,
+# Vendor, License) comes from the GitHub API cache via extract-tool-metadata.py.
+#
+
+$TOOL_DEFINITIONS += @{
+    Name = "artemis"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "godap"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "BeaconHunter"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "4n4lDetector"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "aLEAPP"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "iLEAPP"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "lessmsi"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "fx"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "CobaltStrikeScan"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Audacity"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Ares"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Zui"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "RDPCacheStitcher"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "ffmpeg"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "ripgrep"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "binlex"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "cmder"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Recaf"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "DBeaver"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Dumpbin"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "dnSpy"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Dokany"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "mboxviewer"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "zstd"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "CyberChef"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "redress"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "h2database"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "INDXRipper"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "dll_to_exe"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "HollowsHunter"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "PE-bear"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "PE-sieve"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "PE-utils"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "WinObjEx64"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Detect It Easy"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "XELFViewer"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "jd-gui"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "LogBoost"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "jq"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Jumplist Browser"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "MFTBrowser"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Prefetch Browser"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "bytecode-viewer"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "gftrace"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "adalanche"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "MsgViewer"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "capa"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "capa-rules"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Ghidra GolangAnalyzerExtension"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "PowerShell"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Ghidra BTIGhidra"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Ghidra Cartographer"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Flare-Floss"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Flare-Fakenet-NG"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "GoReSym"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "mmdbinspect"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Elfparser-ng"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "readpe"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "DitExplorer"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "srum_dump"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "forensic-timeliner"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "jwt-cli"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "dsq"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "MetadataPlus"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Loki"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Notepad++"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "HindSight"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "evtx_dump"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "ComparePlus"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "DSpellCheck"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "VS Code PowerShell Extension"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "vscode-shellcheck"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "qpdf"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Fibratus"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Radare2"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Iaito"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "hfs"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "obsidian-mitre-attack"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Cutter"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Nerd Fonts"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Strawberry Perl"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "sidr"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "jadx"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Sleuthkit"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "qrtool"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "debloat"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "VS Code Spell Checker"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Thumbcacheviewer"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "gron"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "MemProcFS"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "upx"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Velociraptor"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Witr"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "fq"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "fqlite"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Zircolite"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "ImHex"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "chainsaw"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "YARA"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "yara-x"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "yq"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "x64dbg"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "hayabusa"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "takajo"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "zaproxy"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "edit"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "DB Browser for SQLite"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "NetExt"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "YAMAGoya"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "obsidian-dataview"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "obsidian-kanban"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "quickadd"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "obsidian-calendar-plugin"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Templater"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "obsidian-tasks"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "obsidian-excalidraw-plugin"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "admonitions"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "obsidian-timeline"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+New-CreateToolFiles -ToolDefinitions $TOOL_DEFINITIONS -Source "release"

--- a/resources/download/winget.ps1
+++ b/resources/download/winget.ps1
@@ -1,4 +1,5 @@
 . ".\resources\download\common.ps1"
+$TOOL_DEFINITIONS = @()
 
 # Autopsy - available for installation via dfirws-install.ps1
 Write-SynchronizedLog "winget: Downloading Autopsy."
@@ -111,3 +112,349 @@ Write-SynchronizedLog "winget: Downloading Windbg."
 $status = Get-WinGet "Microsoft.WinDbg" "WinDbg*.msi" "windbg.msi" -check "Zip archive data"
 
 Write-SynchronizedLog "winget: Download complete."
+
+#
+# Tool definitions for documentation generation.
+# Fill in the dfirws-specific fields below. Auto-extracted metadata (Homepage,
+# Vendor, License) comes from the winget cache via extract-tool-metadata.py.
+#
+
+$TOOL_DEFINITIONS += @{
+    Name = "Autopsy"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Burp Suite"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Chrome"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Docker Desktop"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "DotNet 6 Desktop Runtime"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "DotNet 8 Desktop Runtime"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "IrfanView"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Obsidian"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "oh-my-posh"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "PowerShell 7"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "PuTTY"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "QEMU"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Ruby"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "VLC"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "VirusTotal CLI"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "WinMerge"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "OpenVPN"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Google Earth Pro"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "OSFMount"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "WireGuard"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Wireshark"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Tailscale"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Firefox"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "Foxit PDF Reader"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "uv"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+$TOOL_DEFINITIONS += @{
+    Name = "WinDbg"
+    Category = ""
+    Shortcuts = @()
+    InstallVerifyCommand = ""
+    Verify = @()
+    Notes = ""
+    Tips = ""
+    Usage = ""
+    SampleCommands = @()
+    SampleFiles = @()
+}
+
+New-CreateToolFiles -ToolDefinitions $TOOL_DEFINITIONS -Source "winget"

--- a/scripts/extract-tool-metadata.py
+++ b/scripts/extract-tool-metadata.py
@@ -30,9 +30,11 @@ def read_json(path: Path) -> dict:
 
 
 def write_tools_json(output_dir: Path, source: str, tools: List[dict]) -> Path:
+    # Strip _extracted suffix for the SourceScript reference
+    base_source = source.replace("_extracted", "")
     doc = {
         "GeneratedAt": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S"),
-        "SourceScript": f"resources/download/{source}.ps1",
+        "SourceScript": f"scripts/extract-tool-metadata.py ({base_source})",
         "Tools": tools,
     }
     out = output_dir / f"tools_{source}.json"
@@ -501,7 +503,7 @@ def main() -> int:
         print("Processing GitHub metadata...")
         github_tools = process_github_metadata(metadata_dir)
         if github_tools:
-            out = write_tools_json(output_dir, "release", github_tools)
+            out = write_tools_json(output_dir, "release_extracted", github_tools)
             print(f"  Wrote {len(github_tools)} tools to {out}")
         else:
             print("  No GitHub metadata found. Run release.ps1 first to populate cache.")
@@ -511,7 +513,7 @@ def main() -> int:
         print("Processing winget metadata...")
         winget_tools = process_winget_metadata(metadata_dir)
         if winget_tools:
-            out = write_tools_json(output_dir, "winget", winget_tools)
+            out = write_tools_json(output_dir, "winget_extracted", winget_tools)
             print(f"  Wrote {len(winget_tools)} tools to {out}")
         else:
             print("  No winget metadata found. Run winget.ps1 first to populate cache.")
@@ -525,7 +527,7 @@ def main() -> int:
             install_script, cache_dir=pypi_cache, rate_limit=args.pypi_rate_limit
         )
         if pypi_tools:
-            out = write_tools_json(output_dir, "python", pypi_tools)
+            out = write_tools_json(output_dir, "python_extracted", pypi_tools)
             print(f"  Wrote {len(pypi_tools)} tools to {out}")
         else:
             print("  No Python packages found or PyPI lookups failed.")


### PR DESCRIPTION
Adds $TOOL_DEFINITIONS skeleton entries for every tool in each download script (118 GitHub releases, 26 winget packages, 123 Python packages). Each entry has empty dfirws-specific fields (Category, Shortcuts, InstallVerifyCommand, Verify, Notes, Tips, Usage, SampleCommands, SampleFiles) ready to be filled in manually. Auto-extracted metadata (Homepage, Vendor, License) comes separately from the API caches.

Also renames extract-tool-metadata.py output files to use _extracted suffix (tools_release_extracted.json, etc.) so they don't conflict with the manual definitions generated by New-CreateToolFiles.

https://claude.ai/code/session_01VCMdqhEp21SAcXx8a9fmjg