### PR TITLE
Fix PATH environment variable in MSYS2 build script

### DIFF
--- a/setup/install/install_msys2.ps1
+++ b/setup/install/install_msys2.ps1
@@ -54,7 +54,7 @@ if ((Test-Path "C:\git\r2ai\src\Makefile") -and (Test-Path "C:\Tools\radare2\bin
     Copy-Item -Recurse "C:\git\r2ai\src\*" "C:\tmp\r2ai_build\" 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"
 
     # Build r2ai with msys2 toolchain
-    & "C:\Tools\msys64\usr\bin\bash.exe" -lc "export PKG_CONFIG_PATH=/c/Tools/radare2/lib/pkgconfig && export PATH=/ucrt64/bin:/c/Tools/radare2/bin:\$PATH && cd /c/tmp/r2ai_build && make DOTEXE=.exe" 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"
+    & "C:\Tools\msys64\usr\bin\bash.exe" -lc "export PKG_CONFIG_PATH=/c/Tools/radare2/lib/pkgconfig && export PATH=/ucrt64/bin:/usr/bin:/c/Tools/radare2/bin:\$PATH && cd /c/tmp/r2ai_build && make DOTEXE=.exe" 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"
 
     # Copy output to persistent location
     $r2ai_output = "C:\Tools\msys64\r2ai_build"


### PR DESCRIPTION
## Summary
Updated the MSYS2 build script to include `/usr/bin` in the PATH environment variable during the r2ai build process.

## Changes
- Added `/usr/bin` to the PATH export in the bash command executed within the MSYS2 environment
- This ensures that standard Unix utilities available in the MSYS2 installation are accessible during the build

## Details
The PATH variable in the build command now includes `/usr/bin` between `/ucrt64/bin` and `/c/Tools/radare2/bin`. This change allows the build process to locate and use utilities from the MSYS2 `/usr/bin` directory, which may be required by the build system or dependencies.

https://claude.ai/code/session_01PXqFpmdDAB4hKQd5AwJSq6