### PR TITLE
Suppress output from spell file download operations

### DIFF
--- a/resources/download/winget.ps1
+++ b/resources/download/winget.ps1
@@ -720,8 +720,8 @@ if ($status) {
     Copy-Item -Path ".\downloads\nvim.msi\Neovim*.msi" -Destination ".\downloads\neovim.msi" -Force
     Remove-Item -Path ".\downloads\nvim.msi" -Force -Recurse
 }
-Get-FileFromUri "https://github.com/vim/vim/raw/refs/heads/master/runtime/spell/en.utf-8.spl" -FilePath ".\downloads\en.utf-8.spl"
-Get-FileFromUri "https://github.com/vim/vim/raw/refs/heads/master/runtime/spell/en.utf-8.sug" -FilePath ".\downloads\en.utf-8.sug"
+$null = Get-FileFromUri "https://github.com/vim/vim/raw/refs/heads/master/runtime/spell/en.utf-8.spl" -FilePath ".\downloads\en.utf-8.spl"
+$null = Get-FileFromUri "https://github.com/vim/vim/raw/refs/heads/master/runtime/spell/en.utf-8.sug" -FilePath ".\downloads\en.utf-8.sug"
 
 $TOOL_DEFINITIONS += @{
     Name = "Neovim"


### PR DESCRIPTION
## Summary
Suppress the output from `Get-FileFromUri` calls when downloading Vim spell files for Neovim by assigning the results to `$null`.

## Changes
- Wrapped `Get-FileFromUri` calls for English spell files (`en.utf-8.spl` and `en.utf-8.sug`) with `$null =` assignment to suppress any output these operations may produce

## Details
This change prevents the spell file download operations from outputting unnecessary information to the console, keeping the script output cleaner and more focused on relevant status messages.

https://claude.ai/code/session_01XeA7U8W52BjBUTAsCxkbQN