### PR TITLE
Create r2.exe alias for radare2.exe to fix r2ai Makefile build

### DIFF
--- a/setup/install/install_msys2.ps1
+++ b/setup/install/install_msys2.ps1
@@ -49,6 +49,9 @@ if ((Test-Path "C:\git\r2ai\src\Makefile") -and (Test-Path "C:\Tools\radare2\bin
     $env:MSYSTEM = 'UCRT64'
     $env:PKG_CONFIG_PATH = "C:\Tools\radare2\lib\pkgconfig"
 
+    # Create r2 alias for radare2 (the Makefile expects 'r2' command in PATH)
+    Copy-Item "C:\Tools\radare2\bin\radare2.exe" "C:\Tools\radare2\bin\r2.exe" -Force
+
     # Copy source to writable location (git mount is read-only)
     New-Item -ItemType Directory -Force -Path "C:\tmp\r2ai_build" | Out-Null
     Copy-Item -Recurse "C:\git\r2ai\src\*" "C:\tmp\r2ai_build\" 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"


### PR DESCRIPTION
The r2ai Makefile expects 'r2' command in PATH for both the r2check
sanity target and $(shell r2 -NNH R2_LIBEXT) to determine the library
extension (.dll). Without it, r2check fails with exit 127 and DOTLIB
would be empty instead of '.dll'.

https://claude.ai/code/session_01JZzdr4f3QkBQmtVghHbWM4