### PR TITLE
Suppress warnings when downloading PowerShell modules

### DIFF
--- a/resources/download/powershell.ps1
+++ b/resources/download/powershell.ps1
@@ -4,7 +4,7 @@ Clear-Tmp powershell
 
 # Download PowerShell modules
 Write-SynchronizedLog "powershell: Downloading ImportExcel, posh-git and Terminal-Icons."
-Save-Module -Name ImportExcel,posh-git,Terminal-Icons -Path .\tmp\powershell -Force
+Save-Module -Name ImportExcel,posh-git,Terminal-Icons -Path .\tmp\powershell -Force -WarningAction SilentlyContinue
 
 if (! (Test-Path ".\tmp\powershell\ImportExcel")) {
     Write-SynchronizedLog "powershell: ImportExcel module not found. Exiting."


### PR DESCRIPTION
## Summary
Added warning suppression to the PowerShell module download command to prevent non-critical warnings from being displayed during the module installation process.

## Changes
- Added `-WarningAction SilentlyContinue` parameter to the `Save-Module` command when downloading ImportExcel, posh-git, and Terminal-Icons modules

## Details
This change suppresses warning messages that may be generated during the module download and installation process, providing cleaner output while still allowing the script to function normally. The modules will continue to be downloaded and validated as before, with the validation logic remaining intact (as evidenced by the subsequent `Test-Path` check for the ImportExcel module).

https://claude.ai/code/session_01VNP8XheRx18V1y23NrjKnw