### PR TITLE
Fix r2ai build by ensuring radare2 is accessible in MSYS2 PATH

### DIFF
--- a/setup/install/install_msys2.ps1
+++ b/setup/install/install_msys2.ps1
@@ -57,7 +57,8 @@ if ((Test-Path "C:\git\r2ai\src\Makefile") -and (Test-Path "C:\Tools\radare2\bin
     Copy-Item -Recurse "C:\git\r2ai\src\*" "C:\tmp\r2ai_build\" 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"
 
     # Build r2ai with msys2 toolchain
-    & "C:\Tools\msys64\usr\bin\bash.exe" -lc "export PKG_CONFIG_PATH=/c/Tools/radare2/lib/pkgconfig && export PATH=/ucrt64/bin:/usr/bin:/c/Tools/radare2/bin:\$PATH && cd /c/tmp/r2ai_build && make DOTEXE=.exe" 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"
+    # Ensure r2 is accessible in MSYS2 PATH (r2check target runs 'r2 -NN -qcq --')
+    & "C:\Tools\msys64\usr\bin\bash.exe" -lc "export PKG_CONFIG_PATH=/c/Tools/radare2/lib/pkgconfig && export PATH=/ucrt64/bin:/usr/bin:/c/Tools/radare2/bin:\$PATH && command -v r2 || cp /c/Tools/radare2/bin/radare2.exe /ucrt64/bin/r2.exe && cd /c/tmp/r2ai_build && make DOTEXE=.exe" 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"
 
     # Copy output to persistent location
     $r2ai_output = "C:\Tools\msys64\r2ai_build"


### PR DESCRIPTION
## Summary
This change fixes the r2ai build process on MSYS2 by ensuring the radare2 executable is accessible in the build environment's PATH. The build was failing because the `r2check` target requires the `r2` command to be available.

## Key Changes
- Added a check to verify if `r2` is accessible via `command -v r2`
- If `r2` is not found, the script now copies `radare2.exe` to `/ucrt64/bin/r2.exe` to make it available in the MSYS2 environment
- Added a clarifying comment explaining why this step is necessary

## Implementation Details
The fix uses a simple conditional approach: `command -v r2 || cp /c/Tools/radare2/bin/radare2.exe /ucrt64/bin/r2.exe`
- This checks if `r2` is already in the PATH
- If not found, it copies the radare2 executable and renames it to `r2.exe` in the UCRT64 bin directory
- This ensures the `r2check` target in the Makefile can successfully run `r2 -NN -qcq --`

https://claude.ai/code/session_01UaD42KfrihMSx7n4JGqHvL