### PR TITLE
Add distribution profiles to control tool downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ DFIRWS should work with the Windows Sandbox in both Windows 10 and Windows 11 ev
 - [Installation and configuration](#installation-and-configuration)
 - [Download tools and enrichment data](#download-tools-and-enrichment-data)
 - [Usage and configuration of the sandbox](#usage-and-configuration-of-the-sandbox)
+  - [Distribution profiles](#distribution-profiles)
+  - [Sandbox configuration](#sandbox-configuration)
 - [Usage and configuration of the VM](#usage-and-configuration-of-the-vm)
 - [Update](#update)
 - [Documentation](#documentation)
@@ -141,6 +143,32 @@ Personally I run the following command to download everything and cache Visual S
 ```
 
 ## Usage and configuration of the sandbox
+
+### Distribution profiles
+
+DFIRWS supports distribution profiles to control which tools are downloaded. This is useful for standalone or external client installations where you don't need the full tool suite.
+
+Two profiles are available:
+
+- **Full** (default) - Downloads all tools, including all build toolchains (Node.js, Rust, Go, MSYS2) and large optional tools.
+- **Basic** - Skips Rust, Go, and MSYS2 toolchains. Keeps Node.js for JavaScript malware analysis. Excludes large optional tools like Autopsy, ELK Stack, Binary Ninja, Neo4j, hashcat, LibreOffice, and others.
+
+To use a profile, pass `-Profile` to `downloadFiles.ps1`:
+
+```PowerShell
+.\downloadFiles.ps1 -Profile Basic
+```
+
+For persistent configuration, copy `local\defaults\profile-config.ps1.template` to `local\profile-config.ps1` and set `$DFIRWS_PROFILE = "Basic"`. You can also override individual toolchain inclusion and add extras (large tools to include despite the profile):
+
+```PowerShell
+$DFIRWS_PROFILE = "Basic"
+$DFIRWS_EXTRAS = @("Autopsy", "LibreOffice")
+```
+
+The `-Profile` CLI parameter takes precedence over the config file. Explicit switches like `-Rust` or `-Node` always override the profile setting.
+
+### Sandbox configuration
 
 The quickest way to use the DFIRWS is to start a sandbox by clicking on **dfirws.wsb** or running **.\dfirws.wsb** in a PowerShell terminal. The sandbox will start and the tools will be available after a couple of minutes.
 

--- a/local/defaults/profile-config.ps1.template
+++ b/local/defaults/profile-config.ps1.template
@@ -1,0 +1,24 @@
+# Distribution profile configuration for DFIRWS
+# Copy this file to local/profile-config.ps1 and customize.
+#
+# Select profile: "Basic" or "Full"
+# Default (empty string) = Full (all tools downloaded)
+$DFIRWS_PROFILE = ""
+
+# Override script inclusion (overrides the profile setting)
+# Uncomment and set to $true/$false to override:
+# $DFIRWS_PROFILE_NODE = $true
+# $DFIRWS_PROFILE_RUST = $false
+# $DFIRWS_PROFILE_GO = $false
+# $DFIRWS_PROFILE_MSYS2 = $false
+
+# Extra tools to include even when excluded by the profile.
+# Add tool names to force-include them.
+# Available extras for Basic profile:
+#   "Autopsy", "QEMU", "Burp Suite", "Google Earth Pro",
+#   "Binary Ninja", "Neo4j", "hashcat",
+#   "Volatility Workbench 3", "Volatility Workbench 2.1",
+#   "LibreOffice", "Elastic Stack (ELK + Beats)"
+#
+# Example: $DFIRWS_EXTRAS = @("Autopsy", "LibreOffice")
+$DFIRWS_EXTRAS = @()

--- a/local/defaults/profiles.ps1
+++ b/local/defaults/profiles.ps1
@@ -1,0 +1,39 @@
+# Profile definitions for DFIRWS distribution profiles.
+# Used by downloadFiles.ps1 to control which tools are downloaded.
+#
+# Each profile defines:
+#   Scripts      - Which build sandbox scripts to run (node, rust, go, msys2)
+#   ExcludeTools - Large tools to skip in shared download scripts (winget.ps1, http.ps1)
+
+$DFIRWS_PROFILES = @{
+    "Basic" = @{
+        Scripts = @{
+            "node"   = $true
+            "rust"   = $false
+            "go"     = $false
+            "msys2"  = $false
+        }
+        ExcludeTools = @(
+            "Autopsy",
+            "QEMU",
+            "Burp Suite",
+            "Google Earth Pro",
+            "Binary Ninja",
+            "Neo4j",
+            "hashcat",
+            "Volatility Workbench 3",
+            "Volatility Workbench 2.1",
+            "LibreOffice",
+            "Elastic Stack (ELK + Beats)"
+        )
+    }
+    "Full" = @{
+        Scripts = @{
+            "node"   = $true
+            "rust"   = $true
+            "go"     = $true
+            "msys2"  = $true
+        }
+        ExcludeTools = @()
+    }
+}

--- a/resources/download/basic.ps1
+++ b/resources/download/basic.ps1
@@ -155,7 +155,7 @@ if ($all -or $Python) {
 }
 
 # MSYS2
-if ($all -or $MSYS2) {
+if (($all -and $profileMsys2Enabled) -or $MSYS2) {
     $status = Get-FileFromUri -uri "https://github.com/msys2/msys2-installer/releases/download/nightly-x86_64/msys2-base-x86_64-latest.sfx.exe" -FilePath "${SETUP_PATH}\msys2.exe" -CheckURL "No" -check "PE32"
     if ($status) {
         Copy-Item "${SETUP_PATH}\msys2.exe" "${TOOLS}\bin\msys2.exe"
@@ -165,7 +165,7 @@ if ($all -or $MSYS2) {
 
 #
 # Packages used in Go sandbox
-if ($all -or $Go) {
+if (($all -and $profileGoEnabled) -or $Go) {
     # GoLang - available for installation via dfirws-install.ps1
     Write-SynchronizedLog "winget: Downloading GoLang."
     $status = Get-WinGet "GoLang.Go" "Go*.msi" "golang.msi" -check "Composite Document File V2 Document"
@@ -173,7 +173,7 @@ if ($all -or $Go) {
 
 #
 # Packages used in Rust sandbox
-if ($all -or $Rust) {
+if (($all -and $profileRustEnabled) -or $Rust) {
     # git - installed during start
     $status = Get-GitHubRelease -repo "git-for-windows/git" -path "${SETUP_PATH}\git.exe" -match "64-bit.exe" -check "PE32"
 

--- a/resources/download/common.ps1
+++ b/resources/download/common.ps1
@@ -733,6 +733,32 @@ function Wait-Sandbox {
     }
 }
 
+# Function to check if a tool should be downloaded based on the active profile.
+# Returns $true if the tool should be included, $false if excluded by profile.
+function Test-ToolIncluded {
+    param (
+        [Parameter(Mandatory=$True)] [string]$ToolName
+    )
+
+    # If no profile filtering is active, include everything
+    if ($null -eq $DFIRWS_EXCLUDE_TOOLS -or $DFIRWS_EXCLUDE_TOOLS.Count -eq 0) {
+        return $true
+    }
+
+    # Check if tool is in the extras include list (overrides exclusion)
+    if ($null -ne $DFIRWS_EXTRAS_RESOLVED -and $DFIRWS_EXTRAS_RESOLVED -contains $ToolName) {
+        return $true
+    }
+
+    # Check if tool is excluded by profile
+    if ($DFIRWS_EXCLUDE_TOOLS -contains $ToolName) {
+        Write-SynchronizedLog "Skipping $ToolName (excluded by profile)."
+        return $false
+    }
+
+    return $true
+}
+
 # Function to stop the sandbox
 function Stop-Sandbox {
     [CmdletBinding(SupportsShouldProcess)]

--- a/resources/download/http.ps1
+++ b/resources/download/http.ps1
@@ -1684,12 +1684,14 @@ $TOOL_DEFINITIONS += @{
 }
 
 # Volatility Workbench 3
-$status = Get-FileFromUri -uri "https://www.osforensics.com/downloads/VolatilityWorkbench.zip" -FilePath ".\downloads\volatilityworkbench.zip" -check "Zip archive data"
-if ($status) {
-    if (Test-Path -Path "${TOOLS}\VolatilityWorkbench") {
-        Remove-Item -Recurse -Force "${TOOLS}\VolatilityWorkbench" | Out-Null 2>&1
+if (Test-ToolIncluded -ToolName "Volatility Workbench 3") {
+    $status = Get-FileFromUri -uri "https://www.osforensics.com/downloads/VolatilityWorkbench.zip" -FilePath ".\downloads\volatilityworkbench.zip" -check "Zip archive data"
+    if ($status) {
+        if (Test-Path -Path "${TOOLS}\VolatilityWorkbench") {
+            Remove-Item -Recurse -Force "${TOOLS}\VolatilityWorkbench" | Out-Null 2>&1
+        }
+        & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\volatilityworkbench.zip" -o"${TOOLS}\VolatilityWorkbench" | Out-Null
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\volatilityworkbench.zip" -o"${TOOLS}\VolatilityWorkbench" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1730,12 +1732,14 @@ $TOOL_DEFINITIONS += @{
 }
 
 # Volatility Workbench 2
-$status = Get-FileFromUri -uri "https://www.osforensics.com/downloads/VolatilityWorkbench-v2.1.zip" -FilePath ".\downloads\volatilityworkbench2.zip" -check "Zip archive data"
-if ($status) {
-    if (Test-Path -Path "${TOOLS}\VolatilityWorkbench2") {
-        Remove-Item -Recurse -Force "${TOOLS}\VolatilityWorkbench2" | Out-Null 2>&1
+if (Test-ToolIncluded -ToolName "Volatility Workbench 2.1") {
+    $status = Get-FileFromUri -uri "https://www.osforensics.com/downloads/VolatilityWorkbench-v2.1.zip" -FilePath ".\downloads\volatilityworkbench2.zip" -check "Zip archive data"
+    if ($status) {
+        if (Test-Path -Path "${TOOLS}\VolatilityWorkbench2") {
+            Remove-Item -Recurse -Force "${TOOLS}\VolatilityWorkbench2" | Out-Null 2>&1
+        }
+        & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\volatilityworkbench2.zip" -o"${TOOLS}\VolatilityWorkbench2" | Out-Null
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\volatilityworkbench2.zip" -o"${TOOLS}\VolatilityWorkbench2" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1776,7 +1780,9 @@ $TOOL_DEFINITIONS += @{
 }
 
 # Volatility Workbench 2 Profiles
-$status = Get-FileFromUri -uri "https://www.osforensics.com/downloads/Collection.zip" -FilePath ".\downloads\volatilityworkbench2profiles.zip" -check "Zip archive data"
+if (Test-ToolIncluded -ToolName "Volatility Workbench 2.1") {
+    $status = Get-FileFromUri -uri "https://www.osforensics.com/downloads/Collection.zip" -FilePath ".\downloads\volatilityworkbench2profiles.zip" -check "Zip archive data"
+}
 
 # Nirsoft tools
 New-Item -Path "${TOOLS}\nirsoft" -ItemType Directory -Force | Out-Null
@@ -1993,7 +1999,9 @@ $TOOL_DEFINITIONS += @{
 }
 
 # Binary Ninja - manual installation
-$status = Get-FileFromUri -uri "https://cdn.binary.ninja/installers/binaryninja_free_win64.exe" -FilePath ".\downloads\binaryninja.exe" -check "PE32"
+if (Test-ToolIncluded -ToolName "Binary Ninja") {
+    $status = Get-FileFromUri -uri "https://cdn.binary.ninja/installers/binaryninja_free_win64.exe" -FilePath ".\downloads\binaryninja.exe" -check "PE32"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "Binary Ninja"
@@ -2228,8 +2236,10 @@ $TOOL_DEFINITIONS += @{
 }
 
 # https://neo4j.com/deployment-center/#community - Neo4j - installed during start
-$NeoVersion = Get-DownloadUrlFromPage -Url "https://neo4j.com/deployment-center/#community" -RegEx '4.4.[^"]+-windows\.zip'
-$status = Get-FileFromUri -uri "https://neo4j.com/artifact.php?name=neo4j-community-${NeoVersion}" -FilePath ".\downloads\neo4j.zip" -CheckURL "Yes" -check "Zip archive data"
+if (Test-ToolIncluded -ToolName "Neo4j") {
+    $NeoVersion = Get-DownloadUrlFromPage -Url "https://neo4j.com/deployment-center/#community" -RegEx '4.4.[^"]+-windows\.zip'
+    $status = Get-FileFromUri -uri "https://neo4j.com/artifact.php?name=neo4j-community-${NeoVersion}" -FilePath ".\downloads\neo4j.zip" -CheckURL "Yes" -check "Zip archive data"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "Neo4j"
@@ -2361,10 +2371,12 @@ $TOOL_DEFINITIONS += @{
 }
 
 # https://www.libreoffice.org/download/download-libreoffice/ - LibreOffice - installed during start
-$LibreOfficeVersionDownloadPage = Get-DownloadUrlFromPage -Url "https://www.libreoffice.org/download/download-libreoffice/" -RegEx 'https://[^"]+.msi'
-$LibreOfficeVersionDownloadPage_64 = $LibreOfficeVersionDownloadPage.Replace("dl/win-x86/", "dl/win-x86_64/").Replace("x86.msi", "x86-64.msi").Replace("https://download.documentfoundation.org/libreoffice/stable/", "https://www.libreoffice.org/donate/dl/")
-$LibreOfficeVersion = Get-DownloadUrlFromPage -Url "${LibreOfficeVersionDownloadPage_64}" -RegEx 'https://[^"]+.msi'
-$status = Get-FileFromUri -uri ${LibreOfficeVersion} -FilePath ".\downloads\LibreOffice.msi" -CheckURL "Yes" -check "Composite Document File V2 Document"
+if (Test-ToolIncluded -ToolName "LibreOffice") {
+    $LibreOfficeVersionDownloadPage = Get-DownloadUrlFromPage -Url "https://www.libreoffice.org/download/download-libreoffice/" -RegEx 'https://[^"]+.msi'
+    $LibreOfficeVersionDownloadPage_64 = $LibreOfficeVersionDownloadPage.Replace("dl/win-x86/", "dl/win-x86_64/").Replace("x86.msi", "x86-64.msi").Replace("https://download.documentfoundation.org/libreoffice/stable/", "https://www.libreoffice.org/donate/dl/")
+    $LibreOfficeVersion = Get-DownloadUrlFromPage -Url "${LibreOfficeVersionDownloadPage_64}" -RegEx 'https://[^"]+.msi'
+    $status = Get-FileFromUri -uri ${LibreOfficeVersion} -FilePath ".\downloads\LibreOffice.msi" -CheckURL "Yes" -check "Composite Document File V2 Document"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "LibreOffice"
@@ -3022,15 +3034,17 @@ $TOOL_DEFINITIONS += @{
 }
 
 # https://hashcat.net/hashcat/ - hashcat
-$hashcat_version = Get-DownloadUrlFromPage -url "https://hashcat.net/hashcat/" -RegEx 'fil[^"]+\.7z'
-$status = Get-FileFromUri -uri "https://hashcat.net/${hashcat_version}" -FilePath ".\downloads\hashcat.7z" -CheckURL "Yes" -check "7-zip archive data"
-if ($status) {
-    if (Test-Path -Path "${TOOLS}\hashcat") {
-        Remove-Item -Recurse -Force "${TOOLS}\hashcat" | Out-Null 2>&1
+if (Test-ToolIncluded -ToolName "hashcat") {
+    $hashcat_version = Get-DownloadUrlFromPage -url "https://hashcat.net/hashcat/" -RegEx 'fil[^"]+\.7z'
+    $status = Get-FileFromUri -uri "https://hashcat.net/${hashcat_version}" -FilePath ".\downloads\hashcat.7z" -CheckURL "Yes" -check "7-zip archive data"
+    if ($status) {
+        if (Test-Path -Path "${TOOLS}\hashcat") {
+            Remove-Item -Recurse -Force "${TOOLS}\hashcat" | Out-Null 2>&1
+        }
+        & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\hashcat.7z" -o"${TOOLS}" | Out-Null
+        Start-Sleep -Seconds 3
+        Move-Item ${TOOLS}\hashcat-* "${TOOLS}\hashcat" | Out-Null
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\hashcat.7z" -o"${TOOLS}" | Out-Null
-    Start-Sleep -Seconds 3
-    Move-Item ${TOOLS}\hashcat-* "${TOOLS}\hashcat" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -3071,8 +3085,10 @@ $TOOL_DEFINITIONS += @{
 }
 
 # Drivers for hashcat
-$intel_driver = Get-DownloadUrlFromPage -url "https://www.intel.com/content/www/us/en/developer/articles/technical/intel-cpu-runtime-for-opencl-applications-with-sycl-support.html" -RegEx 'https://[^"]+\.exe'
-$status = Get-FileFromUri -uri "${intel_driver}" -FilePath ".\downloads\intel_driver.exe" -CheckURL "Yes" -check "PE32"
+if (Test-ToolIncluded -ToolName "hashcat") {
+    $intel_driver = Get-DownloadUrlFromPage -url "https://www.intel.com/content/www/us/en/developer/articles/technical/intel-cpu-runtime-for-opencl-applications-with-sycl-support.html" -RegEx 'https://[^"]+\.exe'
+    $status = Get-FileFromUri -uri "${intel_driver}" -FilePath ".\downloads\intel_driver.exe" -CheckURL "Yes" -check "PE32"
+}
 
 # Mex for WinDbg
 $status = Get-FileFromUri -uri "https://download.microsoft.com/download/0/c/4/0c4c45e3-bf02-49bf-8d68-6fa611f442e6/Mex.exe" -FilePath ".\downloads\mex.exe" -CheckURL "Yes" -check "PE32"
@@ -3105,18 +3121,20 @@ $TOOL_DEFINITIONS += @{
 }
 
 # ELK
-$ELK_VERSION = ((curl.exe --silent -L "https://api.github.com/repos/elastic/elasticsearch/releases/latest" | ConvertFrom-Json).tag_name).Replace("v", "")
-Set-Content -Path ".\downloads\elk_version.txt" -Value "${ELK_VERSION}"
-$status = Get-FileFromUri -uri "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ELK_VERSION}-windows-x86_64.zip" -FilePath ".\downloads\elasticsearch.zip" -CheckURL "Yes" -check "Zip archive data"
-$status = Get-FileFromUri -uri "https://artifacts.elastic.co/downloads/kibana/kibana-${ELK_VERSION}-windows-x86_64.zip" -FilePath ".\downloads\kibana.zip" -CheckURL "Yes" -check "Zip archive data"
-$status = Get-FileFromUri -uri "https://artifacts.elastic.co/downloads/logstash/logstash-${ELK_VERSION}-windows-x86_64.zip" -FilePath ".\downloads\logstash.zip" -CheckURL "Yes" -check "Zip archive data"
-$status = Get-FileFromUri -uri "https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-${ELK_VERSION}-windows-x86_64.zip" -FilePath ".\downloads\elastic-agent.zip" -CheckURL "Yes" -check "Zip archive data"
-$status = Get-FileFromUri -uri "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-${ELK_VERSION}-windows-x86_64.zip" -FilePath ".\downloads\filebeat.zip" -CheckURL "Yes" -check "Zip archive data"
-$status = Get-FileFromUri -uri "https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-${ELK_VERSION}-windows-x86_64.zip" -FilePath ".\downloads\metricbeat.zip" -CheckURL "Yes" -check "Zip archive data"
-$status = Get-FileFromUri -uri "https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-${ELK_VERSION}-windows-x86_64.zip" -FilePath ".\downloads\packetbeat.zip" -CheckURL "Yes" -check "Zip archive data"
-$status = Get-FileFromUri -uri "https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-${ELK_VERSION}-windows-x86_64.zip" -FilePath ".\downloads\heartbeat.zip" -CheckURL "Yes" -check "Zip archive data"
-$status = Get-FileFromUri -uri "https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-${ELK_VERSION}-windows-x86_64.zip" -FilePath ".\downloads\auditbeat.zip" -CheckURL "Yes" -check "Zip archive data"
-$status = Get-FileFromUri -uri "https://artifacts.elastic.co/downloads/beats/winlogbeat/winlogbeat-${ELK_VERSION}-windows-x86_64.zip" -FilePath ".\downloads\winlogbeat.zip" -CheckURL "Yes" -check "Zip archive data"
+if (Test-ToolIncluded -ToolName "Elastic Stack (ELK + Beats)") {
+    $ELK_VERSION = ((curl.exe --silent -L "https://api.github.com/repos/elastic/elasticsearch/releases/latest" | ConvertFrom-Json).tag_name).Replace("v", "")
+    Set-Content -Path ".\downloads\elk_version.txt" -Value "${ELK_VERSION}"
+    $status = Get-FileFromUri -uri "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ELK_VERSION}-windows-x86_64.zip" -FilePath ".\downloads\elasticsearch.zip" -CheckURL "Yes" -check "Zip archive data"
+    $status = Get-FileFromUri -uri "https://artifacts.elastic.co/downloads/kibana/kibana-${ELK_VERSION}-windows-x86_64.zip" -FilePath ".\downloads\kibana.zip" -CheckURL "Yes" -check "Zip archive data"
+    $status = Get-FileFromUri -uri "https://artifacts.elastic.co/downloads/logstash/logstash-${ELK_VERSION}-windows-x86_64.zip" -FilePath ".\downloads\logstash.zip" -CheckURL "Yes" -check "Zip archive data"
+    $status = Get-FileFromUri -uri "https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-${ELK_VERSION}-windows-x86_64.zip" -FilePath ".\downloads\elastic-agent.zip" -CheckURL "Yes" -check "Zip archive data"
+    $status = Get-FileFromUri -uri "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-${ELK_VERSION}-windows-x86_64.zip" -FilePath ".\downloads\filebeat.zip" -CheckURL "Yes" -check "Zip archive data"
+    $status = Get-FileFromUri -uri "https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-${ELK_VERSION}-windows-x86_64.zip" -FilePath ".\downloads\metricbeat.zip" -CheckURL "Yes" -check "Zip archive data"
+    $status = Get-FileFromUri -uri "https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-${ELK_VERSION}-windows-x86_64.zip" -FilePath ".\downloads\packetbeat.zip" -CheckURL "Yes" -check "Zip archive data"
+    $status = Get-FileFromUri -uri "https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-${ELK_VERSION}-windows-x86_64.zip" -FilePath ".\downloads\heartbeat.zip" -CheckURL "Yes" -check "Zip archive data"
+    $status = Get-FileFromUri -uri "https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-${ELK_VERSION}-windows-x86_64.zip" -FilePath ".\downloads\auditbeat.zip" -CheckURL "Yes" -check "Zip archive data"
+    $status = Get-FileFromUri -uri "https://artifacts.elastic.co/downloads/beats/winlogbeat/winlogbeat-${ELK_VERSION}-windows-x86_64.zip" -FilePath ".\downloads\winlogbeat.zip" -CheckURL "Yes" -check "Zip archive data"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "Elastic Stack (ELK + Beats)"

--- a/resources/download/winget.ps1
+++ b/resources/download/winget.ps1
@@ -2,8 +2,10 @@
 $TOOL_DEFINITIONS = @()
 
 # Autopsy - available for installation via dfirws-install.ps1
-Write-SynchronizedLog "winget: Downloading Autopsy."
-$status = Get-WinGet "SleuthKit.Autopsy" "Autopsy*.msi" "autopsy.msi" -check "Composite Document File V2 Document"
+if (Test-ToolIncluded -ToolName "Autopsy") {
+    Write-SynchronizedLog "winget: Downloading Autopsy."
+    $status = Get-WinGet "SleuthKit.Autopsy" "Autopsy*.msi" "autopsy.msi" -check "Composite Document File V2 Document"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "Autopsy"
@@ -30,8 +32,10 @@ $TOOL_DEFINITIONS += @{
 }
 
 # Burp suite - available for installation via dfirws-install.ps1
-Write-SynchronizedLog "winget: Downloading Burp Suite."
-$status = Get-WinGet "PortSwigger.BurpSuite.${BURP_SUITE_EDITION}" "Burp*.exe" "burp.exe" -check "PE32"
+if (Test-ToolIncluded -ToolName "Burp Suite") {
+    Write-SynchronizedLog "winget: Downloading Burp Suite."
+    $status = Get-WinGet "PortSwigger.BurpSuite.${BURP_SUITE_EDITION}" "Burp*.exe" "burp.exe" -check "PE32"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "Burp Suite"
@@ -274,8 +278,10 @@ $TOOL_DEFINITIONS += @{
 }
 
 # Qemu - available for installation via dfirws-install.ps1
-Write-SynchronizedLog "winget: Downloading Qemu."
-$status = Get-WinGet "SoftwareFreedomConservancy.QEMU" "QEMU*.exe" "qemu.exe" -check "PE32"
+if (Test-ToolIncluded -ToolName "QEMU") {
+    Write-SynchronizedLog "winget: Downloading Qemu."
+    $status = Get-WinGet "SoftwareFreedomConservancy.QEMU" "QEMU*.exe" "qemu.exe" -check "PE32"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "QEMU"
@@ -455,8 +461,10 @@ $TOOL_DEFINITIONS += @{
 }
 
 # Google Earth Pro - available for installation via dfirws-install.ps1
-Write-SynchronizedLog "winget: Downloading Google Earth Pro."
-$status = Get-WinGet "Google.EarthPro" "Google*.exe" "googleearth.exe" -check "PE32"
+if (Test-ToolIncluded -ToolName "Google Earth Pro") {
+    Write-SynchronizedLog "winget: Downloading Google Earth Pro."
+    $status = Get-WinGet "Google.EarthPro" "Google*.exe" "googleearth.exe" -check "PE32"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "Google Earth Pro"


### PR DESCRIPTION
## Summary
Implement a distribution profile system for DFIRWS that allows users to download a curated subset of tools based on their needs. This enables lighter installations for standalone or external client deployments while maintaining the full feature set as the default.

## Key Changes

- **Profile System**: Added two distribution profiles ("Basic" and "Full") defined in `local/defaults/profiles.ps1`
  - **Full** (default): Downloads all tools and build toolchains (Node.js, Rust, Go, MSYS2)
  - **Basic**: Excludes Rust, Go, and MSYS2 toolchains; skips large optional tools (Autopsy, ELK Stack, Binary Ninja, Neo4j, hashcat, LibreOffice, Volatility Workbench, Burp Suite, QEMU, Google Earth Pro)

- **Profile Configuration**: 
  - Added `-Profile` parameter to `downloadFiles.ps1` to select profile at runtime
  - Added `local/profile-config.ps1.template` for persistent configuration
  - Support for per-toolchain overrides (`$DFIRWS_PROFILE_NODE`, `$DFIRWS_PROFILE_RUST`, etc.)
  - Support for extras list to force-include specific tools despite profile exclusions

- **Tool Filtering**: 
  - Added `Test-ToolIncluded()` function in `common.ps1` to check if a tool should be downloaded
  - Wrapped all large/optional tool downloads in `http.ps1` and `winget.ps1` with profile checks
  - Updated `basic.ps1` to respect profile settings for build toolchains

- **Documentation**: Updated README.md with distribution profile section explaining usage and configuration

## Implementation Details

- Profile resolution order: CLI parameter > config file > default (Full)
- Extras list overrides profile exclusions, allowing selective tool inclusion
- Explicit command-line switches (e.g., `-Rust`, `-Node`) always override profile settings
- Backward compatible: existing scripts work unchanged; profiles are opt-in

https://claude.ai/code/session_01LMhTuLbw1rRXLRGtcydjDw