### PR TITLE
Fix MSYS2 r2ai build failure in sandbox upgrades

### DIFF
--- a/setup/install/install_msys2.ps1
+++ b/setup/install/install_msys2.ps1
@@ -39,11 +39,6 @@ if (Test-Path -Path "C:\Tools\msys64\usr\bin\bash.exe") {
     Write-Output "MSYS2 installation done."
 }
 
-# Ensure required MSYS2/UCRT64 build packages are present on both fresh install and update paths.
-# Without this step, updated sandboxes may miss `make` and fail r2ai compilation.
-Write-DateLog "Ensure MSYS2 build packages are installed." 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"
-& "C:\Tools\msys64\usr\bin\bash.exe" -lc 'pacman --noconfirm -S --needed make bc binutils cpio expect git gnu-netcat mingw-w64-ucrt-x86_64-autotools mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-make mingw-w64-ucrt-x86_64-toolchain nasm ncurses ncurses-devel pv rsync tree zsh vim' 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"
-
 ## Compile r2ai plugin if radare2 and r2ai source are available
 if ((Test-Path "C:\git\r2ai\src\Makefile") -and (Test-Path "C:\Tools\radare2\bin\radare2.exe")) {
     Write-DateLog "Compiling r2ai plugin for radare2." 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"
@@ -65,7 +60,7 @@ if ((Test-Path "C:\git\r2ai\src\Makefile") -and (Test-Path "C:\Tools\radare2\bin
     # The upstream Makefile default target may run `r2check` which executes `r2`.
     # In the sandbox this runtime check can fail (Error 127) even when compilation works,
     # so provide a temporary no-op `r2` shim only for this build invocation.
-    $r2aiBuildCommand = 'export PKG_CONFIG_PATH=/c/Tools/radare2/lib/pkgconfig; export PATH=/ucrt64/bin:/usr/bin:/c/Tools/radare2/bin:$PATH; mkdir -p /tmp/r2shim; printf "#!/usr/bin/env sh\nexit 0\n" > /tmp/r2shim/r2; chmod +x /tmp/r2shim/r2; export PATH=/tmp/r2shim:$PATH; MAKE_BIN=$(command -v make || command -v gmake || true); [ -n "$MAKE_BIN" ] || { echo "make not found in PATH=$PATH"; ls -l /usr/bin/make /ucrt64/bin/make* 2>/dev/null || true; exit 127; }; cd /c/tmp/r2ai_build; "$MAKE_BIN" DOTEXE=.exe'
+    $r2aiBuildCommand = 'export PKG_CONFIG_PATH=/c/Tools/radare2/lib/pkgconfig; export PATH=/ucrt64/bin:/usr/bin:/c/Tools/radare2/bin:$PATH; mkdir -p /tmp/r2shim; echo "#!/usr/bin/env sh" > /tmp/r2shim/r2; echo "exit 0" >> /tmp/r2shim/r2; chmod +x /tmp/r2shim/r2; export PATH=/tmp/r2shim:$PATH; MAKE_BIN=$(command -v make || command -v mingw32-make || command -v gmake || true); [ -n "$MAKE_BIN" ] || { echo "make not found in PATH=$PATH"; ls -l /usr/bin/make /ucrt64/bin/make* 2>/dev/null || true; exit 127; }; cd /c/tmp/r2ai_build; "$MAKE_BIN" DOTEXE=.exe'
     & "C:\Tools\msys64\usr\bin\bash.exe" -lc $r2aiBuildCommand 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"
     # Copy output to persistent location
     $r2ai_output = "C:\Tools\msys64\r2ai_build"


### PR DESCRIPTION
### Motivation
- Upgrades were triggering a redundant `pacman --needed` pass that produced noisy "up to date -- skipping" output and could mask the real build flow. 
- The r2ai build was failing due to a brittle `printf`-based shim creation that produced `printf: usage` in MSYS2 logs and prevented `r2ai.dll` from being produced. 
- Make invocation was fragile in the sandbox where the `make` binary can be named differently, causing the Makefile step to abort when `make` wasn't found.

### Description
- Removed the post-install `pacman --noconfirm -S --needed ...` package enforcement block from `setup/install/install_msys2.ps1` so upgrade flows no longer re-run the extra package install pass. 
- Replaced the `printf`-based shim creation with `echo`-based writes to create a temporary no-op `/tmp/r2shim/r2`, avoiding the `printf: usage` error. 
- Broadened the make resolution in the r2ai build command to try `mingw32-make` as an additional fallback (`make || mingw32-make || gmake`) before invoking the Makefile.

### Testing
- Reviewed changes with `git diff -- setup/install/install_msys2.ps1` to confirm only the intended edits were applied. 
- Attempted PowerShell AST parsing with `pwsh -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('setup/install/install_msys2.ps1',...)"` but the check could not run because `pwsh` was not available in the environment. 
- File content was inspected programmatically and the modified build command and removed package block were validated by review (no runtime sandbox build executed in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991b7df39cc832ebbed24a0b3a7b741)