### PR TITLE
Normalize SourceType and add npm/cargo aliases in tools docs generator

### DIFF
--- a/scripts/generate-tools-docs.py
+++ b/scripts/generate-tools-docs.py
@@ -66,7 +66,9 @@ def get_string_list(value) -> List[str]:
 SOURCE_TYPE_LABELS = {
     "python": "Python",
     "node": "npm",
+    "npm": "npm",
     "rust": "Cargo",
+    "cargo": "Cargo",
     "go": "Go",
     "http": "HTTP",
     "release": "GitHub Release",
@@ -83,9 +85,9 @@ SOURCE_TYPE_LABELS = {
 
 
 def get_source_label(tool: dict) -> str:
-    source_type = tool.get("SourceType", "")
+    source_type = str(tool.get("SourceType", "") or "").strip()
     if source_type:
-        return SOURCE_TYPE_LABELS.get(source_type, source_type)
+        return SOURCE_TYPE_LABELS.get(source_type.lower(), source_type)
     return ""
 
 
@@ -123,7 +125,8 @@ def write_tool_page(docs_root: Path, tool: dict, category_path: str, slug: str) 
     lines: List[str] = []
     lines.append(f"# {tool.get('Name', '')}")
     lines.append("")
-    lines.append(f"**Category:** {category_path.replace('\\\\', ' / ')}")
+    category_display = category_path.replace('\\', ' / ')
+    lines.append(f"**Category:** {category_display}")
     lines.append("")
 
     meta_added = False


### PR DESCRIPTION
### Motivation
- The tools docs generator produced inconsistent or missing "Source" entries in overview tables when `SourceType` values used different casing or used direct values like `npm`/`cargo` instead of `node`/`rust`.
- The generator also had a Python f-string parse issue caused by a backslash-containing expression when rendering category paths, preventing execution in some environments.

### Description
- Normalize `SourceType` handling in `scripts/generate-tools-docs.py` by coercing to `str`, trimming, and performing a lowercase lookup in `get_source_label()` so lookups are case-insensitive and robust.
- Add explicit aliases `"npm": "npm"` and `"cargo": "Cargo"` to `SOURCE_TYPE_LABELS` while keeping the existing `node -> npm` and `rust -> Cargo` mappings so both direct and indirect names render correctly.
- Fix the category line generation to avoid an f-string with a backslash by computing `category_display = category_path.replace('\\', ' / ')` and then using that in the f-string.

### Testing
- Ran `python scripts/generate-tools-docs.py --help` to confirm the script loads and prints usage (succeeded).
- Imported the module and exercised `get_source_label()` with various inputs (`'node'`, `'npm'`, `'rust'`, `'cargo'`, uppercase variants) to verify normalized outputs like `npm` and `Cargo` (succeeded).
- Generated docs from a temporary JSON containing tools with `SourceType` values `npm` and `cargo` and confirmed both appear in the generated `docs/tools/index.md` overview table as `npm` and `Cargo` respectively (succeeded).
- Confirmed the script no longer triggers the f-string backslash parse error and runs end-to-end for the validation case (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991c5520a08832eaeec51cc16da2f07)