### PR TITLE
Expand Basic profile exclusions and add git repo filtering

### DIFF
--- a/downloadFiles.ps1
+++ b/downloadFiles.ps1
@@ -161,6 +161,12 @@ if ($activeProfileName -ne "" -and (Test-Path variable:DFIRWS_PROFILES) -and $DF
     if ($DFIRWS_EXTRAS_RESOLVED.Count -gt 0) {
         Write-DateLog "Extras included: $($DFIRWS_EXTRAS_RESOLVED -join ', ')"
     }
+
+    # Build git repo exclude list
+    $DFIRWS_EXCLUDE_GIT_REPOS = @()
+    if ($null -ne $activeProfile.ExcludeGitRepos) {
+        $DFIRWS_EXCLUDE_GIT_REPOS = $activeProfile.ExcludeGitRepos
+    }
 } else {
     # No profile = Full behavior (everything included)
     $profileNodeEnabled  = $true
@@ -169,6 +175,7 @@ if ($activeProfileName -ne "" -and (Test-Path variable:DFIRWS_PROFILES) -and $DF
     $profileMsys2Enabled = $true
     $DFIRWS_EXCLUDE_TOOLS = @()
     $DFIRWS_EXTRAS_RESOLVED = @()
+    $DFIRWS_EXCLUDE_GIT_REPOS = @()
 }
 
 $ProgressPreference = "SilentlyContinue"
@@ -203,6 +210,9 @@ if ($AllTools.IsPresent) {
     $all = $true
 } elseif ($Didier.IsPresent -or $Enrichment.IsPresent -or $Freshclam.IsPresent -or $Git.IsPresent -or $GoLang.IsPresent -or $Http.IsPresent -or $Kape.IsPresent -or $LogBoost.IsPresent -or $MSYS2.IsPresent -or $Node.IsPresent -or $PowerShell.IsPresent -or $Python.IsPresent -or $Release.IsPresent -or $Rust.IsPresent -or $Winget.IsPresent -or $Verify.IsPresent -or $VisualStudioBuildTools.IsPresent -or $Zimmerman.IsPresent) {
     $all = $false
+} elseif ($Profile -ne "") {
+    Write-DateLog "Download tools for dfirws using profile: $Profile"
+    $all = $true
 } else {
     Write-DateLog "No arguments given. Will download all tools for dfirws."
     $all = $true

--- a/local/defaults/profile-config.ps1.template
+++ b/local/defaults/profile-config.ps1.template
@@ -5,8 +5,8 @@
 # Default (empty string) = Full (all tools downloaded)
 $DFIRWS_PROFILE = ""
 
-# Override script inclusion (overrides the profile setting)
-# Uncomment and set to $true/$false to override:
+# Override script inclusion (overrides profile setting)
+# Uncomment to override:
 # $DFIRWS_PROFILE_NODE = $true
 # $DFIRWS_PROFILE_RUST = $false
 # $DFIRWS_PROFILE_GO = $false
@@ -14,11 +14,27 @@ $DFIRWS_PROFILE = ""
 
 # Extra tools to include even when excluded by the profile.
 # Add tool names to force-include them.
-# Available extras for Basic profile:
-#   "Autopsy", "QEMU", "Burp Suite", "Google Earth Pro",
-#   "Binary Ninja", "Neo4j", "hashcat",
-#   "Volatility Workbench 3", "Volatility Workbench 2.1",
-#   "LibreOffice", "Elastic Stack (ELK + Beats)"
+#
+# Available extras for Basic profile (grouped by source):
+#   basic.ps1:   "Ghidra", "ClamAV"
+#   winget.ps1:  "Autopsy", "Burp Suite", "QEMU", "Google Earth Pro",
+#                "Obsidian", "OpenVPN", "Tailscale", "Chrome", "Firefox",
+#                "VLC", "PuTTY", "WireGuard", "Foxit PDF Reader", "Ruby",
+#                "VirusTotal CLI"
+#   http.ps1:    "Binary Ninja", "Neo4j", "hashcat",
+#                "Volatility Workbench 3", "Volatility Workbench 2.1",
+#                "LibreOffice", "Elastic Stack (ELK + Beats)",
+#                "Tor Browser", "VeraCrypt", "capa Explorer Web"
+#   release.ps1: "Audacity", "Zui", "ffmpeg", "cmder", "DBeaver",
+#                "godap", "Recaf", "4n4lDetector", "Dokany", "adalanche",
+#                "Cutter", "Fibratus", "h2database", "Strawberry Perl",
+#                "zaproxy", "YAMAGoya", "Velociraptor", "fqlite"
+#
+# Note: Adding "Obsidian" also requires adding the Obsidian plugins:
+#   "obsidian-mitre-attack", "obsidian-dataview", "obsidian-kanban",
+#   "quickadd", "obsidian-calendar-plugin", "Templater",
+#   "obsidian-tasks", "obsidian-excalidraw-plugin", "admonitions",
+#   "obsidian-timeline"
 #
 # Example: $DFIRWS_EXTRAS = @("Autopsy", "LibreOffice")
 $DFIRWS_EXTRAS = @()

--- a/local/defaults/profiles.ps1
+++ b/local/defaults/profiles.ps1
@@ -3,7 +3,8 @@
 #
 # Each profile defines:
 #   Scripts      - Which build sandbox scripts to run (node, rust, go, msys2)
-#   ExcludeTools - Large tools to skip in shared download scripts (winget.ps1, http.ps1)
+#   ExcludeTools - Large or optional tools to skip in download scripts
+#   ExcludeGitRepos - Git repositories to skip in git.ps1
 
 $DFIRWS_PROFILES = @{
     "Basic" = @{
@@ -14,17 +15,77 @@ $DFIRWS_PROFILES = @{
             "msys2"  = $false
         }
         ExcludeTools = @(
+            # basic.ps1
+            "Ghidra",
+            "ClamAV",
+            # winget.ps1
             "Autopsy",
-            "QEMU",
             "Burp Suite",
+            "QEMU",
             "Google Earth Pro",
+            "Obsidian",
+            "OpenVPN",
+            "Tailscale",
+            "Chrome",
+            "Firefox",
+            "VLC",
+            "PuTTY",
+            "WireGuard",
+            "Foxit PDF Reader",
+            "Ruby",
+            "VirusTotal CLI",
+            # http.ps1
             "Binary Ninja",
             "Neo4j",
             "hashcat",
             "Volatility Workbench 3",
             "Volatility Workbench 2.1",
             "LibreOffice",
-            "Elastic Stack (ELK + Beats)"
+            "Elastic Stack (ELK + Beats)",
+            "Tor Browser",
+            "VeraCrypt",
+            "capa Explorer Web",
+            # release.ps1
+            "Audacity",
+            "Zui",
+            "ffmpeg",
+            "cmder",
+            "DBeaver",
+            "godap",
+            "Recaf",
+            "4n4lDetector",
+            "Dokany",
+            "adalanche",
+            "Cutter",
+            "Fibratus",
+            "h2database",
+            "Strawberry Perl",
+            "zaproxy",
+            "YAMAGoya",
+            "Velociraptor",
+            "fqlite",
+            # release.ps1 - Obsidian plugins (excluded with Obsidian)
+            "obsidian-mitre-attack",
+            "obsidian-dataview",
+            "obsidian-kanban",
+            "quickadd",
+            "obsidian-calendar-plugin",
+            "Templater",
+            "obsidian-tasks",
+            "obsidian-excalidraw-plugin",
+            "admonitions",
+            "obsidian-timeline"
+        )
+        ExcludeGitRepos = @(
+            "DFIRArtifactMuseum",
+            "dictionaries",
+            "dfirws-sample-files",
+            "IDR",
+            "MSRC",
+            "fibratus",
+            "MemProcFS.wiki",
+            "LeechCore.wiki",
+            "Trawler"
         )
     }
     "Full" = @{
@@ -35,5 +96,6 @@ $DFIRWS_PROFILES = @{
             "msys2"  = $true
         }
         ExcludeTools = @()
+        ExcludeGitRepos = @()
     }
 }

--- a/resources/download/basic.ps1
+++ b/resources/download/basic.ps1
@@ -50,7 +50,9 @@ $TOOL_DEFINITIONS += @{
 # Packages used in freshclam sandbox
 if ($all -or $Freshclam) {
     # ClamAV - installed during start
-    $status = Get-GitHubRelease -repo "Cisco-Talos/clamav" -path "${SETUP_PATH}\clamav.msi" -match "win.x64.msi$" -check "Composite Document File V2 Document"
+    if (Test-ToolIncluded -ToolName "ClamAV") {
+        $status = Get-GitHubRelease -repo "Cisco-Talos/clamav" -path "${SETUP_PATH}\clamav.msi" -match "win.x64.msi$" -check "Composite Document File V2 Document"
+    }
 }
 
 $TOOL_DEFINITIONS += @{
@@ -111,15 +113,17 @@ if ($all -or $Python) {
     $status = Get-FileFromUri -uri "https://corretto.aws/downloads/latest/amazon-corretto-21-x64-windows-jdk.msi" -FilePath ".\downloads\corretto.msi" -check "Composite Document File V2 Document"
 
     # Ghidra - latest release
-    $status = Get-GitHubRelease -repo "NationalSecurityAgency/ghidra" -path "${SETUP_PATH}\ghidra.zip" -match "_PUBLIC_" -check "Zip archive data"
-    if ($status) {
-        if (Test-Path "${TOOLS}\ghidra") {
-            Remove-Item "${TOOLS}\ghidra" -Recurse -Force
+    if (Test-ToolIncluded -ToolName "Ghidra") {
+        $status = Get-GitHubRelease -repo "NationalSecurityAgency/ghidra" -path "${SETUP_PATH}\ghidra.zip" -match "_PUBLIC_" -check "Zip archive data"
+        if ($status) {
+            if (Test-Path "${TOOLS}\ghidra") {
+                Remove-Item "${TOOLS}\ghidra" -Recurse -Force
+            }
+            & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\ghidra.zip" -o"${TOOLS}" | Out-Null
+            New-Item -ItemType Directory -Force -Path "${TOOLS}\ghidra" | Out-Null
+            Move-Item ${TOOLS}\ghidra_1* "${TOOLS}\ghidra\"
+            Copy-Item "${TOOLS}\ghidra\*\support\ghidra.ico" "${TOOLS}\ghidra" -Recurse -Force
         }
-        & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\ghidra.zip" -o"${TOOLS}" | Out-Null
-        New-Item -ItemType Directory -Force -Path "${TOOLS}\ghidra" | Out-Null
-        Move-Item ${TOOLS}\ghidra_1* "${TOOLS}\ghidra\"
-        Copy-Item "${TOOLS}\ghidra\*\support\ghidra.ico" "${TOOLS}\ghidra" -Recurse -Force
     }
 
     $TOOL_DEFINITIONS += @{

--- a/resources/download/git.ps1
+++ b/resources/download/git.ps1
@@ -77,6 +77,10 @@ $repourls = `
 
 foreach ($repourl in $repourls) {
     $repo = Write-Output $repourl | ForEach-Object { $_ -replace "^.*/" } | ForEach-Object { $_ -replace "\.git$" }
+    if ($null -ne $DFIRWS_EXCLUDE_GIT_REPOS -and $DFIRWS_EXCLUDE_GIT_REPOS.Count -gt 0 -and $DFIRWS_EXCLUDE_GIT_REPOS -contains $repo) {
+        Write-SynchronizedLog "Skipping git repo ${repo} (excluded by profile)."
+        continue
+    }
     if ( Test-Path -Path "${repo}" ) {
         Set-Location "${repo}"
         ${result} = git pull 2>&1

--- a/resources/download/http.ps1
+++ b/resources/download/http.ps1
@@ -2081,8 +2081,10 @@ $TOOL_DEFINITIONS += @{
 }
 
 # Tor browser
-$TorBrowserUrl = Get-DownloadUrlFromPage -Url "https://www.torproject.org/download/" -RegEx '/dist/[^"]+exe'
-$status = Get-FileFromUri -uri "https://www.torproject.org$TorBrowserUrl" -FilePath ".\downloads\torbrowser.exe" -check "PE32"
+if (Test-ToolIncluded -ToolName "Tor Browser") {
+    $TorBrowserUrl = Get-DownloadUrlFromPage -Url "https://www.torproject.org/download/" -RegEx '/dist/[^"]+exe'
+    $status = Get-FileFromUri -uri "https://www.torproject.org$TorBrowserUrl" -FilePath ".\downloads\torbrowser.exe" -check "PE32"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "Tor Browser"
@@ -2171,8 +2173,10 @@ $TOOL_DEFINITIONS += @{
 }
 
 # Veracrypt - manual installation
-$VeracryptUrl = Get-DownloadUrlFromPage -Url "https://www.veracrypt.fr/en/Downloads.html" -RegEx 'https://[^"]+VeraCrypt_Setup[^"]+.msi'
-$status = Get-FileFromUri -uri "${VeracryptUrl}" -FilePath ".\downloads\veracrypt.msi" -check "Composite Document File V2 Document"
+if (Test-ToolIncluded -ToolName "VeraCrypt") {
+    $VeracryptUrl = Get-DownloadUrlFromPage -Url "https://www.veracrypt.fr/en/Downloads.html" -RegEx 'https://[^"]+VeraCrypt_Setup[^"]+.msi'
+    $status = Get-FileFromUri -uri "${VeracryptUrl}" -FilePath ".\downloads\veracrypt.msi" -check "Composite Document File V2 Document"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "VeraCrypt"
@@ -2325,12 +2329,14 @@ $TOOL_DEFINITIONS += @{
 }
 
 # capa Explorer web
-$status = Get-FileFromUri -uri "https://mandiant.github.io/capa/explorer/capa-explorer-web.zip" -FilePath ".\downloads\capa-explorer-web.zip" -check "Zip archive data"
-if ($status) {
-    if (Test-Path -Path "${TOOLS}\capa-explorer-web") {
-        Remove-Item -Recurse -Force "${TOOLS}\capa-explorer-web" | Out-Null 2>&1
+if (Test-ToolIncluded -ToolName "capa Explorer Web") {
+    $status = Get-FileFromUri -uri "https://mandiant.github.io/capa/explorer/capa-explorer-web.zip" -FilePath ".\downloads\capa-explorer-web.zip" -check "Zip archive data"
+    if ($status) {
+        if (Test-Path -Path "${TOOLS}\capa-explorer-web") {
+            Remove-Item -Recurse -Force "${TOOLS}\capa-explorer-web" | Out-Null 2>&1
+        }
+        & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\capa-explorer-web.zip" -o"${TOOLS}" | Out-Null
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\capa-explorer-web.zip" -o"${TOOLS}" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{

--- a/resources/download/release.ps1
+++ b/resources/download/release.ps1
@@ -42,13 +42,15 @@ $TOOL_DEFINITIONS += @{
 }
 
 # godap
-$status = Get-GitHubRelease -repo "Macmod/godap" -path "${SETUP_PATH}\godap.zip" -match "windows-amd64.zip$" -check "Zip archive data"
-if ($status) {
-    if (Test-Path "${TOOLS}\godap") {
-        Remove-Item "${TOOLS}\godap" -Recurse -Force
+if (Test-ToolIncluded -ToolName "godap") {
+    $status = Get-GitHubRelease -repo "Macmod/godap" -path "${SETUP_PATH}\godap.zip" -match "windows-amd64.zip$" -check "Zip archive data"
+    if ($status) {
+        if (Test-Path "${TOOLS}\godap") {
+            Remove-Item "${TOOLS}\godap" -Recurse -Force
+        }
+        & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\godap.zip" -o"${TOOLS}\godap" | Out-Null
+        Move-Item ${TOOLS}\godap-* "${TOOLS}\godap"
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\godap.zip" -o"${TOOLS}\godap" | Out-Null
-    Move-Item ${TOOLS}\godap-* "${TOOLS}\godap"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -118,7 +120,9 @@ $TOOL_DEFINITIONS += @{
 }
 
 # 4n4lDetector - installed in sandbox during startup
-$status =  Get-GitHubRelease -repo "4n0nym0us/4n4lDetector" -path "${SETUP_PATH}\4n4lDetector.zip" -match "4n4lDetector" -check "Zip archive data"
+if (Test-ToolIncluded -ToolName "4n4lDetector") {
+    $status =  Get-GitHubRelease -repo "4n0nym0us/4n4lDetector" -path "${SETUP_PATH}\4n4lDetector.zip" -match "4n4lDetector" -check "Zip archive data"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "4n4lDetector"
@@ -388,13 +392,15 @@ $TOOL_DEFINITIONS += @{
 }
 
 # Audacity
-$status = Get-GitHubRelease -repo "audacity/audacity" -path "${SETUP_PATH}\audacity.zip" -match "64bit.zip" -check "Zip archive data"
-if ($status) {
-    if (Test-Path "${TOOLS}\audacity") {
-        Remove-Item "${TOOLS}\audacity" -Recurse -Force
+if (Test-ToolIncluded -ToolName "Audacity") {
+    $status = Get-GitHubRelease -repo "audacity/audacity" -path "${SETUP_PATH}\audacity.zip" -match "64bit.zip" -check "Zip archive data"
+    if ($status) {
+        if (Test-Path "${TOOLS}\audacity") {
+            Remove-Item "${TOOLS}\audacity" -Recurse -Force
+        }
+        & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\audacity.zip" -o"${TOOLS}" | Out-Null
+        Move-Item ${TOOLS}\audacity-* "${TOOLS}\audacity"
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\audacity.zip" -o"${TOOLS}" | Out-Null
-    Move-Item ${TOOLS}\audacity-* "${TOOLS}\audacity"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -469,7 +475,9 @@ $TOOL_DEFINITIONS += @{
 }
 
 # Brim/Zui (Zq) - installed during start
-$status =  Get-GitHubRelease -repo "brimdata/zui" -path "${SETUP_PATH}\zui.exe" -match "exe$" -check "PE32"
+if (Test-ToolIncluded -ToolName "Zui") {
+    $status =  Get-GitHubRelease -repo "brimdata/zui" -path "${SETUP_PATH}\zui.exe" -match "exe$" -check "PE32"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "Zui"
@@ -542,13 +550,15 @@ $TOOL_DEFINITIONS += @{
 }
 
 # ffmpeg
-$status = Get-GitHubRelease -repo "BtbN/FFmpeg-Builds" -path "${SETUP_PATH}\ffmpeg.zip" -match "win64-gpl-7" -check "Zip archive data"
-if ($status) {
-    if (Test-Path "${TOOLS}\ffmpeg") {
-        Remove-Item "${TOOLS}\ffmpeg" -Recurse -Force
+if (Test-ToolIncluded -ToolName "ffmpeg") {
+    $status = Get-GitHubRelease -repo "BtbN/FFmpeg-Builds" -path "${SETUP_PATH}\ffmpeg.zip" -match "win64-gpl-7" -check "Zip archive data"
+    if ($status) {
+        if (Test-Path "${TOOLS}\ffmpeg") {
+            Remove-Item "${TOOLS}\ffmpeg" -Recurse -Force
+        }
+        & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\ffmpeg.zip" -o"${TOOLS}" | Out-Null
+        Move-Item ${TOOLS}\ffmpeg-* "${TOOLS}\ffmpeg"
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\ffmpeg.zip" -o"${TOOLS}" | Out-Null
-    Move-Item ${TOOLS}\ffmpeg-* "${TOOLS}\ffmpeg"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -658,7 +668,9 @@ $TOOL_DEFINITIONS += @{
 }
 
 # cmder - installed during start
-$status =  Get-GitHubRelease -repo "cmderdev/cmder" -path "${SETUP_PATH}\cmder.7z" -match "cmder.7z" -check "7-zip archive data"
+if (Test-ToolIncluded -ToolName "cmder") {
+    $status =  Get-GitHubRelease -repo "cmderdev/cmder" -path "${SETUP_PATH}\cmder.7z" -match "cmder.7z" -check "7-zip archive data"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "cmder"
@@ -683,10 +695,12 @@ $TOOL_DEFINITIONS += @{
 }
 
 # Recaf
-$status = Get-GitHubRelease -repo "Col-E/Recaf" -path "${SETUP_PATH}\recaf.jar" -match "jar-with-dependencies.jar" -check "Java archive data \(JAR\)"
-if ($status) {
-    Copy-Item ${SETUP_PATH}\recaf.jar ${TOOLS}\lib\recaf.jar
-    Set-Content -Encoding Ascii -Path "${TOOLS}\bin\recaf.bat" "@echo off`njava --module-path ${SANDBOX_TOOLS}\javafx-sdk\lib --add-modules javafx.controls -jar C:\Tools\lib\recaf.jar"
+if (Test-ToolIncluded -ToolName "Recaf") {
+    $status = Get-GitHubRelease -repo "Col-E/Recaf" -path "${SETUP_PATH}\recaf.jar" -match "jar-with-dependencies.jar" -check "Java archive data \(JAR\)"
+    if ($status) {
+        Copy-Item ${SETUP_PATH}\recaf.jar ${TOOLS}\lib\recaf.jar
+        Set-Content -Encoding Ascii -Path "${TOOLS}\bin\recaf.bat" "@echo off`njava --module-path ${SANDBOX_TOOLS}\javafx-sdk\lib --add-modules javafx.controls -jar C:\Tools\lib\recaf.jar"
+    }
 }
 
 $TOOL_DEFINITIONS += @{
@@ -714,12 +728,14 @@ $TOOL_DEFINITIONS += @{
 }
 
 # DBeaver
-$status = Get-GitHubRelease -repo "dbeaver/dbeaver" -path "${SETUP_PATH}\dbeaver.zip" -match "win32.win32.x86_64.zip" -check "Zip archive data"
-if ($status) {
-    if (Test-Path "${TOOLS}\dbeaver") {
-        Remove-Item "${TOOLS}\dbeaver" -Recurse -Force
+if (Test-ToolIncluded -ToolName "DBeaver") {
+    $status = Get-GitHubRelease -repo "dbeaver/dbeaver" -path "${SETUP_PATH}\dbeaver.zip" -match "win32.win32.x86_64.zip" -check "Zip archive data"
+    if ($status) {
+        if (Test-Path "${TOOLS}\dbeaver") {
+            Remove-Item "${TOOLS}\dbeaver" -Recurse -Force
+        }
+        & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\dbeaver.zip" -o"${TOOLS}" | Out-Null
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\dbeaver.zip" -o"${TOOLS}" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -845,7 +861,9 @@ $TOOL_DEFINITIONS += @{
 }
 
 # Dokany - available for manual installation
-$status =  Get-GitHubRelease -repo "dokan-dev/dokany" -path "${SETUP_PATH}\dokany.msi" -match "Dokan_x64.msi" -check "Composite Document File V2 Document"
+if (Test-ToolIncluded -ToolName "Dokany") {
+    $status =  Get-GitHubRelease -repo "dokan-dev/dokany" -path "${SETUP_PATH}\dokany.msi" -match "Dokan_x64.msi" -check "Composite Document File V2 Document"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "Dokany"
@@ -1031,16 +1049,18 @@ $TOOL_DEFINITIONS += @{
 }
 
 # h2database - available for manual installation
-$status = Get-GitHubRelease -repo "h2database/h2database" -path "${SETUP_PATH}\h2database.zip" -match "bundle.jar" -check "Java archive data"
-if ($status) {
-    if (Test-Path "${TOOLS}\h2database") {
-        Remove-Item "${TOOLS}\h2database" -Recurse -Force
+if (Test-ToolIncluded -ToolName "h2database") {
+    $status = Get-GitHubRelease -repo "h2database/h2database" -path "${SETUP_PATH}\h2database.zip" -match "bundle.jar" -check "Java archive data"
+    if ($status) {
+        if (Test-Path "${TOOLS}\h2database") {
+            Remove-Item "${TOOLS}\h2database" -Recurse -Force
+        }
+        & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\h2database.zip" -o"${TOOLS}\h2database" | Out-Null
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\h2database.zip" -o"${TOOLS}\h2database" | Out-Null
-}
-$status = Get-GitHubRelease -repo "h2database/h2database" -path "${SETUP_PATH}\h2.pdf" -match "h2.pdf"
-if ($status) {
-    Copy-Item ${SETUP_PATH}\h2.pdf ${TOOLS}\h2database
+    $status = Get-GitHubRelease -repo "h2database/h2database" -path "${SETUP_PATH}\h2.pdf" -match "h2.pdf"
+    if ($status) {
+        Copy-Item ${SETUP_PATH}\h2.pdf ${TOOLS}\h2database
+    }
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1705,9 +1725,11 @@ $TOOL_DEFINITIONS += @{
 }
 
 # adalanche
-$status = Get-GitHubRelease -repo "lkarlslund/adalanche" -path "${SETUP_PATH}\adalanche.exe" -match "adalanche-windows-x64" -check "PE32"
-if ($status) {
-    Copy-Item ${SETUP_PATH}\adalanche.exe ${TOOLS}\bin\
+if (Test-ToolIncluded -ToolName "adalanche") {
+    $status = Get-GitHubRelease -repo "lkarlslund/adalanche" -path "${SETUP_PATH}\adalanche.exe" -match "adalanche-windows-x64" -check "PE32"
+    if ($status) {
+        Copy-Item ${SETUP_PATH}\adalanche.exe ${TOOLS}\bin\
+    }
 }
 
 $TOOL_DEFINITIONS += @{
@@ -2695,7 +2717,9 @@ $TOOL_DEFINITIONS += @{
 }
 
 # Fibratus
-$status = Get-GitHubRelease -repo "rabbitstack/fibratus" -path "${SETUP_PATH}\fibratus.msi" -match "fibratus-[.0-9]+-amd64.msi$" -check "Composite Document File V2 Document"
+if (Test-ToolIncluded -ToolName "Fibratus") {
+    $status = Get-GitHubRelease -repo "rabbitstack/fibratus" -path "${SETUP_PATH}\fibratus.msi" -match "fibratus-[.0-9]+-amd64.msi$" -check "Composite Document File V2 Document"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "Fibratus"
@@ -2874,14 +2898,16 @@ $TOOL_DEFINITIONS += @{
 }
 
 # obsidian-mitre-attack
-$status = Get-GitHubRelease -repo "reuteras/obsidian-mitre-attack" -path "${SETUP_PATH}\obsidian-mitre-attack.zip" -match "release.zip" -check "Zip archive data"
-if ($status) {
-    if (Test-Path "${TOOLS}\obsidian-mitre-attack") {
-        Remove-Item "${TOOLS}\obsidian-mitre-attack" -Recurse -Force
+if (Test-ToolIncluded -ToolName "obsidian-mitre-attack") {
+    $status = Get-GitHubRelease -repo "reuteras/obsidian-mitre-attack" -path "${SETUP_PATH}\obsidian-mitre-attack.zip" -match "release.zip" -check "Zip archive data"
+    if ($status) {
+        if (Test-Path "${TOOLS}\obsidian-mitre-attack") {
+            Remove-Item "${TOOLS}\obsidian-mitre-attack" -Recurse -Force
+        }
+        & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\obsidian-mitre-attack.zip" -o"${TOOLS}" | Out-Null
+        Move-Item "${TOOLS}\MITRE" "${TOOLS}\obsidian-mitre-attack"
+        Remove-Item "${TOOLS}\README.md" -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\obsidian-mitre-attack.zip" -o"${TOOLS}" | Out-Null
-    Move-Item "${TOOLS}\MITRE" "${TOOLS}\obsidian-mitre-attack"
-    Remove-Item "${TOOLS}\README.md" -Force
 }
 
 $TOOL_DEFINITIONS += @{
@@ -2901,13 +2927,15 @@ $TOOL_DEFINITIONS += @{
 }
 
 # Cutter
-$status = Get-GitHubRelease -repo "rizinorg/cutter" -path "${SETUP_PATH}\cutter.zip" -match "Windows-x86_64.zip" -check "Zip archive data"
-if ($status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\cutter.zip" -o"${TOOLS}" | Out-Null
-    if (Test-Path "${TOOLS}\cutter") {
-        Remove-Item "${TOOLS}\cutter" -Recurse -Force
+if (Test-ToolIncluded -ToolName "Cutter") {
+    $status = Get-GitHubRelease -repo "rizinorg/cutter" -path "${SETUP_PATH}\cutter.zip" -match "Windows-x86_64.zip" -check "Zip archive data"
+    if ($status) {
+        & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\cutter.zip" -o"${TOOLS}" | Out-Null
+        if (Test-Path "${TOOLS}\cutter") {
+            Remove-Item "${TOOLS}\cutter" -Recurse -Force
+        }
+        Move-Item ${TOOLS}\Cutter-* ${TOOLS}\cutter
     }
-    Move-Item ${TOOLS}\Cutter-* ${TOOLS}\cutter
 }
 
 $TOOL_DEFINITIONS += @{
@@ -2969,12 +2997,14 @@ $TOOL_DEFINITIONS += @{
 }
 
 # Perl by Strawberry
-$status = Get-GitHubRelease -repo "StrawberryPerl/Perl-Dist-Strawberry" -path "${SETUP_PATH}\perl.zip" -match "portable.zip" -check "Zip archive data"
-if ($status) {
-    if (Test-Path "${TOOLS}\perl") {
-        Remove-Item "${TOOLS}\perl" -Recurse -Force
+if (Test-ToolIncluded -ToolName "Strawberry Perl") {
+    $status = Get-GitHubRelease -repo "StrawberryPerl/Perl-Dist-Strawberry" -path "${SETUP_PATH}\perl.zip" -match "portable.zip" -check "Zip archive data"
+    if ($status) {
+        if (Test-Path "${TOOLS}\perl") {
+            Remove-Item "${TOOLS}\perl" -Recurse -Force
+        }
+        & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\perl.zip" -o"${TOOLS}\perl" | Out-Null
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\perl.zip" -o"${TOOLS}\perl" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -3319,9 +3349,11 @@ $TOOL_DEFINITIONS += @{
 }
 
 # Velociraptor
-$status = Get-GitHubRelease -repo "velocidex/velociraptor" -path "${SETUP_PATH}\velociraptor.exe" -match "windows-amd64.exe$" -check "PE32"
-if ($status) {
-    Copy-Item "${SETUP_PATH}\velociraptor.exe" "${TOOLS}\bin\" -Force
+if (Test-ToolIncluded -ToolName "Velociraptor") {
+    $status = Get-GitHubRelease -repo "velocidex/velociraptor" -path "${SETUP_PATH}\velociraptor.exe" -match "windows-amd64.exe$" -check "PE32"
+    if ($status) {
+        Copy-Item "${SETUP_PATH}\velociraptor.exe" "${TOOLS}\bin\" -Force
+    }
 }
 
 $TOOL_DEFINITIONS += @{
@@ -3413,7 +3445,9 @@ $TOOL_DEFINITIONS += @{
 }
 
 # fqlite
-$status = Get-GitHubRelease -repo "pawlaszczyk/fqlite" -path "${SETUP_PATH}\fqlite.exe" -match "windows.exe" -check "PE32"
+if (Test-ToolIncluded -ToolName "fqlite") {
+    $status = Get-GitHubRelease -repo "pawlaszczyk/fqlite" -path "${SETUP_PATH}\fqlite.exe" -match "windows.exe" -check "PE32"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "fqlite"
@@ -3815,7 +3849,9 @@ $TOOL_DEFINITIONS += @{
 }
 
 # zaproxy - available for installation with dfirws-install.ps1
-$status = Get-GitHubRelease -repo "zaproxy/zaproxy" -path "${SETUP_PATH}\zaproxy.exe" -match "windows.exe" -check "PE32"
+if (Test-ToolIncluded -ToolName "zaproxy") {
+    $status = Get-GitHubRelease -repo "zaproxy/zaproxy" -path "${SETUP_PATH}\zaproxy.exe" -match "windows.exe" -check "PE32"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "zaproxy"
@@ -3940,12 +3976,14 @@ $TOOL_DEFINITIONS += @{
 }
 
 # YAMAGoya
-$status = Get-GitHubRelease -repo "JPCERTCC/YAMAGoya" -path "${SETUP_PATH}\YAMAGoya.zip" -match "YAMAGoya.*.zip" -check "Zip archive data"
-if ($status) {
-    if (Test-Path "${TOOLS}\YAMAGoya") {
-        Remove-Item "${TOOLS}\YAMAGoya" -Recurse -Force
+if (Test-ToolIncluded -ToolName "YAMAGoya") {
+    $status = Get-GitHubRelease -repo "JPCERTCC/YAMAGoya" -path "${SETUP_PATH}\YAMAGoya.zip" -match "YAMAGoya.*.zip" -check "Zip archive data"
+    if ($status) {
+        if (Test-Path "${TOOLS}\YAMAGoya") {
+            Remove-Item "${TOOLS}\YAMAGoya" -Recurse -Force
+        }
+        & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\YAMAGoya.zip" -o"${TOOLS}\YAMAGoya" | Out-Null
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\YAMAGoya.zip" -o"${TOOLS}\YAMAGoya" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -3976,50 +4014,53 @@ $TOOL_DEFINITIONS += @{
 # Obsidian plugins
 #
 
-# obsidian-dataview
-$status = Get-GitHubRelease -repo "blacksmithgu/obsidian-dataview" -path "${SETUP_PATH}\obsidian-plugins\obsidian-dataview\main.js" -match "main.js" -check "JavaScript source"
-$status = Get-GitHubRelease -repo "blacksmithgu/obsidian-dataview" -path "${SETUP_PATH}\obsidian-plugins\obsidian-dataview\manifest.json" -match "manifest.json" -check "JSON text data"
-$status = Get-GitHubRelease -repo "blacksmithgu/obsidian-dataview" -path "${SETUP_PATH}\obsidian-plugins\obsidian-dataview\styles.css" -match "styles.css" -check "ASCII text"
+# Obsidian plugins - all gated on Obsidian inclusion
+if (Test-ToolIncluded -ToolName "Obsidian") {
+    # obsidian-dataview
+    $status = Get-GitHubRelease -repo "blacksmithgu/obsidian-dataview" -path "${SETUP_PATH}\obsidian-plugins\obsidian-dataview\main.js" -match "main.js" -check "JavaScript source"
+    $status = Get-GitHubRelease -repo "blacksmithgu/obsidian-dataview" -path "${SETUP_PATH}\obsidian-plugins\obsidian-dataview\manifest.json" -match "manifest.json" -check "JSON text data"
+    $status = Get-GitHubRelease -repo "blacksmithgu/obsidian-dataview" -path "${SETUP_PATH}\obsidian-plugins\obsidian-dataview\styles.css" -match "styles.css" -check "ASCII text"
 
-# obsidian-kanban
-$status = Get-GitHubRelease -repo "mgmeyers/obsidian-kanban" -path "${SETUP_PATH}\obsidian-plugins\obsidian-kanban\main.js" -match "main.js" -check "JavaScript source"
-$status = Get-GitHubRelease -repo "mgmeyers/obsidian-kanban" -path "${SETUP_PATH}\obsidian-plugins\obsidian-kanban\manifest.json" -match "manifest.json" -check "JSON text data"
-$status = Get-GitHubRelease -repo "mgmeyers/obsidian-kanban" -path "${SETUP_PATH}\obsidian-plugins\obsidian-kanban\styles.css" -match "styles.css" -check "ASCII text"
+    # obsidian-kanban
+    $status = Get-GitHubRelease -repo "mgmeyers/obsidian-kanban" -path "${SETUP_PATH}\obsidian-plugins\obsidian-kanban\main.js" -match "main.js" -check "JavaScript source"
+    $status = Get-GitHubRelease -repo "mgmeyers/obsidian-kanban" -path "${SETUP_PATH}\obsidian-plugins\obsidian-kanban\manifest.json" -match "manifest.json" -check "JSON text data"
+    $status = Get-GitHubRelease -repo "mgmeyers/obsidian-kanban" -path "${SETUP_PATH}\obsidian-plugins\obsidian-kanban\styles.css" -match "styles.css" -check "ASCII text"
 
-# quickadd
-$status = Get-GitHubRelease -repo "chhoumann/quickadd" -path "${SETUP_PATH}\obsidian-plugins\quickadd\main.js" -match "main.js" -check "JavaScript source"
-$status = Get-GitHubRelease -repo "chhoumann/quickadd" -path "${SETUP_PATH}\obsidian-plugins\quickadd\manifest.json" -match "manifest.json" -check "JSON text data"
-$status = Get-GitHubRelease -repo "chhoumann/quickadd" -path "${SETUP_PATH}\obsidian-plugins\quickadd\styles.css" -match "styles.css" -check "ASCII text"
+    # quickadd
+    $status = Get-GitHubRelease -repo "chhoumann/quickadd" -path "${SETUP_PATH}\obsidian-plugins\quickadd\main.js" -match "main.js" -check "JavaScript source"
+    $status = Get-GitHubRelease -repo "chhoumann/quickadd" -path "${SETUP_PATH}\obsidian-plugins\quickadd\manifest.json" -match "manifest.json" -check "JSON text data"
+    $status = Get-GitHubRelease -repo "chhoumann/quickadd" -path "${SETUP_PATH}\obsidian-plugins\quickadd\styles.css" -match "styles.css" -check "ASCII text"
 
-# obsidian-calendar-plugin
-$status = Get-GitHubRelease -repo "liamcain/obsidian-calendar-plugin" -path "${SETUP_PATH}\obsidian-plugins\obsidian-calendar-plugin\main.js" -match "main.js" -check "JavaScript source"
-$status = Get-GitHubRelease -repo "liamcain/obsidian-calendar-plugin" -path "${SETUP_PATH}\obsidian-plugins\obsidian-calendar-plugin\manifest.json" -match "manifest.json" -check "JSON text data"
-$status = Get-GitHubRelease -repo "liamcain/obsidian-calendar-plugin" -path "${SETUP_PATH}\obsidian-plugins\obsidian-calendar-plugin\styles.css" -match "styles.css" -check "ASCII text"
+    # obsidian-calendar-plugin
+    $status = Get-GitHubRelease -repo "liamcain/obsidian-calendar-plugin" -path "${SETUP_PATH}\obsidian-plugins\obsidian-calendar-plugin\main.js" -match "main.js" -check "JavaScript source"
+    $status = Get-GitHubRelease -repo "liamcain/obsidian-calendar-plugin" -path "${SETUP_PATH}\obsidian-plugins\obsidian-calendar-plugin\manifest.json" -match "manifest.json" -check "JSON text data"
+    $status = Get-GitHubRelease -repo "liamcain/obsidian-calendar-plugin" -path "${SETUP_PATH}\obsidian-plugins\obsidian-calendar-plugin\styles.css" -match "styles.css" -check "ASCII text"
 
-# Templater
-$status = Get-GitHubRelease -repo "SilentVoid13/Templater" -path "${SETUP_PATH}\obsidian-plugins\Templater\main.js" -match "main.js" -check "JavaScript source"
-$status = Get-GitHubRelease -repo "SilentVoid13/Templater" -path "${SETUP_PATH}\obsidian-plugins\Templater\manifest.json" -match "manifest.json" -check "JSON text data"
-$status = Get-GitHubRelease -repo "SilentVoid13/Templater" -path "${SETUP_PATH}\obsidian-plugins\Templater\styles.css" -match "styles.css" -check "ASCII text"
+    # Templater
+    $status = Get-GitHubRelease -repo "SilentVoid13/Templater" -path "${SETUP_PATH}\obsidian-plugins\Templater\main.js" -match "main.js" -check "JavaScript source"
+    $status = Get-GitHubRelease -repo "SilentVoid13/Templater" -path "${SETUP_PATH}\obsidian-plugins\Templater\manifest.json" -match "manifest.json" -check "JSON text data"
+    $status = Get-GitHubRelease -repo "SilentVoid13/Templater" -path "${SETUP_PATH}\obsidian-plugins\Templater\styles.css" -match "styles.css" -check "ASCII text"
 
-# obsidian-tasks
-$status = Get-GitHubRelease -repo "obsidian-tasks-group/obsidian-tasks" -path "${SETUP_PATH}\obsidian-plugins\obsidian-tasks\main.js" -match "main.js" -check "JavaScript source"
-$status = Get-GitHubRelease -repo "obsidian-tasks-group/obsidian-tasks" -path "${SETUP_PATH}\obsidian-plugins\obsidian-tasks\manifest.json" -match "manifest.json" -check "JSON text data"
-$status = Get-GitHubRelease -repo "obsidian-tasks-group/obsidian-tasks" -path "${SETUP_PATH}\obsidian-plugins\obsidian-tasks\styles.css" -match "styles.css" -check "ASCII text"
+    # obsidian-tasks
+    $status = Get-GitHubRelease -repo "obsidian-tasks-group/obsidian-tasks" -path "${SETUP_PATH}\obsidian-plugins\obsidian-tasks\main.js" -match "main.js" -check "JavaScript source"
+    $status = Get-GitHubRelease -repo "obsidian-tasks-group/obsidian-tasks" -path "${SETUP_PATH}\obsidian-plugins\obsidian-tasks\manifest.json" -match "manifest.json" -check "JSON text data"
+    $status = Get-GitHubRelease -repo "obsidian-tasks-group/obsidian-tasks" -path "${SETUP_PATH}\obsidian-plugins\obsidian-tasks\styles.css" -match "styles.css" -check "ASCII text"
 
-# obsidian-excalidraw-plugin
-$status = Get-GitHubRelease -repo "zsviczian/obsidian-excalidraw-plugin" -path "${SETUP_PATH}\obsidian-plugins\obsidian-excalidraw-plugin\main.js" -match "main.js" -check "JavaScript source"
-$status = Get-GitHubRelease -repo "zsviczian/obsidian-excalidraw-plugin" -path "${SETUP_PATH}\obsidian-plugins\obsidian-excalidraw-plugin\manifest.json" -match "manifest.json" -check "JSON text data"
-$status = Get-GitHubRelease -repo "zsviczian/obsidian-excalidraw-plugin" -path "${SETUP_PATH}\obsidian-plugins\obsidian-excalidraw-plugin\styles.css" -match "styles.css" -check "text"
+    # obsidian-excalidraw-plugin
+    $status = Get-GitHubRelease -repo "zsviczian/obsidian-excalidraw-plugin" -path "${SETUP_PATH}\obsidian-plugins\obsidian-excalidraw-plugin\main.js" -match "main.js" -check "JavaScript source"
+    $status = Get-GitHubRelease -repo "zsviczian/obsidian-excalidraw-plugin" -path "${SETUP_PATH}\obsidian-plugins\obsidian-excalidraw-plugin\manifest.json" -match "manifest.json" -check "JSON text data"
+    $status = Get-GitHubRelease -repo "zsviczian/obsidian-excalidraw-plugin" -path "${SETUP_PATH}\obsidian-plugins\obsidian-excalidraw-plugin\styles.css" -match "styles.css" -check "text"
 
-# admonitions
-$status = Get-GitHubRelease -repo "javalent/admonitions" -path "${SETUP_PATH}\obsidian-plugins\admonitions\main.js" -match "main.js" -check "JavaScript source"
-$status = Get-GitHubRelease -repo "javalent/admonitions" -path "${SETUP_PATH}\obsidian-plugins\admonitions\manifest.json" -match "manifest.json" -check "JSON text data"
-$status = Get-GitHubRelease -repo "javalent/admonitions" -path "${SETUP_PATH}\obsidian-plugins\admonitions\styles.css" -match "styles.css" -check "ASCII text"
+    # admonitions
+    $status = Get-GitHubRelease -repo "javalent/admonitions" -path "${SETUP_PATH}\obsidian-plugins\admonitions\main.js" -match "main.js" -check "JavaScript source"
+    $status = Get-GitHubRelease -repo "javalent/admonitions" -path "${SETUP_PATH}\obsidian-plugins\admonitions\manifest.json" -match "manifest.json" -check "JSON text data"
+    $status = Get-GitHubRelease -repo "javalent/admonitions" -path "${SETUP_PATH}\obsidian-plugins\admonitions\styles.css" -match "styles.css" -check "ASCII text"
 
-# obsidian-timeline
-$status = Get-GitHubRelease -repo "George-debug/obsidian-timeline" -path "${SETUP_PATH}\obsidian-plugins\obsidian-timeline\main.js" -match "main.js" -check "JavaScript source"
-$status = Get-GitHubRelease -repo "George-debug/obsidian-timeline" -path "${SETUP_PATH}\obsidian-plugins\obsidian-timeline\manifest.json" -match "manifest.json" -check "JSON text data"
-$status = Get-GitHubRelease -repo "George-debug/obsidian-timeline" -path "${SETUP_PATH}\obsidian-plugins\obsidian-timeline\styles.css" -match "styles.css" -check "ASCII text"
+    # obsidian-timeline
+    $status = Get-GitHubRelease -repo "George-debug/obsidian-timeline" -path "${SETUP_PATH}\obsidian-plugins\obsidian-timeline\main.js" -match "main.js" -check "JavaScript source"
+    $status = Get-GitHubRelease -repo "George-debug/obsidian-timeline" -path "${SETUP_PATH}\obsidian-plugins\obsidian-timeline\manifest.json" -match "manifest.json" -check "JSON text data"
+    $status = Get-GitHubRelease -repo "George-debug/obsidian-timeline" -path "${SETUP_PATH}\obsidian-plugins\obsidian-timeline\styles.css" -match "styles.css" -check "ASCII text"
+}
 
 
 $TOOL_DEFINITIONS += @{

--- a/resources/download/winget.ps1
+++ b/resources/download/winget.ps1
@@ -62,8 +62,10 @@ $TOOL_DEFINITIONS += @{
 }
 
 # Chrome - available for installation via dfirws-install.ps1
-Write-SynchronizedLog "winget: Downloading Chrome."
-$status = Get-WinGet "Google.Chrome" "Google*.msi" "chrome.msi" -check "Composite Document File V2 Document"
+if (Test-ToolIncluded -ToolName "Chrome") {
+    Write-SynchronizedLog "winget: Downloading Chrome."
+    $status = Get-WinGet "Google.Chrome" "Google*.msi" "chrome.msi" -check "Composite Document File V2 Document"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "Chrome"
@@ -162,8 +164,10 @@ $TOOL_DEFINITIONS += @{
 }
 
 # Obsidian - available for installation via dfirws-install.ps1
-Write-SynchronizedLog "winget: Downloading Obsidian."
-$status = Get-WinGet "Obsidian.Obsidian" "Obsidian*.exe" "obsidian.exe" -check "PE32"
+if (Test-ToolIncluded -ToolName "Obsidian") {
+    Write-SynchronizedLog "winget: Downloading Obsidian."
+    $status = Get-WinGet "Obsidian.Obsidian" "Obsidian*.exe" "obsidian.exe" -check "PE32"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "Obsidian"
@@ -244,8 +248,10 @@ $TOOL_DEFINITIONS += @{
 }
 
 # Putty - available for installation via dfirws-install.ps1
-Write-SynchronizedLog "winget: Downloading Putty."
-$status = Get-WinGet "PuTTY.PuTTY" "PuTTY*.msi" "putty.msi" -check "Composite Document File V2 Document"
+if (Test-ToolIncluded -ToolName "PuTTY") {
+    Write-SynchronizedLog "winget: Downloading Putty."
+    $status = Get-WinGet "PuTTY.PuTTY" "PuTTY*.msi" "putty.msi" -check "Composite Document File V2 Document"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "PuTTY"
@@ -306,8 +312,10 @@ $TOOL_DEFINITIONS += @{
 }
 
 # Ruby - available for installation via dfirws-install.ps1
-Write-SynchronizedLog "winget: Downloading Ruby."
-$status = Get-WinGet "RubyInstallerTeam.Ruby.3.4" "Ruby*.exe" "ruby.exe" -check "PE32"
+if (Test-ToolIncluded -ToolName "Ruby") {
+    Write-SynchronizedLog "winget: Downloading Ruby."
+    $status = Get-WinGet "RubyInstallerTeam.Ruby.3.4" "Ruby*.exe" "ruby.exe" -check "PE32"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "Ruby"
@@ -332,8 +340,10 @@ $TOOL_DEFINITIONS += @{
 }
 
 # VideoLAN VLC - available for installation via dfirws-install.ps1
-Write-SynchronizedLog "winget: Downloading VLC."
-$status = Get-WinGet "VideoLAN.VLC" "VLC*.exe" "vlc_installer.exe" -check "PE32"
+if (Test-ToolIncluded -ToolName "VLC") {
+    Write-SynchronizedLog "winget: Downloading VLC."
+    $status = Get-WinGet "VideoLAN.VLC" "VLC*.exe" "vlc_installer.exe" -check "PE32"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "VLC"
@@ -366,10 +376,12 @@ $TOOL_DEFINITIONS += @{
 }
 
 # VirusTotal CLI
-Write-SynchronizedLog "winget: Downloading VirusTotal CLI."
-$status = Get-WinGet "VirusTotal.vt-cli" "vt-cli*.zip" "vt.zip" -check "Zip archive data"
-if ($status) {
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa ".\downloads\vt.zip" -o"${TOOLS}\bin" | Out-Null
+if (Test-ToolIncluded -ToolName "VirusTotal CLI") {
+    Write-SynchronizedLog "winget: Downloading VirusTotal CLI."
+    $status = Get-WinGet "VirusTotal.vt-cli" "vt-cli*.zip" "vt.zip" -check "Zip archive data"
+    if ($status) {
+        & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa ".\downloads\vt.zip" -o"${TOOLS}\bin" | Out-Null
+    }
 }
 
 $TOOL_DEFINITIONS += @{
@@ -441,8 +453,10 @@ $TOOL_DEFINITIONS += @{
 }
 
 # OpenVPN - available for installation via dfirws-install.ps1
-Write-SynchronizedLog "winget: Downloading OpenVPN."
-$status = Get-WinGet "OpenVPNTechnologies.OpenVPNConnect" "OpenVPN*.msi" "openvpn.msi" -check "Composite Document File V2 Document"
+if (Test-ToolIncluded -ToolName "OpenVPN") {
+    Write-SynchronizedLog "winget: Downloading OpenVPN."
+    $status = Get-WinGet "OpenVPNTechnologies.OpenVPNConnect" "OpenVPN*.msi" "openvpn.msi" -check "Composite Document File V2 Document"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "OpenVPN"
@@ -531,8 +545,10 @@ $TOOL_DEFINITIONS += @{
 }
 
 # WireGuard.WireGuard - available for installation via dfirws-install.ps1
-Write-SynchronizedLog "winget: Downloading WireGuard."
-$status = Get-WinGet "WireGuard.WireGuard" "wireguard*.msi" "wireguard.msi" -check "Composite Document File V2 Document"
+if (Test-ToolIncluded -ToolName "WireGuard") {
+    Write-SynchronizedLog "winget: Downloading WireGuard."
+    $status = Get-WinGet "WireGuard.WireGuard" "wireguard*.msi" "wireguard.msi" -check "Composite Document File V2 Document"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "WireGuard"
@@ -585,8 +601,10 @@ $TOOL_DEFINITIONS += @{
 }
 
 # tailscale - available for installation via dfirws-install.ps1
-Write-SynchronizedLog "winget: Downloading Tailscale."
-$status = Get-WinGet "Tailscale.Tailscale" "Tailscale*.exe" "tailscale.exe" -check "PE32"
+if (Test-ToolIncluded -ToolName "Tailscale") {
+    Write-SynchronizedLog "winget: Downloading Tailscale."
+    $status = Get-WinGet "Tailscale.Tailscale" "Tailscale*.exe" "tailscale.exe" -check "PE32"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "Tailscale"
@@ -611,8 +629,10 @@ $TOOL_DEFINITIONS += @{
 }
 
 # Firefox - available for installation via dfirws-install.ps1
-Write-SynchronizedLog "winget: Downloading Firefox."
-$status = Get-WinGet "Mozilla.Firefox" "Firefox*.exe" "firefox.exe" -check "PE32"
+if (Test-ToolIncluded -ToolName "Firefox") {
+    Write-SynchronizedLog "winget: Downloading Firefox."
+    $status = Get-WinGet "Mozilla.Firefox" "Firefox*.exe" "firefox.exe" -check "PE32"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "Firefox"
@@ -645,8 +665,10 @@ $TOOL_DEFINITIONS += @{
 }
 
 # Foxit PDF Reader - available for installation via dfirws-install.ps1
-Write-SynchronizedLog "winget: Downloading Foxit PDF Reader."
-$status = Get-WinGet "Foxit.FoxitReader" "Foxit*.exe" "foxitreader.exe" -check "PE32"
+if (Test-ToolIncluded -ToolName "Foxit PDF Reader") {
+    Write-SynchronizedLog "winget: Downloading Foxit PDF Reader."
+    $status = Get-WinGet "Foxit.FoxitReader" "Foxit*.exe" "foxitreader.exe" -check "PE32"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "Foxit PDF Reader"


### PR DESCRIPTION
- Fix misleading "No arguments given" message when using -Profile
- Add ~50 tools to Basic profile exclusion list across all download scripts (winget, http, release, basic)
- Add git repository filtering with ExcludeGitRepos in profiles
- Gate downloads for Ghidra, ClamAV, Obsidian plugins, Tor Browser, VeraCrypt, capa Explorer Web, and many more behind Test-ToolIncluded
- Update profile-config template with expanded extras documentation

https://claude.ai/code/session_01LMhTuLbw1rRXLRGtcydjDw