### PR TITLE
Guard Ghidra path references for Basic profile without Ghidra

### DIFF
--- a/local/defaults/Microsoft.PowerShell_profile.ps1
+++ b/local/defaults/Microsoft.PowerShell_profile.ps1
@@ -15,7 +15,9 @@ $env:PATH_TO_FX = "C:\Tools\javafx-sdk\lib"
 $env:POSH_THEMES_PATH = "${HOME}\AppData\Local\Programs\oh-my-posh\themes"
 $env:PSModulePath = "$env:PSModulePath;C:\Downloads\powershell-modules"
 # Find last version of Ghidra
-$env:GHIDRA_INSTALL_DIR = "C:\Tools\ghidra\" + ((Get-ChildItem C:\Tools\ghidra\ | C:\Windows\System32\findstr.exe PUBLIC | Select-Object -Last 1).Split(" ") | Select-Object -Last 1)
+if (Test-Path "C:\Tools\ghidra\") {
+    $env:GHIDRA_INSTALL_DIR = "C:\Tools\ghidra\" + ((Get-ChildItem C:\Tools\ghidra\ | C:\Windows\System32\findstr.exe PUBLIC | Select-Object -Last 1).Split(" ") | Select-Object -Last 1)
+}
 
 # Autosuggestions with PSReadLine
 if (-not(Get-Module -ListAvailable PSReadLine)) {

--- a/local/defaults/customize-sandbox.ps1
+++ b/local/defaults/customize-sandbox.ps1
@@ -70,9 +70,11 @@ ${GHIDRA_THEME}
 USER_AGREEMENT=ACCEPT
 "@
 
-foreach ($version in (Get-ChildItem "${TOOLS}\ghidra\" -Directory).Name) {
-    New-Item -Path "${HOME}\AppData\Roaming\ghidra\${version}" -ItemType Directory -Force | Out-Null
-    ${GHIDRA_CONFIG} | Out-File -FilePath "${HOME}\AppData\Roaming\ghidra\${version}\preferences" -Encoding ascii
+if (Test-Path "${TOOLS}\ghidra\") {
+    foreach ($version in (Get-ChildItem "${TOOLS}\ghidra\" -Directory).Name) {
+        New-Item -Path "${HOME}\AppData\Roaming\ghidra\${version}" -ItemType Directory -Force | Out-Null
+        ${GHIDRA_CONFIG} | Out-File -FilePath "${HOME}\AppData\Roaming\ghidra\${version}\preferences" -Encoding ascii
+    }
 }
 
 # Start explorer in ${HOME}\Desktop\dfirws - use search box for easy access to tools

--- a/setup/install/install_python_tools.ps1
+++ b/setup/install/install_python_tools.ps1
@@ -9,7 +9,10 @@ Write-Output "Start installation of Python in Sandbox."
 $TOOL_DEFINITIONS = @()
 $PYTHON_DEFAULT = "3.11"
 
-$GHIDRA_INSTALL_DIR = (Get-ChildItem "${TOOLS}\ghidra\").FullName | findstr.exe PUBLIC | Select-Object -Last 1
+$GHIDRA_INSTALL_DIR = ""
+if (Test-Path "${TOOLS}\ghidra\") {
+    $GHIDRA_INSTALL_DIR = (Get-ChildItem "${TOOLS}\ghidra\").FullName | findstr.exe PUBLIC | Select-Object -Last 1
+}
 
 $env:UV_TOOL_BIN_DIR = "C:\venv\bin"
 $env:UV_TOOL_DIR = "C:\venv\uv"
@@ -47,8 +50,10 @@ Start-Process -Wait "${SETUP_PATH}\vcredist_17_x64.exe" -ArgumentList "/passive 
 Write-DateLog "Visual C++ Redistributable installed" | Tee-Object -FilePath "${WSDFIR_TEMP}\start_sandbox.log" -Append
 
 # Install .NET 6
-Start-Process -Wait "${SETUP_PATH}\dotnet6desktop.exe" -ArgumentList "/install /quiet /norestart"
-Write-DateLog ".NET 6 Desktop runtime installed" | Tee-Object -FilePath "${WSDFIR_TEMP}\start_sandbox.log" -Append
+if (Test-Path "${SETUP_PATH}\dotnet6desktop.exe") {
+    Start-Process -Wait "${SETUP_PATH}\dotnet6desktop.exe" -ArgumentList "/install /quiet /norestart"
+    Write-DateLog ".NET 6 Desktop runtime installed" | Tee-Object -FilePath "${WSDFIR_TEMP}\start_sandbox.log" -Append
+}
 
 Write-DateLog "Install Git." >> "C:\log\python.txt"
 Install-Git | Out-Null

--- a/setup/start_sandbox.ps1
+++ b/setup/start_sandbox.ps1
@@ -365,7 +365,10 @@ Write-DateLog "Explorer restarted" | Tee-Object -FilePath "${WSDFIR_TEMP}\start_
 # PATH - Windows have a limit of <2048 characters for user PATH
 
 Write-DateLog "Add to PATH" | Tee-Object -FilePath "${WSDFIR_TEMP}\start_sandbox.log" -Append
-$GHIDRA_INSTALL_DIR=((Get-ChildItem "${TOOLS}\ghidra\").Name | findstr "PUBLIC" | Select-Object -Last 1)
+$GHIDRA_INSTALL_DIR=""
+if (Test-Path "${TOOLS}\ghidra\") {
+    $GHIDRA_INSTALL_DIR=((Get-ChildItem "${TOOLS}\ghidra\").Name | findstr "PUBLIC" | Select-Object -Last 1)
+}
 
 # Excluded from PATH due to 2048 character limit. Accessible via desktop shortcuts.
 # "${env:ProgramFiles}\IDR\bin"

--- a/setup/utils/dfirws_folder.ps1
+++ b/setup/utils/dfirws_folder.ps1
@@ -379,9 +379,11 @@ New-Item -Force -ItemType Directory "${HOME}\Desktop\dfirws\Reverse Engineering"
 Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Reverse Engineering\Cutter.lnk" -DestinationPath "${TOOLS}\cutter\cutter.exe"
 Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Reverse Engineering\dnSpy32.lnk" -DestinationPath "${TOOLS}\dnSpy32\dnSpy.exe"
 Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Reverse Engineering\dnSpy64.lnk" -DestinationPath "${TOOLS}\dnSpy64\dnSpy.exe"
-(Get-ChildItem "${TOOLS}\ghidra").Name | Where-Object { $_ -match "ghidra_" } | ForEach-Object {
-    $VERSION = "$_"
-    Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Reverse Engineering\${VERSION}.lnk" -DestinationPath "${TOOLS}\ghidra\${VERSION}\ghidraRun.bat"
+if (Test-Path "${TOOLS}\ghidra") {
+    (Get-ChildItem "${TOOLS}\ghidra").Name | Where-Object { $_ -match "ghidra_" } | ForEach-Object {
+        $VERSION = "$_"
+        Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Reverse Engineering\${VERSION}.lnk" -DestinationPath "${TOOLS}\ghidra\${VERSION}\ghidraRun.bat"
+    }
 }
 #if (Test-Path "${VENV}\jep") {
 #    Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Reverse Engineering\Ghidrathon (Ghidra with JEP and Ghidrathon).lnk" -DestinationPath "${HOME}\Documents\tools\utils\ghidrathon.bat"


### PR DESCRIPTION
- Wrap Get-ChildItem ghidra\ calls with Test-Path in: install_python_tools.ps1, start_sandbox.ps1, customize-sandbox.ps1, Microsoft.PowerShell_profile.ps1, dfirws_folder.ps1
- Guard dotnet6desktop.exe install in Python sandbox with Test-Path

https://claude.ai/code/session_01LMhTuLbw1rRXLRGtcydjDw