### PR TITLE
Fix r2ai MSYS2 build to follow upstream r2pm layout

### DIFF
--- a/setup/install/install_msys2.ps1
+++ b/setup/install/install_msys2.ps1
@@ -52,9 +52,9 @@ if ((Test-Path "C:\git\r2ai\src\Makefile") -and (Test-Path "C:\Tools\radare2\bin
     # Create r2 alias for radare2 (the Makefile expects 'r2' command in PATH)
     Copy-Item "C:\Tools\radare2\bin\radare2.exe" "C:\Tools\radare2\bin\r2.exe" -Force
 
-    # Copy source to writable location (git mount is read-only)
+    # Copy source repository to writable location (git mount is read-only)
     New-Item -ItemType Directory -Force -Path "C:\tmp\r2ai_build" | Out-Null
-    Copy-Item -Recurse "C:\git\r2ai\src\*" "C:\tmp\r2ai_build\" 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"
+    Copy-Item -Recurse "C:\git\r2ai\*" "C:\tmp\r2ai_build\" 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"
 
     # Build r2ai with msys2 toolchain.
     # Build r2ai plugin (and optionally CLI). The || true allows the build to
@@ -71,11 +71,9 @@ if [ -z "$MAKE_BIN" ]; then
   exit 127
 fi
 cd /c/tmp/r2ai_build
-"$MAKE_BIN" clean >/dev/null 2>&1 || true
-# Prefer building the plugin target directly, because some upstream `all`
-# targets include optional checks that can fail in sandboxed environments.
-"$MAKE_BIN" DOTLIB=.dll DOTEXE=.exe r2ai.dll || \
-  "$MAKE_BIN" DOTLIB=.dll DOTEXE=.exe all || true
+"$MAKE_BIN" -C src clean >/dev/null 2>&1 || true
+# Build the same way r2pm does to match upstream expectations.
+"$MAKE_BIN" -C src DOTLIB=.dll DOTEXE=.exe || true
 '@
     $r2aiBuildScript | Out-File -FilePath $r2aiBuildScriptPathWin -Encoding ascii -Force
     & "C:\Tools\msys64\usr\bin\bash.exe" -lc 'bash /c/tmp/r2ai_build/build-r2ai.sh' 2>&1 | Tee-Object -FilePath "C:\log\msys2.txt" -Append
@@ -87,17 +85,17 @@ cd /c/tmp/r2ai_build
     # Copy output to persistent location
     $r2ai_output = "C:\Tools\msys64\r2ai_build"
     New-Item -ItemType Directory -Force -Path "$r2ai_output" | Out-Null
-    if (Test-Path "C:\tmp\r2ai_build\r2ai.dll") {
-        Copy-Item "C:\tmp\r2ai_build\r2ai.dll" "$r2ai_output\r2ai.dll" -Force
-        if (Test-Path "C:\tmp\r2ai_build\r2ai.exe") {
-            Copy-Item "C:\tmp\r2ai_build\r2ai.exe" "$r2ai_output\r2ai.exe" -Force
+    if (Test-Path "C:\tmp\r2ai_build\src\r2ai.dll") {
+        Copy-Item "C:\tmp\r2ai_build\src\r2ai.dll" "$r2ai_output\r2ai.dll" -Force
+        if (Test-Path "C:\tmp\r2ai_build\src\r2ai.exe") {
+            Copy-Item "C:\tmp\r2ai_build\src\r2ai.exe" "$r2ai_output\r2ai.exe" -Force
         }
         Write-DateLog "r2ai plugin compiled successfully." 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"
         Write-Output "r2ai plugin compiled successfully."
-    } elseif (Test-Path "C:\tmp\r2ai_build\r2ai") {
-        Copy-Item "C:\tmp\r2ai_build\r2ai" "$r2ai_output\r2ai.dll" -Force
-        if (Test-Path "C:\tmp\r2ai_build\r2ai.exe") {
-            Copy-Item "C:\tmp\r2ai_build\r2ai.exe" "$r2ai_output\r2ai.exe" -Force
+    } elseif (Test-Path "C:\tmp\r2ai_build\src\r2ai") {
+        Copy-Item "C:\tmp\r2ai_build\src\r2ai" "$r2ai_output\r2ai.dll" -Force
+        if (Test-Path "C:\tmp\r2ai_build\src\r2ai.exe") {
+            Copy-Item "C:\tmp\r2ai_build\src\r2ai.exe" "$r2ai_output\r2ai.exe" -Force
         }
         Write-DateLog "r2ai plugin built without extension; copied r2ai -> r2ai.dll." 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"
         Write-Output "r2ai plugin compiled successfully (extensionless output)."


### PR DESCRIPTION
### Motivation
- The sandbox build for the `r2ai` radare2 plugin failed to produce `r2ai.dll` because the script copied only `src/*` and invoked `make` expecting targets arranged as in the repository root.
- Align the MSYS2 build steps with upstream `r2pm` behavior to avoid missing-target failures and produce artifacts reliably.

### Description
- Updated `setup/install/install_msys2.ps1` to copy the entire `r2ai` repository into `C:\tmp\r2ai_build` instead of only `C:\git\r2ai\src\*` to preserve repository layout during the build. 
- Replaced the inline build invocation with a `make -C src DOTLIB=.dll DOTEXE=.exe` invocation so the build runs from the repository `src` directory the same way upstream does. 
- Adjusted artifact collection to look for `r2ai.dll`/`r2ai.exe` under `C:\tmp\r2ai_build\src\` and to copy them to `C:\Tools\msys64\r2ai_build`.
- Added brief comments explaining the change to mirror `r2pm` installation flow.

### Testing
- Ran `git diff -- setup/install/install_msys2.ps1` to inspect and verify the patch contents successfully. (succeeded)
- Verified working tree status with `git status --short` and committed the change with `git commit` (succeeded).
- Attempted a PowerShell syntax parse via `pwsh -NoProfile -Command ParseFile(...)`, but `pwsh` is not available in this CI container so the parser check could not be executed (skipped).
- Inspected the updated file with `nl -ba setup/install/install_msys2.ps1` to confirm the new build commands and artifact paths are present (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992c644cc90832ea250e67af2984109)