### PR TITLE
Clear InstallVerifyCommand for YARA rules tool

### DIFF
--- a/setup/install/install_python_tools.ps1
+++ b/setup/install/install_python_tools.ps1
@@ -1246,7 +1246,7 @@ $TOOL_DEFINITIONS += @{
             WorkDir  = "`${HOME}\Desktop"
         }
     )
-    InstallVerifyCommand = "Generating YARA rules based on binary code."
+    InstallVerifyCommand = ""
     Verify = @(
         @{
             Type = "command"


### PR DESCRIPTION
## Summary
This change removes the placeholder text from the InstallVerifyCommand field for the YARA rules tool in the Python tools installation script.

## Changes
- Cleared the `InstallVerifyCommand` value from "Generating YARA rules based on binary code." to an empty string for the YARA tool definition

## Details
The InstallVerifyCommand was previously set to a descriptive message rather than an actual verification command. This change sets it to an empty string, likely indicating that no specific command verification is needed for this tool's installation, or that the verification logic will be implemented separately.

https://claude.ai/code/session_01LtwqnTYco1vPosD1iQ3m4j