### PR TITLE
Gate OpenVPN Connect MSI download in http.ps1

### DIFF
--- a/resources/download/http.ps1
+++ b/resources/download/http.ps1
@@ -2499,7 +2499,9 @@ $TOOL_DEFINITIONS += @{
 }
 
 # OpenVPN - manual installation
-$status = Get-FileFromUri -uri "https://openvpn.net/downloads/openvpn-connect-v3-windows.msi" -FilePath ".\downloads\openvpn.msi" -check "Composite Document File V2 Document"
+if (Test-ToolIncluded -ToolName "OpenVPN") {
+    $status = Get-FileFromUri -uri "https://openvpn.net/downloads/openvpn-connect-v3-windows.msi" -FilePath ".\downloads\openvpn.msi" -check "Composite Document File V2 Document"
+}
 
 $TOOL_DEFINITIONS += @{
     Name = "OpenVPN Connect"


### PR DESCRIPTION
The winget OpenVPN download was already gated, but the separate MSI download in http.ps1 was not wrapped with Test-ToolIncluded.

https://claude.ai/code/session_01LMhTuLbw1rRXLRGtcydjDw