### PR TITLE
Copy opencode skills into ~/.config/opencode/skills at sandbox startup

### DIFF
--- a/local/defaults/opencode-skills/sandbox-tools/SKILL.md
+++ b/local/defaults/opencode-skills/sandbox-tools/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: sandbox-tools
+description: Use this skill when working in the DFIRWS Windows Sandbox to analyze artifacts with built-in tools, especially when the task mentions C:\\Tools, C:\\venv, C:\\git, Desktop\\readwrite, Desktop\\readonly, or DFIR triage workflows. It provides deterministic workflows for selecting tools, running quick triage, and reporting repeatable commands.
+---
+
+# Sandbox Tools Skill
+
+## When to use
+Use this skill when the user asks to:
+- analyze files inside the DFIRWS sandbox,
+- choose the right built-in forensic tools,
+- run quick triage on logs, registry hives, browser artifacts, or executables,
+- convert ad-hoc commands into repeatable investigation steps.
+
+If the request is about environment-specific command syntax or tool locations, first read `references/dfirws-paths-and-tools.md`.
+
+## Workflow
+1. **Confirm scope**
+   - Identify artifact type (event log, registry hive, binary, PCAP, archive, memory image, timeline source).
+   - Confirm where artifacts are expected (`Desktop\\readonly` for input artifacts, `Desktop\\readwrite` for analysis output).
+
+2. **Pick the least-friction toolchain**
+   - Prefer tools that are already bundled in `C:\\Tools`.
+   - If a Python package tool is needed, use launchers from `C:\\venv`.
+   - If source-based helper scripts are needed, check `C:\\git`.
+
+3. **Run a quick triage pass before deep analysis**
+   - Hash and identify file type.
+   - Extract high-signal metadata (timestamps, signer/imports for binaries, key fields for logs).
+   - Save outputs into a case subfolder under `Desktop\\readwrite`.
+
+4. **Escalate only when needed**
+   - Start with broad, low-cost checks.
+   - Move to heavier tooling (decompilers, disassemblers, yara-at-scale, timeline fusion) only after triage identifies leads.
+
+5. **Return reproducible output**
+   - Provide exact commands.
+   - Explain why each tool was chosen.
+   - Include assumptions and next-step branches.
+
+## Output template
+Use this structure in responses:
+
+- **Objective**: What question the analysis answers.
+- **Tool choices**: Why these tools were selected.
+- **Commands**: Copy/paste-ready commands.
+- **Findings**: Concise, evidence-first observations.
+- **Next checks**: 2-4 concrete follow-ups.
+
+## Guardrails
+- Prefer offline-capable workflows; do not assume internet access in the final analysis sandbox.
+- Never invent tool output; clearly mark estimated or pending results.
+- Keep pathing Windows-native unless the user explicitly asks for PowerShell-to-Bash translation.
+- Treat `Desktop\\readonly` as evidence input and keep all derived files in `Desktop\\readwrite`.
+- If a command may alter evidence, provide a read-only alternative first.

--- a/local/defaults/opencode-skills/sandbox-tools/references/dfirws-paths-and-tools.md
+++ b/local/defaults/opencode-skills/sandbox-tools/references/dfirws-paths-and-tools.md
@@ -1,0 +1,45 @@
+# DFIRWS Paths and Tool Selection Reference
+
+Use this file only when command/path specificity matters.
+
+## Core paths
+- `C:\\Tools\\` - pre-extracted forensic and reverse engineering binaries.
+- `C:\\venv\\` - Python virtual environments and script launchers.
+- `C:\\git\\` - cloned repositories used by some toolchains.
+- `Desktop\\readonly\\` - read-only evidence/input directory.
+- `Desktop\\readwrite\\` - writable analyst workspace (default for case output).
+
+## Tool selection by artifact type
+
+### Event logs (`.evtx`)
+- Fast summary: chainsaw / hayabusa style event triage tools if available in `C:\\Tools`.
+- Field extraction and custom filtering: Python-based parsers from `C:\\venv`.
+
+### Registry hives (`NTUSER.DAT`, `SYSTEM`, `SOFTWARE`, etc.)
+- Use RegRipper/Registry Explorer family tools for broad extraction.
+- Use `regipy` workflows for scripted extraction and repeatable parsing.
+
+### Executables / DLLs
+- Initial triage: hash, file type, strings, entropy, signer metadata.
+- Deep static RE: Ghidra/radare2 workflows from `C:\\Tools`.
+
+### Browser artifacts / SQLite
+- Use dedicated browser parsers first.
+- Fall back to SQLite CLI/DB Browser plus timeline scripting if parser coverage is incomplete.
+
+### Archives and unknown containers
+- Use 7-Zip and signature tools first.
+- If nested payloads exist, recurse extraction into separate case subfolders.
+
+## Reproducibility pattern
+For each task, return:
+1. Input path assumptions.
+2. Command block(s).
+3. Output location.
+4. Validation command for sanity-checking generated output.
+
+## Safety notes
+- Prefer command options that avoid modifying source artifacts.
+- Treat `Desktop\\readonly` as source evidence and avoid writing back to it.
+- Write derived artifacts (CSV/JSON/reports) under `Desktop\\readwrite\\cases\\<case-id>\\`.
+- If a tool requires write access to source paths, copy source to a working folder first and preserve original hashes.

--- a/setup/start_sandbox.ps1
+++ b/setup/start_sandbox.ps1
@@ -594,6 +594,23 @@ if (Test-Path "${LOCAL_PATH}\opencode.json") {
 } else {
     Copy-Item "${LOCAL_PATH}\defaults\opencode.json" "${opencode_config_dir}\opencode.json" -Force | Out-Null
 }
+
+$opencode_skills_src = ""
+if (Test-Path "${LOCAL_PATH}\opencode-skills") {
+    $opencode_skills_src = "${LOCAL_PATH}\opencode-skills"
+} elseif (Test-Path "${LOCAL_PATH}\defaults\opencode-skills") {
+    $opencode_skills_src = "${LOCAL_PATH}\defaults\opencode-skills"
+}
+
+if ($opencode_skills_src -ne "") {
+    $opencode_skills_dest = "${opencode_config_dir}\skills"
+    New-Item -ItemType Directory -Force -Path "${opencode_skills_dest}" | Out-Null
+    Robocopy.exe /MT:96 /MIR "${opencode_skills_src}" "${opencode_skills_dest}" | Out-Null
+    Write-DateLog "Installed opencode-ai skills." | Tee-Object -FilePath "${WSDFIR_TEMP}\start_sandbox.log" -Append
+} else {
+    Write-DateLog "No opencode-ai skills found in local or defaults." | Tee-Object -FilePath "${WSDFIR_TEMP}\start_sandbox.log" -Append
+}
+
 Write-DateLog "Installed opencode-ai config." | Tee-Object -FilePath "${WSDFIR_TEMP}\start_sandbox.log" -Append
 
 # Config for bash and zsh


### PR DESCRIPTION
### Motivation
- Ensure opencode skills shipped with the repository are installed into the global opencode skills folder so they are discoverable at `~/.config/opencode/skills/<name>/SKILL.md`.
- Allow a user override directory (`local/opencode-skills`) while falling back to repository defaults (`local/defaults/opencode-skills`).
- Make the `sandbox-tools` skill automatically available to the opencode runtime when a sandbox is started.

### Description
- Add logic to `setup/start_sandbox.ps1` to detect `opencode-skills` in either `LOCAL_PATH` or `LOCAL_PATH\defaults` and set an `opencode_skills_src` variable accordingly.
- Create the destination `~/.config/opencode/skills` directory and mirror the selected source into it using `Robocopy.exe /MT:96 /MIR`, with logging for success and fallback cases.
- Add two new default skill files under `local/defaults/opencode-skills/sandbox-tools`: `SKILL.md` (skill metadata and workflow) and `references/dfirws-paths-and-tools.md` (path/tool reference used by the skill).
- Apply a small PowerShell condition fix to check the variable directly (`if ($opencode_skills_src -ne "")`) to avoid string-interpolation pitfalls.

### Testing
- Verified the resulting patch and context lines using `nl -ba setup/start_sandbox.ps1 | sed -n` to inspect the inserted block, and validated the `git diff` output showing the changes.
- Committed the change successfully with `git commit`, producing a new commit on the branch.
- Attempted a PowerShell syntax/parse check with `pwsh -NoProfile -Command ...`, but `pwsh` is not available in this environment so that validation could not be performed.
- Confirmed the new skill files were added under `local/defaults/opencode-skills/sandbox-tools` via the repository diff output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992ee4e9aac832ebf46bd3aa2baa4d3)