### PR TITLE
Exclude binary-refinery from Basic profile

### DIFF
--- a/local/defaults/profile-config.ps1.template
+++ b/local/defaults/profile-config.ps1.template
@@ -34,8 +34,8 @@ $DFIRWS_PROFILE = ""
 #                "vscode-shellcheck", "vscode-spell-checker",
 #                "Extra Nerd Fonts"
 #   node.ps1:    "LUMEN"
-#   python:      "jpterm", "pyghidra", "White-Phoenix", "Kanvas",
-#                "evt2sigma"
+#   python:      "binary-refinery", "jpterm", "pyghidra",
+#                "White-Phoenix", "Kanvas", "evt2sigma"
 #
 # Note: Adding "Obsidian" also requires adding the Obsidian plugins:
 #   "obsidian-mitre-attack", "obsidian-dataview", "obsidian-kanban",

--- a/local/defaults/profiles.ps1
+++ b/local/defaults/profiles.ps1
@@ -89,6 +89,7 @@ $DFIRWS_PROFILES = @{
             # node.ps1 (sandbox)
             "LUMEN",
             # install_python_tools.ps1 (sandbox)
+            "binary-refinery",
             "jpterm",
             "pyghidra",
             "White-Phoenix",

--- a/setup/install/install_python_tools.ps1
+++ b/setup/install/install_python_tools.ps1
@@ -70,7 +70,9 @@ Get-Job | Receive-Job 2>&1 | ForEach-Object{ "$_" } >> "C:\log\python.txt"
 Write-DateLog "Install Python packages in sandbox." >> "C:\log\python.txt"
 
 uv tool install "git+https://github.com/msuhanov/dfir_ntfs.git" 2>&1 | ForEach-Object { "$_" } >> "C:\log\python.txt"
-uv tool install --with "zipp>=3.20" "binary-refinery[extended]" 2>&1 | ForEach-Object { "$_" } >> "C:\log\python.txt"
+if (Test-ToolIncludedSandbox -ToolName "binary-refinery") {
+    uv tool install --with "zipp>=3.20" "binary-refinery[extended]" 2>&1 | ForEach-Object { "$_" } >> "C:\log\python.txt"
+}
 uv tool install --with "click, libfwsi-python, mcp, python-evtx, tabulate, zipp" "regipy>=4.0.0" 2>&1 | ForEach-Object { "$_" } >> "C:\log\python.txt"
 uv tool install --with "pyreadline3, stpyv8" "peepdf-3" 2>&1 | ForEach-Object { "$_" } >> "C:\log\python.txt"
 uv tool install --with "mkdocs-material" "mkdocs" 2>&1 | ForEach-Object { "$_" } >> "C:\log\python.txt"


### PR DESCRIPTION
Gate binary-refinery install in Python sandbox behind Test-ToolIncludedSandbox and add to Basic exclusion list.

https://claude.ai/code/session_01LMhTuLbw1rRXLRGtcydjDw