### PR TITLE
Guard Ghidra extension download when Ghidra install path is absent

### DIFF
--- a/resources/download/release.ps1
+++ b/resources/download/release.ps1
@@ -1886,12 +1886,15 @@ if (Test-ToolIncluded -ToolName "Ghidra") {
     }
 
     # GolangAnalyzerExtension for latest installed Ghidra version
-    $GHIDRA_DIR_NAME = (Get-ChildItem "${TOOLS}\ghidra\").Name | findstr.exe PUBLIC | Select-Object -Last 1
-    if ($GHIDRA_DIR_NAME -match 'ghidra_(.+?)_PUBLIC') {
-        $GHIDRA_VERSION = $Matches[1]
-        $status = Get-GitHubRelease -repo "mooncat-greenpy/Ghidra_GolangAnalyzerExtension" -path "${SETUP_PATH}\GolangAnalyzerExtension_${GHIDRA_VERSION}.zip" -match "${GHIDRA_VERSION}_" -check "Zip archive data"
-        if ($status -or !(Test-Path "${TOOLS}\ghidra_extensions\GolangAnalyzerExtension_${GHIDRA_VERSION}.zip")) {
-            Copy-Item "${SETUP_PATH}\GolangAnalyzerExtension_${GHIDRA_VERSION}.zip" "${TOOLS}\ghidra_extensions\GolangAnalyzerExtension_${GHIDRA_VERSION}.zip"
+    $GHIDRA_PATH = "${TOOLS}\ghidra"
+    if (Test-Path $GHIDRA_PATH) {
+        $GHIDRA_DIR_NAME = (Get-ChildItem $GHIDRA_PATH -ErrorAction SilentlyContinue).Name | Where-Object { $_ -match 'PUBLIC' } | Select-Object -Last 1
+        if ($GHIDRA_DIR_NAME -match 'ghidra_(.+?)_PUBLIC') {
+            $GHIDRA_VERSION = $Matches[1]
+            $status = Get-GitHubRelease -repo "mooncat-greenpy/Ghidra_GolangAnalyzerExtension" -path "${SETUP_PATH}\GolangAnalyzerExtension_${GHIDRA_VERSION}.zip" -match "${GHIDRA_VERSION}_" -check "Zip archive data"
+            if ($status -or !(Test-Path "${TOOLS}\ghidra_extensions\GolangAnalyzerExtension_${GHIDRA_VERSION}.zip")) {
+                Copy-Item "${SETUP_PATH}\GolangAnalyzerExtension_${GHIDRA_VERSION}.zip" "${TOOLS}\ghidra_extensions\GolangAnalyzerExtension_${GHIDRA_VERSION}.zip"
+            }
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent path-not-found warnings when `${TOOLS}\ghidra` is not present while the script is handling Ghidra-related downloads.
- Avoid invoking `Get-ChildItem "${TOOLS}\ghidra\"` on a missing path which previously produced noisy errors in the release logs.

### Description
- Add an explicit `Test-Path` guard around the Ghidra extension logic by introducing `$GHIDRA_PATH = "${TOOLS}\ghidra"` and skipping enumeration when the directory is absent.
- Replace the `Get-ChildItem "${TOOLS}\ghidra\" | findstr.exe PUBLIC` pipeline with a PowerShell-native enumeration using `Get-ChildItem $GHIDRA_PATH -ErrorAction SilentlyContinue | Where-Object { $_ -match 'PUBLIC' } | Select-Object -Last 1` to preserve the same version-detection behavior without spawning external tools.
- Change made in `resources/download/release.ps1` and the downstream download/copy behavior for `GolangAnalyzerExtension` is preserved when a matching installed Ghidra version is found.

### Testing
- Applied the patch successfully via the repository tooling (`apply_patch`/tooling reported success). 
- Attempted a PowerShell parse check with `pwsh -NoProfile -Command "[void][System.Management.Automation.Language.Parser]::ParseFile('resources/download/release.ps1',[ref]$null,[ref]$null); 'ok'"` which failed because `pwsh` is not installed in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699304fcade8832e8ce17b441c314ed8)