### PR TITLE
Normalize TOOL_DEFINITIONS entries during tool file generation

### DIFF
--- a/setup/shared.ps1
+++ b/setup/shared.ps1
@@ -1,4 +1,56 @@
 # Function to create tool files
+function Normalize-ToolDefinitions {
+    param(
+        [Parameter(Mandatory=$True)] [array]$ToolDefinitions
+    )
+
+    $defaultToolValues = [ordered]@{
+        Name                 = ""
+        Homepage             = ""
+        Vendor               = ""
+        License              = ""
+        LicenseUrl           = ""
+        Category             = ""
+        Shortcuts            = @()
+        InstallVerifyCommand = ""
+        Verify               = @()
+        Notes                = ""
+        Tips                 = ""
+        Usage                = ""
+        SampleCommands       = @()
+        SampleFiles          = @()
+        Tags                 = @()
+        FileExtensions       = @()
+        Dependencies         = @()
+        PythonVersion        = ""
+    }
+
+    for ($i = 0; $i -lt $ToolDefinitions.Count; $i++) {
+        $tool = $ToolDefinitions[$i]
+        foreach ($property in $defaultToolValues.Keys) {
+            if (! $tool.ContainsKey($property) -or $null -eq $tool[$property]) {
+                $tool[$property] = $defaultToolValues[$property]
+            }
+        }
+
+        foreach ($shortcut in $tool.Shortcuts) {
+            if (! $shortcut.ContainsKey("Lnk") -or $null -eq $shortcut.Lnk) { $shortcut["Lnk"] = "" }
+            if (! $shortcut.ContainsKey("Target") -or $null -eq $shortcut.Target) { $shortcut["Target"] = "" }
+            if (! $shortcut.ContainsKey("Args") -or $null -eq $shortcut.Args) { $shortcut["Args"] = "" }
+            if (! $shortcut.ContainsKey("Icon") -or $null -eq $shortcut.Icon) { $shortcut["Icon"] = "" }
+            if (! $shortcut.ContainsKey("WorkDir") -or $null -eq $shortcut.WorkDir) { $shortcut["WorkDir"] = "" }
+        }
+
+        foreach ($verify in $tool.Verify) {
+            if (! $verify.ContainsKey("Type") -or $null -eq $verify.Type) { $verify["Type"] = "" }
+            if (! $verify.ContainsKey("Name") -or $null -eq $verify.Name) { $verify["Name"] = "" }
+            if (! $verify.ContainsKey("Expect") -or $null -eq $verify.Expect) { $verify["Expect"] = "" }
+        }
+    }
+
+    return $ToolDefinitions
+}
+
 function New-CreateToolFiles {
     param (
         [Parameter(Mandatory=$True)] [array]$ToolDefinitions,
@@ -14,6 +66,8 @@ function New-CreateToolFiles {
     if (! (Test-Path -Path "$BASE_PATH\dfirws")) {
         New-Item -ItemType Directory -Force -Path "$BASE_PATH\dfirws" | Out-Null
     }
+
+    $ToolDefinitions = Normalize-ToolDefinitions -ToolDefinitions $ToolDefinitions
 
     # Remove old helper files for HTTP installations and create new ones.
     if (Test-Path -Path "$BASE_PATH\dfirws\verify_${source}.ps1") {


### PR DESCRIPTION
### Motivation

- Several scripts populate `$TOOL_DEFINITIONS` with partial metadata which led to inconsistent outputs when generating helper files and the exported `tools_*.json` documentation files.
- Normalize and fill missing fields automatically so downstream consumers and helper-generation code can rely on a consistent tool schema.

### Description

- Added a new `Normalize-ToolDefinitions` helper to `setup/shared.ps1` that inserts default empty values for expected top-level keys such as `Name`, `Homepage`, `Shortcuts`, `Verify`, `Dependencies`, `FileExtensions`, and `PythonVersion`.
- The helper also normalizes nested entries by ensuring `Shortcuts` objects include `Lnk`, `Target`, `Args`, `Icon`, and `WorkDir`, and `Verify` objects include `Type`, `Name`, and `Expect` when missing.
- Updated `New-CreateToolFiles` in `setup/shared.ps1` to call `Normalize-ToolDefinitions -ToolDefinitions $ToolDefinitions` before generating verify/install/shortcut helper scripts and `tools_*.json` export so all downstream output uses the normalized schema.

### Testing

- Ran `git -C /workspace/dfirws diff -- setup/shared.ps1` to confirm the change is limited to `setup/shared.ps1` and it succeeded.
- Ran `git -C /workspace/dfirws status --short` and `git -C /workspace/dfirws commit -m "Normalize tool definitions before file generation"` to stage and commit the change and both commands succeeded.
- Attempted PowerShell static parse with `pwsh -NoProfile -Command "[void][System.Management.Automation.Language.Parser]::ParseFile('setup/shared.ps1',[ref]$null,[ref]$null); 'OK'"` but `pwsh` is not available in this environment so syntax validation could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993e94ca520832ebb86d8681e13e491)