### PR TITLE
Add WPF progress bar and installation success checks to sandbox startup

### DIFF
--- a/setup/start_sandbox.ps1
+++ b/setup/start_sandbox.ps1
@@ -21,7 +21,12 @@ $PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'
 
 Write-DateLog "Start sandbox configuration" | Tee-Object -FilePath "${WSDFIR_TEMP}\start_sandbox.log"
 
-Initialize-SandboxProgress -TotalSteps 30
+# Total number of Update-SandboxProgress calls in this script.
+# Increment this by 1 whenever you add a new Update-SandboxProgress call,
+# and decrement it when you remove one.  Verify with:
+#   (Select-String 'Update-SandboxProgress' setup\start_sandbox.ps1).Count
+$SANDBOX_PROGRESS_STEPS = 30
+Initialize-SandboxProgress -TotalSteps $SANDBOX_PROGRESS_STEPS
 
 # Check if running in verify mode
 if (Test-Path "C:\log\log.txt") {
@@ -706,6 +711,9 @@ if ("${WSDFIR_SYSMON}" -eq "Yes") {
     & "${TOOLS}\sysinternals\Sysmon64.exe" -accepteula -i "${WSDFIR_SYSMON_CONF}" | Out-Null
 }
 Write-DateLog "Starting sysmon done." | Tee-Object -FilePath "${WSDFIR_TEMP}\start_sandbox.log" -Append
+
+# Main setup is complete - sandbox is now usable even while background tasks finish.
+Set-SandboxProgressReady
 
 # If in verify mode, run install_all and install_verify scripts
 if (Test-Path "C:\log\log.txt") {

--- a/setup/wscommon.ps1
+++ b/setup/wscommon.ps1
@@ -178,6 +178,21 @@ function Write-SynchronizedLog {
 }
 
 # Progress bar support for sandbox setup
+#
+# Four public functions:
+#   Initialize-SandboxProgress  - call once at startup (main script only)
+#   Update-SandboxProgress      - call in the main process at each step
+#   Update-SandboxProgressFile  - call from child processes (customize.ps1, etc.)
+#   Set-SandboxProgressReady    - sandbox is usable; bar turns green, extras still run
+#   Close-SandboxProgress       - call at the very end
+#
+# To add a new step: add one Update-SandboxProgress call and increment
+# $SANDBOX_PROGRESS_STEPS in start_sandbox.ps1 by 1.
+# Verify the count with: (Select-String 'Update-SandboxProgress' start_sandbox.ps1).Count
+
+# File used for cross-process progress updates (child scripts → WPF window).
+# Must match the path used in child scripts.
+$script:SandboxProgressFile = "C:\tmp\sandbox_progress_update.txt"
 $script:SandboxProgressSync = $null
 $script:SandboxProgressPS   = $null
 $script:SandboxProgressRS   = $null
@@ -188,11 +203,19 @@ function Initialize-SandboxProgress {
         [string]$Title   = "DFIRWS Sandbox Setup"
     )
 
+    # Remove any stale cross-process update file from a previous run.
+    if (Test-Path $script:SandboxProgressFile) {
+        Remove-Item $script:SandboxProgressFile -Force -ErrorAction SilentlyContinue
+    }
+
     $sync = [hashtable]::Synchronized(@{
-        CurrentStep = 0
-        TotalSteps  = $TotalSteps
-        Status      = "Starting..."
-        Done        = $false
+        CurrentStep   = 0
+        TotalSteps    = $TotalSteps
+        Status        = "Starting..."
+        Done          = $false
+        Ready         = $false   # set by Set-SandboxProgressReady
+        UpdateFile    = $script:SandboxProgressFile
+        FileLastWrite = [datetime]::MinValue
     })
     $script:SandboxProgressSync = $sync
 
@@ -234,9 +257,34 @@ function Initialize-SandboxProgress {
         $timer = New-Object System.Windows.Threading.DispatcherTimer
         $timer.Interval = [TimeSpan]::FromMilliseconds(300)
         $timer.Add_Tick({
+            # Poll the cross-process update file written by child scripts.
+            $updateFile = $sync.UpdateFile
+            if ($updateFile -and (Test-Path $updateFile)) {
+                try {
+                    $fi = Get-Item $updateFile -ErrorAction SilentlyContinue
+                    if ($fi -and $fi.LastWriteTime -gt $sync.FileLastWrite) {
+                        $raw = [System.IO.File]::ReadAllText($updateFile)
+                        $upd = $raw | ConvertFrom-Json
+                        if ($upd.Status) { $sync.Status = $upd.Status }
+                        # A positive Step overrides the counter; -1 means status-only.
+                        if ($upd.Step -ge 0) { $sync.CurrentStep = $upd.Step }
+                        $sync.FileLastWrite = $fi.LastWriteTime
+                    }
+                } catch {}
+            }
+
             $pct       = if ($sync.TotalSteps -gt 0) { $sync.CurrentStep / $sync.TotalSteps } else { 0 }
             $bar.Value = [Math]::Min([double]$pct, 1.0)
             $status.Text = $sync.Status
+
+            # Turn bar green when the sandbox is declared ready.
+            if ($sync.Ready -and $bar.Foreground -isnot [System.Windows.Media.SolidColorBrush] -or
+                ($sync.Ready -and ($bar.Foreground -as [System.Windows.Media.SolidColorBrush])?.Color -ne [System.Windows.Media.Colors]::Green)) {
+                if ($sync.Ready) {
+                    $bar.Foreground = [System.Windows.Media.Brushes]::ForestGreen
+                }
+            }
+
             if ($sync.Done) {
                 $timer.Stop()
                 $window.Close()
@@ -252,10 +300,40 @@ function Initialize-SandboxProgress {
 }
 
 function Update-SandboxProgress {
+    # Call this in the main (parent) process at each numbered step.
     param([string]$Status)
     if ($script:SandboxProgressSync) {
         $script:SandboxProgressSync.CurrentStep++
         $script:SandboxProgressSync.Status = $Status
+    }
+}
+
+function Update-SandboxProgressFile {
+    # Call this from child processes (customize.ps1, dfirws_folder.ps1, …)
+    # that cannot share the in-process hashtable.  The WPF timer polls the
+    # file on every tick.  Pass -Step to move the bar, or omit it for a
+    # status-only update (bar position stays unchanged).
+    param(
+        [Parameter(Mandatory=$true)] [string]$Status,
+        [int]$Step = -1
+    )
+    $progressFile = $script:SandboxProgressFile
+    if (-not $progressFile) { $progressFile = "C:\tmp\sandbox_progress_update.txt" }
+    try {
+        $payload = [ordered]@{ Status = $Status; Step = $Step } | ConvertTo-Json -Compress
+        [System.IO.File]::WriteAllText($progressFile, $payload)
+    } catch {}
+}
+
+function Set-SandboxProgressReady {
+    # Call when the sandbox is fully usable but background extras are still
+    # running (e.g. after Sysmon starts).  Fills bar to 100 % and turns it
+    # green.  The window stays open until Close-SandboxProgress is called.
+    param([string]$Status = "Sandbox ready - completing extras...")
+    if ($script:SandboxProgressSync) {
+        $script:SandboxProgressSync.CurrentStep = $script:SandboxProgressSync.TotalSteps
+        $script:SandboxProgressSync.Status      = $Status
+        $script:SandboxProgressSync.Ready       = $true
     }
 }
 
@@ -273,6 +351,9 @@ function Close-SandboxProgress {
         $script:SandboxProgressRS.Close()
         $script:SandboxProgressRS.Dispose()
         $script:SandboxProgressRS = $null
+    }
+    if (Test-Path $script:SandboxProgressFile) {
+        Remove-Item $script:SandboxProgressFile -Force -ErrorAction SilentlyContinue
     }
 }
 


### PR DESCRIPTION
- Add Initialize-SandboxProgress, Update-SandboxProgress, and
  Close-SandboxProgress functions to wscommon.ps1. The progress window
  runs in a dedicated STA runspace using WPF, polling a synchronized
  hashtable every 300 ms so the main script is never blocked.
- Call Initialize-SandboxProgress -TotalSteps 30 at the start of
  start_sandbox.ps1 and wire 30 Update-SandboxProgress checkpoints
  through the script so the bar advances at each major phase.
- Replace bare process calls with Start-Process -PassThru so the exit
  code is captured and a WARNING is logged when 7-Zip, Java, Visual C++
  Redistributable, .NET 6, or .NET 8 installers report failure.
- Add a retry loop (up to 3 attempts, 5-second back-off) for the Python
  installer, which has historically been unreliable.
- Call Close-SandboxProgress at the end to mark the bar complete and
  dispose the WPF runspace cleanly.

https://claude.ai/code/session_01CpArVN952CkyY5q6LVmRDt