### PR TITLE
Fix PS 5.1 syntax error in progress bar color check

### DIFF
--- a/setup/wscommon.ps1
+++ b/setup/wscommon.ps1
@@ -278,11 +278,9 @@ function Initialize-SandboxProgress {
             $status.Text = $sync.Status
 
             # Turn bar green when the sandbox is declared ready.
-            if ($sync.Ready -and $bar.Foreground -isnot [System.Windows.Media.SolidColorBrush] -or
-                ($sync.Ready -and ($bar.Foreground -as [System.Windows.Media.SolidColorBrush])?.Color -ne [System.Windows.Media.Colors]::Green)) {
-                if ($sync.Ready) {
-                    $bar.Foreground = [System.Windows.Media.Brushes]::ForestGreen
-                }
+            # Simple assignment every tick is fine - WPF is idempotent on same brush.
+            if ($sync.Ready) {
+                $bar.Foreground = [System.Windows.Media.Brushes]::ForestGreen
             }
 
             if ($sync.Done) {


### PR DESCRIPTION
The null-conditional operator (?.) used in the WPF timer tick handler is PowerShell 7+ only.  Windows Sandbox sources wscommon.ps1 in Windows PowerShell 5.1, which rejects the syntax entirely and prevents the file from loading.

Replace the over-engineered guard with a plain `if ($sync.Ready)` check.  Assigning the same ForestGreen brush on every 300 ms tick is idempotent and has no visible cost.

https://claude.ai/code/session_01CpArVN952CkyY5q6LVmRDt