### PR TITLE
Add error handling and validation to Get-Winget function

### DIFF
--- a/resources/download/common.ps1
+++ b/resources/download/common.ps1
@@ -671,10 +671,21 @@ function Get-Winget {
 
     Write-SynchronizedLog "Downloading $AppName version $VERSION."
 
+    New-Item -ItemType Directory -Force -Path .\tmp\winget | Out-Null
     winget download --disable-interactivity	--exact --id "$AppName" -d .\tmp\winget 2>&1 | Out-Null
     Remove-Item .\tmp\winget\*.yaml -Force 2>&1 | Out-Null
 
+    if (-not (Test-Path .\tmp\winget\)) {
+        Write-SynchronizedLog "Error: winget download failed for $AppName - tmp\winget directory does not exist."
+        return $false
+    }
+
     $FileName = Get-ChildItem .\tmp\winget\ | Select-Object -Last 1 -ExpandProperty FullName
+
+    if (-not $FileName) {
+        Write-SynchronizedLog "Error: winget download failed for $AppName - no file found in tmp\winget."
+        return $false
+    }
 
     if ($check -ne "" ) {
         $FILE_TYPE = & "$GIT_FILE" -b "$FileName"


### PR DESCRIPTION
## Summary
Enhanced the `Get-Winget` function with improved error handling and validation to catch and report failures during the winget download process.

## Key Changes
- **Ensure directory creation**: Added explicit `New-Item` call to create the `.\tmp\winget\` directory before attempting download, preventing potential failures if the directory doesn't exist
- **Validate directory existence**: Added check after download to verify that the `.\tmp\winget\` directory exists, returning `$false` with an error log if missing
- **Validate downloaded file**: Added check to ensure at least one file was downloaded to the directory, returning `$false` with an error log if no files are found

## Implementation Details
These validation checks are placed strategically after the winget download operation and before file processing, ensuring that any download failures are caught early with clear error messages logged for troubleshooting. The function now returns `$false` on failure instead of potentially proceeding with invalid data.

https://claude.ai/code/session_01Y4UAM5ocb1o6sYVGLkgP3i