### PR TITLE
Improve VSCode extension download error handling and messaging

### DIFF
--- a/resources/download/http.ps1
+++ b/resources/download/http.ps1
@@ -14,11 +14,15 @@ if (! $NoVSCodeExtensions.IsPresent) {
 
         if ("$vscode_cpp_string" -ne "") {
             $vscode_tmp = $vscode_cpp_string | Select-String -Pattern '"AssetUri":"[^"]+ms-vscode.cpptools/([^/]+)/'
-            $vscode_cpp_version = $vscode_tmp.Matches.Groups[1].Value
-            # Visual Studio Code C++ extension
-            $status = Get-FileFromUri -uri "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ms-vscode/vsextensions/cpptools/$vscode_cpp_version/vspackage?targetPlatform=win32-x64" -FilePath ".\downloads\vscode\vscode-cpp.vsix" -CheckURL "Yes" -check "Zip archive data"
+            if ($null -ne $vscode_tmp -and $null -ne $vscode_tmp.Matches -and $vscode_tmp.Matches.Count -gt 0) {
+                $vscode_cpp_version = $vscode_tmp.Matches.Groups[1].Value
+                # Visual Studio Code C++ extension
+                $status = Get-FileFromUri -uri "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ms-vscode/vsextensions/cpptools/$vscode_cpp_version/vspackage?targetPlatform=win32-x64" -FilePath ".\downloads\vscode\vscode-cpp.vsix" -CheckURL "Yes" -check "Zip archive data"
+            } else {
+                Write-DateLog "ERROR: Could not parse version for Visual Studio Code C++ extension. You may be blocked by Microsoft. Try running downloadFiles.ps1 with -HttpNoVSCodeExtensions to skip VSCode extension downloads."
+            }
         } else {
-            Write-DateLog "ERROR: Could not get URI for Visual Studio Code C++ extension"
+            Write-DateLog "ERROR: Could not get URI for Visual Studio Code C++ extension. You may be blocked by Microsoft. Try running downloadFiles.ps1 with -HttpNoVSCodeExtensions to skip VSCode extension downloads."
         }
     }
 
@@ -33,10 +37,10 @@ if (! $NoVSCodeExtensions.IsPresent) {
                 # Visual Studio Code python extension
                 $status = Get-FileFromUri -uri "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ms-python/vsextensions/python/$vscode_python_version/vspackage" -FilePath ".\downloads\vscode\vscode-python.vsix" -CheckURL "Yes" -check "Zip archive data"
             } else {
-                Write-DateLog "ERROR: Could not parse version for Visual Studio Code python extension"
+                Write-DateLog "ERROR: Could not parse version for Visual Studio Code python extension. You may be blocked by Microsoft. Try running downloadFiles.ps1 with -HttpNoVSCodeExtensions to skip VSCode extension downloads."
             }
         } else {
-            Write-DateLog "ERROR: Could not get URI for Visual Studio Code python extension"
+            Write-DateLog "ERROR: Could not get URI for Visual Studio Code python extension. You may be blocked by Microsoft. Try running downloadFiles.ps1 with -HttpNoVSCodeExtensions to skip VSCode extension downloads."
         }
     } catch {
         Write-DateLog "ERROR: Failed to download Visual Studio Code python extension: $($_.Exception.Message)"
@@ -48,11 +52,15 @@ if (! $NoVSCodeExtensions.IsPresent) {
 
         if ("$vscode_mermaid_string" -ne "") {
             $vscode_tmp = $vscode_mermaid_string | Select-String -Pattern '"AssetUri":"[^"]+markdown-mermaid/([^/]+)/'
-            $vscode_mermaid_version = $vscode_tmp.Matches.Groups[1].Value
-            # Visual Studio Code mermaid extension
-            $status = Get-FileFromUri -uri "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/bierner/vsextensions/markdown-mermaid/$vscode_mermaid_version/vspackage" -FilePath ".\downloads\vscode\vscode-mermaid.vsix" -CheckURL "Yes" -check "Zip archive data"
+            if ($null -ne $vscode_tmp -and $null -ne $vscode_tmp.Matches -and $vscode_tmp.Matches.Count -gt 0) {
+                $vscode_mermaid_version = $vscode_tmp.Matches.Groups[1].Value
+                # Visual Studio Code mermaid extension
+                $status = Get-FileFromUri -uri "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/bierner/vsextensions/markdown-mermaid/$vscode_mermaid_version/vspackage" -FilePath ".\downloads\vscode\vscode-mermaid.vsix" -CheckURL "Yes" -check "Zip archive data"
+            } else {
+                Write-DateLog "ERROR: Could not parse version for Visual Studio Code mermaid extension. You may be blocked by Microsoft. Try running downloadFiles.ps1 with -HttpNoVSCodeExtensions to skip VSCode extension downloads."
+            }
         } else {
-            Write-DateLog "ERROR: Could not get URI for Visual Studio Code mermaid extension"
+            Write-DateLog "ERROR: Could not get URI for Visual Studio Code mermaid extension. You may be blocked by Microsoft. Try running downloadFiles.ps1 with -HttpNoVSCodeExtensions to skip VSCode extension downloads."
         }
     }
 
@@ -62,11 +70,15 @@ if (! $NoVSCodeExtensions.IsPresent) {
 
         if ("$vscode_ruff_string" -ne "") {
             $vscode_tmp = $vscode_ruff_string | Select-String -Pattern '"AssetUri":"[^"]+charliermarsh.ruff/([^/]+)/'
-            $vscode_ruff_version = $vscode_tmp.Matches.Groups[1].Value
-            # Visual Studio Code ruff extension
-            $status = Get-FileFromUri -uri "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/charliermarsh/vsextensions/ruff/$vscode_ruff_version/vspackage" -FilePath ".\downloads\vscode\vscode-ruff.vsix" -CheckURL "Yes" -check "Zip archive data"
+            if ($null -ne $vscode_tmp -and $null -ne $vscode_tmp.Matches -and $vscode_tmp.Matches.Count -gt 0) {
+                $vscode_ruff_version = $vscode_tmp.Matches.Groups[1].Value
+                # Visual Studio Code ruff extension
+                $status = Get-FileFromUri -uri "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/charliermarsh/vsextensions/ruff/$vscode_ruff_version/vspackage" -FilePath ".\downloads\vscode\vscode-ruff.vsix" -CheckURL "Yes" -check "Zip archive data"
+            } else {
+                Write-DateLog "ERROR: Could not parse version for Visual Studio Code ruff extension. You may be blocked by Microsoft. Try running downloadFiles.ps1 with -HttpNoVSCodeExtensions to skip VSCode extension downloads."
+            }
         } else {
-            Write-DateLog "ERROR: Could not get URI for Visual Studio Code ruff extension"
+            Write-DateLog "ERROR: Could not get URI for Visual Studio Code ruff extension. You may be blocked by Microsoft. Try running downloadFiles.ps1 with -HttpNoVSCodeExtensions to skip VSCode extension downloads."
         }
     }
 }


### PR DESCRIPTION
## Summary
Enhanced error handling and user messaging for VSCode extension downloads in the HTTP download script. Added null checks before accessing regex match results and improved error messages to provide users with actionable guidance when downloads fail.

## Key Changes
- **Added null safety checks** for regex match results before accessing version strings for C++ tools, mermaid, and ruff extensions
- **Improved error messages** across all VSCode extension download failures to inform users they may be blocked by Microsoft and suggest using the `-HttpNoVSCodeExtensions` flag as a workaround
- **Better error differentiation** between URI retrieval failures and version parsing failures with specific error messages for each scenario
- **Wrapped version extraction logic** in conditional blocks to prevent null reference exceptions when regex patterns don't match

## Implementation Details
- Added checks for `$null -ne $vscode_tmp`, `$null -ne $vscode_tmp.Matches`, and `$vscode_tmp.Matches.Count -gt 0` before accessing match groups
- Applied consistent error messaging pattern across C++, Python, Mermaid, and Ruff extensions
- Error messages now guide users to use `-HttpNoVSCodeExtensions` flag to skip problematic downloads when Microsoft blocks requests

https://claude.ai/code/session_01CvcWTaRixDR8LTUVsRg3JF