### PR TITLE
Skip tools with no Name instead of generating category-N.md files

### DIFF
--- a/scripts/generate-tools-docs.py
+++ b/scripts/generate-tools-docs.py
@@ -480,6 +480,11 @@ def main() -> int:
             )
         tools = filtered
 
+    unnamed: list[dict] = [t for t in tools if not (t.get("Name") or "").strip()]
+    if unnamed:
+        print(f"Warning: skipping {len(unnamed)} tool(s) with no Name.")
+    tools = [t for t in tools if (t.get("Name") or "").strip()]
+
     grouped: Dict[str, List[dict]] = {}
     for tool in tools:
         category_path = tool.get("CategoryPath") or tool.get("Category") or "Uncategorized"


### PR DESCRIPTION
Tools whose Name field is empty or None produced get_slug("") → "category" as the page slug, leading to category.md, category-2.md … category-72.md under tools/uncategorized/. Filter them out after loading (with a warning) so only well-defined tools are written to disk.

https://claude.ai/code/session_011i3TJPeP36KGaFb6DXXYFj