### PR TITLE
Skip null/unnamed tools in New-CreateToolFiles JSON export

### DIFF
--- a/setup/shared.ps1
+++ b/setup/shared.ps1
@@ -177,6 +177,10 @@ function New-CreateToolFiles {
     $tools_export = @()
     for ($i = 0; $i -lt $AllToolDefinitions.Count; $i++) {
         $tool = $AllToolDefinitions[$i]
+        if ($null -eq $tool -or [string]::IsNullOrWhiteSpace($tool.Name)) {
+            Write-SynchronizedLog "Warning: skipping tool at index $i with no Name in $Source."
+            continue
+        }
         $category_path = $null
 
         if ($null -ne $tool.Shortcuts -and $tool.Shortcuts.Count -gt 0) {


### PR DESCRIPTION
When $AllToolDefinitions contains entries where $tool is null or $tool.Name is null/empty (a PowerShell array-handling quirk with large nested hashtables), the export loop was writing all-null records to the JSON, resulting in dozens of category-N.md stub pages. Guard each iteration so these phantom entries are skipped with a warning instead.

https://claude.ai/code/session_011i3TJPeP36KGaFb6DXXYFj