### PR TITLE
Disable MD060 markdown linting rule

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -9,3 +9,5 @@ MD013:
   line_length: 700
   tables: false
 
+MD060: false
+


### PR DESCRIPTION
## Summary
Disabled the MD060 markdown linting rule in the markdown-lint configuration file.

## Changes
- Added `MD060: false` to `.github/linters/.markdown-lint.yml` to disable the MD060 rule

## Details
This change disables the MD060 markdown linting rule, which checks for spaces inside code span delimiters. This allows markdown files in the repository to use code spans without adhering to this specific formatting requirement.

https://claude.ai/code/session_015QorT7HKTDnSL1v4WLMDFg