### PR TITLE
Rename -Profile parameter to -DistributionProfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,10 @@ Two profiles are available:
 - **Full** (default) - Downloads all tools, including all build toolchains (Node.js, Rust, Go, MSYS2) and large optional tools.
 - **Basic** - Skips Rust, Go, and MSYS2 toolchains. Keeps Node.js for JavaScript malware analysis. Excludes large optional tools like Autopsy, ELK Stack, Binary Ninja, Neo4j, hashcat, LibreOffice, and others.
 
-To use a profile, pass `-Profile` to `downloadFiles.ps1`:
+To use a profile, pass `-DistributionProfile` to `downloadFiles.ps1`:
 
 ```PowerShell
-.\downloadFiles.ps1 -Profile Basic
+.\downloadFiles.ps1 -DistributionProfile Basic
 ```
 
 For persistent configuration, copy `local\defaults\profile-config.ps1.template` to `local\profile-config.ps1` and set `$DFIRWS_PROFILE = "Basic"`. You can also override individual toolchain inclusion and add extras (large tools to include despite the profile):
@@ -165,7 +165,7 @@ $DFIRWS_PROFILE = "Basic"
 $DFIRWS_EXTRAS = @("Autopsy", "LibreOffice")
 ```
 
-The `-Profile` CLI parameter takes precedence over the config file. Explicit switches like `-Rust` or `-Node` always override the profile setting.
+The `-DistributionProfile` CLI parameter takes precedence over the config file. Explicit switches like `-Rust` or `-Node` always override the profile setting.
 
 ### Sandbox configuration
 

--- a/downloadFiles.ps1
+++ b/downloadFiles.ps1
@@ -27,11 +27,11 @@
     This will download all files needed for DFIRWS, update enrichments and ClamAV databases with Freshclam.
 
 .EXAMPLE
-    .\downloadFiles.ps1 -Profile Basic
+    .\downloadFiles.ps1 -DistributionProfile Basic
     Download a basic distribution without large optional tools and without Rust, Go, and MSYS2 toolchains.
 
 .EXAMPLE
-    .\downloadFiles.ps1 -Profile Full
+    .\downloadFiles.ps1 -DistributionProfile Full
     Download all tools (same as default behavior).
 
 .NOTES


### PR DESCRIPTION
## Summary
Renamed the `-Profile` parameter to `-DistributionProfile` in the `downloadFiles.ps1` script and updated all related documentation to reflect this change.

## Key Changes
- Renamed `-Profile` CLI parameter to `-DistributionProfile` in `downloadFiles.ps1` script signature and documentation
- Updated README.md examples to use the new `-DistributionProfile` parameter name
- Updated all references in code comments and documentation to use the new parameter name

## Details
This change improves clarity by using a more descriptive parameter name that better indicates the purpose of the parameter (selecting a distribution profile) and reduces potential naming conflicts with other profile-related functionality.

https://claude.ai/code/session_01NF5KFLBf5itRnhqJFAjFry