### PR TITLE
Add existence check before copying tools_node.json file

### DIFF
--- a/resources/download/node.ps1
+++ b/resources/download/node.ps1
@@ -65,6 +65,8 @@ if (!(Test-ToolIncluded -ToolName "LUMEN") -and (Test-Path -Path "${ROOT_PATH}\m
 
 if (Test-Path -Path "${ROOT_PATH}\log\dfirws" ) {
     Copy-Item "${ROOT_PATH}\log\dfirws\*_node.ps1" "${ROOT_PATH}\downloads\dfirws\" -Force
-    Copy-Item "${ROOT_PATH}\log\dfirws\tools_node.json" "${ROOT_PATH}\downloads\dfirws\" -Force
+    if (Test-Path -Path "${ROOT_PATH}\log\dfirws\tools_node.json") {
+        Copy-Item "${ROOT_PATH}\log\dfirws\tools_node.json" "${ROOT_PATH}\downloads\dfirws\" -Force
+    }
     Remove-Item -Recurse -Force "${ROOT_PATH}\log\dfirws" 2>&1 | Out-Null
 }


### PR DESCRIPTION
## Summary
Added a conditional check to verify that the `tools_node.json` file exists before attempting to copy it, preventing potential errors when the file is missing.

## Key Changes
- Wrapped the `Copy-Item` command for `tools_node.json` in a `Test-Path` conditional block
- This prevents the script from failing if the file doesn't exist in the source directory

## Implementation Details
The change adds a safety check that only attempts to copy `tools_node.json` if it exists at `${ROOT_PATH}\log\dfirws\tools_node.json`. This is a defensive programming practice that makes the script more robust when dealing with optional or conditionally-generated files. The wildcard copy operation for `*_node.ps1` files remains unchanged and unconditional.

https://claude.ai/code/session_01SBcWZ3xQsUNoicbgGrDm4S