### PR TITLE
Update Windows 11 VM configuration and installation checks

### DIFF
--- a/resources/vm/answer_files/Autounattend.xml
+++ b/resources/vm/answer_files/Autounattend.xml
@@ -69,6 +69,16 @@
                     <Description>BypassRAMCheck</Description>
                     <Path>cmd /c reg add "HKLM\SYSTEM\Setup\LabConfig" /v "BypassRAMCheck" /t REG_DWORD /d 1</Path>
                 </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>4</Order>
+                    <Description>BypassCPUCheck</Description>
+                    <Path>cmd /c reg add "HKLM\SYSTEM\Setup\LabConfig" /v "BypassCPUCheck" /t REG_DWORD /d 1</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>5</Order>
+                    <Description>BypassStorageCheck</Description>
+                    <Path>cmd /c reg add "HKLM\SYSTEM\Setup\LabConfig" /v "BypassStorageCheck" /t REG_DWORD /d 1</Path>
+                </RunSynchronousCommand>
             </RunSynchronous>
         </component>
         <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
@@ -192,7 +202,7 @@
                     <Description>Add exclusion for Windows Defender</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\microsoft-updates.ps1</CommandLine>
+                    <CommandLine>cmd.exe /c a:\microsoft-updates.bat</CommandLine>
                     <Order>98</Order>
                     <Description>Enable Microsoft Updates</Description>
                 </SynchronousCommand>

--- a/resources/vm/windows_11.pkr.hcl.default
+++ b/resources/vm/windows_11.pkr.hcl.default
@@ -40,7 +40,7 @@ variable "memory" {
 
 variable "restart_timeout" {
   type    = string
-  default = "5m"
+  default = "30m"
 }
 
 variable "output_directory" {
@@ -78,7 +78,7 @@ source "vmware-iso" "windows_11" {
   boot_wait         = "-1s"
   communicator      = "winrm"
   cpus              = "${var.cpus}"
-  disk_adapter_type = "lsisas1068"
+  disk_adapter_type = "sata"
   disk_size         = "${var.disk_size}"
   disk_type_id      = "${var.disk_type_id}"
   floppy_files      = [


### PR DESCRIPTION
## Summary
This PR updates the Windows 11 VM build configuration to improve compatibility and installation reliability by adding additional hardware requirement bypasses, updating the Microsoft Updates installation method, and adjusting timeout and disk adapter settings.

## Key Changes
- **Added hardware bypass checks** in Autounattend.xml:
  - Added `BypassCPUCheck` registry entry to bypass CPU requirement validation
  - Added `BypassStorageCheck` registry entry to bypass storage requirement validation
  
- **Updated Microsoft Updates installation method**:
  - Changed from PowerShell script (`microsoft-updates.ps1`) to batch file (`microsoft-updates.bat`) for more reliable execution during Windows setup
  
- **Adjusted Packer configuration** (windows_11.pkr.hcl.default):
  - Increased `restart_timeout` from 5 minutes to 30 minutes to allow more time for system restarts during installation
  - Changed `disk_adapter_type` from `lsisas1068` (LSI SAS) to `sata` for better compatibility

## Implementation Details
These changes address common issues when building Windows 11 VMs in lab/virtualized environments where hardware specifications may not meet Microsoft's strict requirements. The timeout increase accommodates slower virtual environments, and the disk adapter change improves compatibility with certain hypervisor configurations.

https://claude.ai/code/session_01PTSeSnoTz6cTnh9FEAXRdj