### PR TITLE
Add ModifyPartitions to DiskConfiguration and clean up Autounattend.xml

### DIFF
--- a/resources/vm/answer_files/Autounattend.xml
+++ b/resources/vm/answer_files/Autounattend.xml
@@ -2,32 +2,65 @@
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <servicing/>
     <settings pass="windowsPE">
-        <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">            
+        <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <DiskConfiguration>
                 <Disk wcm:action="add">
                     <CreatePartitions>
-						<!-- Windows RE Tools partition -->
+                        <!-- Windows RE Tools partition -->
                         <CreatePartition wcm:action="add">
                             <Order>1</Order>
                             <Type>Primary</Type>
                             <Size>300</Size>
                         </CreatePartition>
+                        <!-- EFI System Partition -->
                         <CreatePartition wcm:action="add">
                             <Order>2</Order>
                             <Size>500</Size>
                             <Type>EFI</Type>
                         </CreatePartition>
+                        <!-- Microsoft Reserved Partition -->
                         <CreatePartition wcm:action="add">
                             <Order>3</Order>
                             <Size>128</Size>
                             <Type>MSR</Type>
                         </CreatePartition>
+                        <!-- Windows partition -->
                         <CreatePartition wcm:action="add">
                             <Order>4</Order>
                             <Extend>true</Extend>
                             <Type>Primary</Type>
                         </CreatePartition>
                     </CreatePartitions>
+                    <ModifyPartitions>
+                        <!-- WinRE partition: NTFS, mark as Recovery -->
+                        <ModifyPartition wcm:action="add">
+                            <Order>1</Order>
+                            <PartitionID>1</PartitionID>
+                            <Label>WinRE</Label>
+                            <Format>NTFS</Format>
+                            <TypeID>DE94BBA4-06D1-4D40-A16A-BFD50179D6AC</TypeID>
+                        </ModifyPartition>
+                        <!-- EFI System Partition: must be FAT32 -->
+                        <ModifyPartition wcm:action="add">
+                            <Order>2</Order>
+                            <PartitionID>2</PartitionID>
+                            <Label>System</Label>
+                            <Format>FAT32</Format>
+                        </ModifyPartition>
+                        <!-- MSR: no format required -->
+                        <ModifyPartition wcm:action="add">
+                            <Order>3</Order>
+                            <PartitionID>3</PartitionID>
+                        </ModifyPartition>
+                        <!-- Windows partition: NTFS, drive C -->
+                        <ModifyPartition wcm:action="add">
+                            <Order>4</Order>
+                            <PartitionID>4</PartitionID>
+                            <Label>Windows</Label>
+                            <Format>NTFS</Format>
+                            <Letter>C</Letter>
+                        </ModifyPartition>
+                    </ModifyPartitions>
                     <DiskID>0</DiskID>
                     <WillWipeDisk>true</WillWipeDisk>
                 </Disk>
@@ -44,7 +77,6 @@
                         <PartitionID>4</PartitionID>
                     </InstallTo>
                     <WillShowUI>OnError</WillShowUI>
-                    <!-- <InstallToAvailablePartition>false</InstallToAvailablePartition> -->
                     <InstallFrom>
                         <MetaData wcm:action="add">
                             <Key>/Image/Index</Key>
@@ -237,5 +269,4 @@
             <SkipAutoActivation>true</SkipAutoActivation>
         </component>
     </settings>
-    <cpi:offlineImage xmlns:cpi="urn:schemas-microsoft-com:cpi" cpi:source="catalog:d:/sources/install_windows 7 ENTERPRISE.clg"/>
 </unattend>


### PR DESCRIPTION
Without ModifyPartitions, Windows Setup creates the GPT partition layout but never formats the EFI System Partition (FAT32) or the Windows partition (NTFS). When Setup finishes extracting the WIM (~77%) and tries to install the EFI bootloader, it hits an unformatted partition and aborts with "Windows 11 installation failed".

Changes:
- Add ModifyPartitions section explicitly formatting each partition: WinRE (NTFS, TypeID DE94BBA4 recovery), EFI System (FAT32), MSR (no format), Windows (NTFS, letter C).
- Remove stale Windows 7 catalog reference from cpi:offlineImage.
- Fix mixed tabs/spaces and trailing whitespace in the component tag.

https://claude.ai/code/session_01PTSeSnoTz6cTnh9FEAXRdj