### PR TITLE
Fix VMware Tools installation by using Packer's tools_upload_flavor

### DIFF
--- a/resources/vm/scripts/vm-guest-tools.ps1
+++ b/resources/vm/scripts/vm-guest-tools.ps1
@@ -3,57 +3,29 @@ $7z_MSI_URL = "https://www.7-zip.org/a/${7Z_MSI_NAME}"
 
 Write-Output "Install VMware Tools"
 
-Write-Output "Download 7-Zip MSI Needed to unzip VMware tools."
-
+Write-Output "Download 7-Zip MSI needed to extract VMware Tools ISO."
 curl.exe -L -o "C:\Windows\Temp\${7Z_MSI_NAME}" -s --retry 10 --retry-all-errors "${7Z_MSI_URL}"
 
 Write-Output "Install 7-Zip MSI"
 Start-Process -Wait msiexec -ArgumentList "/i C:\Windows\Temp\${7Z_MSI_NAME} /qn /norestart"
 
-Write-Output "Download VMware Tools"
-if (!(Test-Path "C:\Windows\Temp\windows.iso")) {
-    Try {
-        # Disabling the progress bar speeds up IWR https://github.com/PowerShell/PowerShell/issues/2138
-        $ProgressPreference = 'SilentlyContinue'
-        $pageContentLinks = (Invoke-WebRequest('https://softwareupdate.vmware.com/cds/vmw-desktop/ws') -UseBasicParsing).Links | where-object {$_.href -Match "[0-9]"} | Select-Object href | ForEach-Object { $_.href.Trim('/') }
-        $versionObject = $pageContentLinks | ForEach-Object{ new-object System.Version ($_) } | sort-object -Descending | select-object -First 1 -Property:Major,Minor,Build
-        $newestVersion = $versionObject.Major.ToString()+"."+$versionObject.Minor.ToString()+"."+$versionObject.Build.ToString() | out-string
-        $newestVersion = $newestVersion.TrimEnd("`r?`n")
+# Packer uploads the VMware Tools ISO from the host via tools_upload_flavor = "windows"
+$vmwareToolsIso = "C:\Windows\Temp\vmware-tools.iso"
 
-        $nextURISubdirectoryObject = (Invoke-WebRequest("https://softwareupdate.vmware.com/cds/vmw-desktop/ws/$newestVersion/") -UseBasicParsing).Links | where-object {$_.href -Match "[0-9]"} | Select-Object href | where-object {$_.href -Match "[0-9]"}
-        $nextUriSubdirectory = $nextURISubdirectoryObject.href | Out-String
-        $nextUriSubdirectory = $nextUriSubdirectory.TrimEnd("`r?`n")
-        $newestVMwareToolsURL = "https://softwareupdate.vmware.com/cds/vmw-desktop/ws/$newestVersion/$nextURISubdirectory/windows/packages/tools-windows.tar"
-        Write-Output "The latest version of VMware tools has been determined to be downloadable from $newestVMwareToolsURL"
-        curl.exe -L -o "C:\Windows\Temp\vmware-tools.tar" -s --retry 10 --retry-all-errors "$newestVMwareToolsURL"
-    } Catch {
-        Write-Output "Unable to determine the latest version of VMware tools. Falling back to hardcoded URL."
-        curl.exe -L -o "C:\Windows\Temp\vmware-tools.tar" -s --retry 10 --retry-all-errors "https://softwareupdate.vmware.com/cds/vmw-desktop/ws/17.5.0/22583795//windows/packages/tools-windows.tar"
+if (!(Test-Path $vmwareToolsIso)) {
+    Write-Output "ERROR: VMware Tools ISO not found at $vmwareToolsIso. Packer tools_upload_flavor may not be configured."
+    Exit 1
 }
 
-Write-Output "Unzip VMware TAR"
-
-& "C:\Program Files\7-Zip\7z.exe" x C:\Windows\Temp\vmware-tools.tar -oC:\Windows\Temp | Out-Null
-
-Move-Item c:\windows\temp\VMware-tools-windows-*.iso c:\windows\temp\windows.iso
-
-if (Test-Path "C:\Program Files (x86)\VMWare") {
-    Try {
-        Remove-Item "C:\Program Files (x86)\VMWare" -Recurse -Force -ErrorAction Stop
-    } Catch {
-        Write-Output "Directory didn't exist to be removed." }
-    }
-}
-
-Write-Output "Unzip VMware ISO"
-& "C:\Program Files\7-Zip\7z.exe" x "C:\Windows\Temp\windows.iso" -o"C:\Windows\Temp\VMWare" | Out-Null
+Write-Output "Extract VMware Tools ISO"
+& "C:\Program Files\7-Zip\7z.exe" x "$vmwareToolsIso" -o"C:\Windows\Temp\VMWare" | Out-Null
 
 Write-Output "Install VMware Tools"
 Start-Process -Wait "C:\Windows\Temp\VMWare\setup.exe" -ArgumentList '/S /v"/qn REBOOT=R\"'
 
 Write-Output "Remove temp files"
-Remove-Item -Force "C:\Windows\Temp\vmware-tools.tar"
-Remove-Item -Force "C:\Windows\Temp\windows.iso"
+Remove-Item -Force "C:\Windows\Temp\${7Z_MSI_NAME}"
+Remove-Item -Force "$vmwareToolsIso"
 Remove-Item -Force -Recurse "C:\Windows\Temp\VMware"
 
 Exit 0

--- a/resources/vm/windows_11.pkr.hcl.default
+++ b/resources/vm/windows_11.pkr.hcl.default
@@ -93,8 +93,10 @@ source "vmware-iso" "windows_11" {
                         "./resources/vm/scripts/vm-guest-tools.ps1",
                         "./resources/vm/scripts/win-updates.ps1"
                     ]
-  guest_os_type     = "windows11-64"
-  headless          = "${var.headless}"
+  guest_os_type        = "windows11-64"
+  headless             = "${var.headless}"
+  tools_upload_flavor  = "windows"
+  tools_upload_path    = "c:/Windows/Temp/vmware-tools.iso"
   iso_checksum      = "${var.iso_checksum}"
   iso_urls          = [
                         "${var.iso_url_local}",


### PR DESCRIPTION
Broadcom locked down softwareupdate.vmware.com in March 2025 and now requires account authentication. As a result, both the dynamic version detection and the hardcoded fallback URL in vm-guest-tools.ps1 receive an HTML login page instead of a TAR file, causing 7-Zip to fail with "Is not archive".

Fix by using Packer's built-in tools_upload_flavor = "windows", which copies the VMware Tools ISO directly from the host machine's VMware Workstation installation into the guest VM before provisioners run. No internet access is required.

Changes to windows_11.pkr.hcl.default:
- Add tools_upload_flavor = "windows"
- Add tools_upload_path = "c:/Windows/Temp/vmware-tools.iso"

Changes to vm-guest-tools.ps1:
- Remove the TAR download/extraction logic (softwareupdate.vmware.com is no longer publicly accessible)
- Use the ISO already uploaded by Packer at the configured path
- Clean up the brace-imbalance in the old download block

https://claude.ai/code/session_01PTSeSnoTz6cTnh9FEAXRdj