### PR TITLE
Fix VMware Tools silent install hanging on Windows 11

### DIFF
--- a/resources/vm/scripts/vm-guest-tools.ps1
+++ b/resources/vm/scripts/vm-guest-tools.ps1
@@ -21,7 +21,7 @@ Write-Output "Extract VMware Tools ISO"
 & "C:\Program Files\7-Zip\7z.exe" x "$vmwareToolsIso" -o"C:\Windows\Temp\VMWare" | Out-Null
 
 Write-Output "Install VMware Tools"
-Start-Process -Wait "C:\Windows\Temp\VMWare\setup.exe" -ArgumentList '/S /v"/qn REBOOT=R\"'
+Start-Process -Wait "C:\Windows\Temp\VMWare\setup64.exe" -ArgumentList '/S /v "/qn REBOOT=R"'
 
 Write-Output "Remove temp files"
 Remove-Item -Force "C:\Windows\Temp\${7Z_MSI_NAME}"


### PR DESCRIPTION
Use setup64.exe instead of setup.exe for 64-bit Windows 11, and fix malformed argument quoting ('/S /v"/qn REBOOT=R\"' → '/S /v "/qn REBOOT=R"'). The trailing backslash-quote caused the installer to hang waiting for UI input.

https://claude.ai/code/session_01PTSeSnoTz6cTnh9FEAXRdj