### PR TITLE
Fix Windows 11 boot wait timeout in VMware ISO builder

### DIFF
--- a/resources/vm/windows_11.pkr.hcl.default
+++ b/resources/vm/windows_11.pkr.hcl.default
@@ -75,7 +75,7 @@ variable "iso_url_remote" {
 
 source "vmware-iso" "windows_11" {
   boot_command      = [ "a<wait>a<wait>a" ]
-  boot_wait         = "-1s"
+  boot_wait         = "3s"
   communicator      = "winrm"
   cpus              = "${var.cpus}"
   disk_adapter_type = "sata"


### PR DESCRIPTION
## Summary
Corrected the `boot_wait` configuration in the Windows 11 VMware ISO builder from an invalid negative value to a valid positive timeout.

## Changes
- Updated `boot_wait` parameter from `-1s` to `3s` in the Windows 11 Packer configuration
  - The previous value of `-1s` is not a valid timeout duration
  - Changed to `3s` to provide a reasonable boot wait period before Packer attempts to communicate with the VM

## Details
The `boot_wait` setting controls how long Packer waits after booting the VM before attempting to connect via the configured communicator (WinRM in this case). The negative value was likely a configuration error that would cause the builder to fail or behave unexpectedly. The new value of 3 seconds provides adequate time for the Windows 11 boot sequence to initialize before Packer attempts to establish a connection.

https://claude.ai/code/session_019ARr99nFyt8c1o2rGfVxzs