### PR TITLE
Send repeated Enter keypresses to reliably dismiss EFI boot prompt

### DIFF
--- a/resources/vm/windows_11.pkr.hcl.default
+++ b/resources/vm/windows_11.pkr.hcl.default
@@ -74,7 +74,7 @@ variable "iso_url_remote" {
 }
 
 source "vmware-iso" "windows_11" {
-  boot_command      = [ "a<wait>a<wait>a" ]
+  boot_command      = [ "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter>" ]
   boot_wait         = "3s"
   communicator      = "winrm"
   cpus              = "${var.cpus}"


### PR DESCRIPTION
The EFI firmware + Windows PE boot sequence takes longer than 5 seconds to show the boot prompt, so a single keypress sent at a fixed boot_wait is sent too early and missed. Replace the one-shot 'a' presses with repeated Enter keypresses every second across a ~15s window (t=3s to t=15s), so the prompt is caught whenever it appears regardless of how long EFI initialization takes.

https://claude.ai/code/session_019ARr99nFyt8c1o2rGfVxzs