### PR TITLE
Fix Packer hang and EFI boot prompt with SATA disk

### DIFF
--- a/resources/vm/windows_11.pkr.hcl.default
+++ b/resources/vm/windows_11.pkr.hcl.default
@@ -75,7 +75,7 @@ variable "iso_url_remote" {
 
 source "vmware-iso" "windows_11" {
   boot_command      = [ "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter>" ]
-  boot_wait         = "3s"
+  boot_wait         = "-1s"
   communicator      = "winrm"
   cpus              = "${var.cpus}"
   disk_adapter_type = "sata"
@@ -112,6 +112,7 @@ source "vmware-iso" "windows_11" {
                         "RemoteDisplay.vnc.enabled" = "false"
                         "RemoteDisplay.vnc.port"    = "5900"
                         "Firmware"                  = "efi"
+                        "bios.bootOrder"            = "cdrom,hdd"
                         "Annotation"                = "Packer version: ${packer.version}|0D|0AVM creation time: ${formatdate("DD MMM YYYY hh:mm ZZZ", timestamp())}|0D|0AUsername: ${var.username}|0D|0APassword: ${var.password}|0D|0A|0D|0AWindows 11 with dfirws installed.",
                     }
   vnc_port_max                   = 5980


### PR DESCRIPTION
Two issues introduced by the disk_adapter_type change (lsisas1068 → sata):

1. Packer hangs after "Starting virtual machine...": boot_wait = "3s" caused Packer to try VNC for boot commands, but VNC is disabled in vmx_data (RemoteDisplay.vnc.enabled = false), causing a hang. Revert boot_wait to "-1s" so Packer skips VNC entirely.

2. EFI boot prompt requiring manual Enter: VMware's EFI firmware, when it detects a SATA disk (even empty), may show a boot selection screen before booting from DVD. With the old SAS (lsisas1068) controller, EFI did not register the disk as a UEFI boot candidate and booted from DVD automatically. Add bios.bootOrder = "cdrom,hdd" to vmx_data to instruct VMware to prioritize the DVD without user interaction.

https://claude.ai/code/session_019ARr99nFyt8c1o2rGfVxzs