### PR TITLE
Revert disk adapter to lsisas1068 and remove invalid bios.bootOrder

### DIFF
--- a/resources/vm/windows_11.pkr.hcl.default
+++ b/resources/vm/windows_11.pkr.hcl.default
@@ -78,7 +78,7 @@ source "vmware-iso" "windows_11" {
   boot_wait         = "-1s"
   communicator      = "winrm"
   cpus              = "${var.cpus}"
-  disk_adapter_type = "sata"
+  disk_adapter_type = "lsisas1068"
   disk_size         = "${var.disk_size}"
   disk_type_id      = "${var.disk_type_id}"
   floppy_files      = [
@@ -112,7 +112,6 @@ source "vmware-iso" "windows_11" {
                         "RemoteDisplay.vnc.enabled" = "false"
                         "RemoteDisplay.vnc.port"    = "5900"
                         "Firmware"                  = "efi"
-                        "bios.bootOrder"            = "cdrom,hdd"
                         "Annotation"                = "Packer version: ${packer.version}|0D|0AVM creation time: ${formatdate("DD MMM YYYY hh:mm ZZZ", timestamp())}|0D|0AUsername: ${var.username}|0D|0APassword: ${var.password}|0D|0A|0D|0AWindows 11 with dfirws installed.",
                     }
   vnc_port_max                   = 5980


### PR DESCRIPTION
Two fixes:

1. Remove bios.bootOrder from vmx_data: this is a BIOS-only setting, not valid for EFI VMs. VMware Workstation likely shows a warning dialog when it encounters unknown EFI vmx settings, blocking vmrun start and causing Packer to hang at "Starting virtual machine...".

2. Revert disk_adapter_type from sata back to lsisas1068: the SAS controller has no UEFI driver in VMware's EFI firmware, so EFI cannot enumerate the disk and boots from DVD automatically without showing a boot selection prompt. The original 77% installation failure was caused by the missing BypassCPUCheck/BypassStorageCheck LabConfig entries and ModifyPartitions section in Autounattend.xml, not the disk adapter type. Those fixes are still in place.

https://claude.ai/code/session_019ARr99nFyt8c1o2rGfVxzs