### PR TITLE
Restore Installed snapshot and clean it up before final snapshot

### DIFF
--- a/createVM.ps1
+++ b/createVM.ps1
@@ -178,6 +178,9 @@ foreach ($file in "tmp\windows_11.pkr.hcl", ".\tmp\git.zip", ".\tmp\tools.zip", 
     }
 }
 
+Write-Output "Delete snapshot 'Installed'"
+vmrun.exe -T ws deleteSnapshot "${VM_VMX}" "Installed"
+
 Write-Output "Create snapshot 'DFIRWS ready'"
 vmrun.exe -T ws snapshot "${VM_VMX}" "DFIRWS ready"
 

--- a/resources/vm/windows_11.pkr.hcl.default
+++ b/resources/vm/windows_11.pkr.hcl.default
@@ -160,6 +160,12 @@ build {
       "./resources/vm/scripts/set-winrm-automatic.bat"
     ]
   }
+
+  post-processor "shell-local" {
+    inline = [
+      "vmrun -T ws snapshot ${var.output_directory}/${var.vm_name}.vmx Installed"
+      ]
+  }
 }
 
 packer {


### PR DESCRIPTION
The Installed snapshot post-processor was removed in ee74e73, but install_dfirws_in_vm.ps1 guards against running without it. Without the snapshot, the script exits early before adding shared folders, causing removeSharedFolder in createVM.ps1 to fail with "A file was not found".

Restore the post-processor in the Packer build to recreate the Installed snapshot, and delete it in createVM.ps1 before taking the final DFIRWS ready snapshot so only one snapshot remains.

https://claude.ai/code/session_019ARr99nFyt8c1o2rGfVxzs