### PR TITLE
Fix speakeasy-emulator installation with setuptools dependency

### DIFF
--- a/setup/install/install_python_tools.ps1
+++ b/setup/install/install_python_tools.ps1
@@ -140,7 +140,6 @@ foreach ($package in `
     "rexi", `
     "scapy", `
     "shodan", `
-    "speakeasy-emulator", `
     "stego-lsb", `
     "sqlit-tui[all]", `
     "time-decode", `
@@ -153,6 +152,10 @@ foreach ($package in `
         uv tool install --python "C:\Program Files\Python311\python.exe" $package 2>&1 | ForEach-Object { "$_" } >> "C:\log\python.txt"
         Write-DateLog "Installed $package via uv tool install." 2>&1 | ForEach-Object { "$_" } >> "C:\log\python.txt"
 }
+
+# speakeasy-emulator requires setuptools (pkg_resources) which is not included in uv tool isolated envs
+uv tool install --python "C:\Program Files\Python311\python.exe" --with setuptools speakeasy-emulator 2>&1 | ForEach-Object { "$_" } >> "C:\log\python.txt"
+Write-DateLog "Installed speakeasy-emulator via uv tool install." 2>&1 | ForEach-Object { "$_" } >> "C:\log\python.txt"
 
 # Download IOCs for mvt
  mvt-ios download-iocs 2>&1 | ForEach-Object { "$_" } >> "C:\log\python.txt"


### PR DESCRIPTION
## Summary
Moved `speakeasy-emulator` installation to a separate command with explicit `setuptools` dependency to resolve installation failures in isolated `uv tool` environments.

## Key Changes
- Removed `speakeasy-emulator` from the standard `uv tool install` batch that uses isolated environments
- Added dedicated installation command for `speakeasy-emulator` with `--with setuptools` flag to include the required `pkg_resources` module
- Specified explicit Python path (`C:\Program Files\Python311\python.exe`) for the installation

## Implementation Details
The `speakeasy-emulator` package requires `setuptools` (specifically the `pkg_resources` module) which is not available in `uv tool`'s isolated virtual environments by default. By installing it separately with the `--with setuptools` flag, we ensure the dependency is available while maintaining the isolation benefits for other tools.

https://claude.ai/code/session_012cJQjXx13tvSvVrY3XsMJQ