### PR TITLE
Use python -m venv + pip for speakeasy-emulator to fix pkg_resources

### DIFF
--- a/setup/install/install_python_tools.ps1
+++ b/setup/install/install_python_tools.ps1
@@ -153,9 +153,10 @@ foreach ($package in `
         Write-DateLog "Installed $package via uv tool install." 2>&1 | ForEach-Object { "$_" } >> "C:\log\python.txt"
 }
 
-# speakeasy-emulator requires setuptools (pkg_resources); use a dedicated venv to ensure it is available
-uv venv --python "C:\Program Files\Python311\python.exe" "C:\venv\speakeasy" 2>&1 | ForEach-Object { "$_" } >> "C:\log\python.txt"
-uv pip install --python "C:\venv\speakeasy\Scripts\python.exe" setuptools speakeasy-emulator 2>&1 | ForEach-Object { "$_" } >> "C:\log\python.txt"
+# speakeasy-emulator requires setuptools (pkg_resources); use python -m venv + pip to ensure it is available
+# uv pip install does not reliably expose pkg_resources even when setuptools is installed
+& "C:\Program Files\Python311\python.exe" -m venv "C:\venv\speakeasy" 2>&1 | ForEach-Object { "$_" } >> "C:\log\python.txt"
+& "C:\venv\speakeasy\Scripts\pip.exe" install setuptools speakeasy-emulator 2>&1 | ForEach-Object { "$_" } >> "C:\log\python.txt"
 Copy-Item "C:\venv\speakeasy\Scripts\speakeasy.exe" "C:\venv\bin\speakeasy.exe" -Force 2>&1 | ForEach-Object { "$_" } >> "C:\log\python.txt"
 Write-DateLog "Installed speakeasy-emulator in dedicated venv." 2>&1 | ForEach-Object { "$_" } >> "C:\log\python.txt"
 


### PR DESCRIPTION
uv pip install setuptools does not make pkg_resources importable, even when setuptools is installed. Switch to python -m venv (which provisions pip via ensurepip) and pip install, which reliably includes pkg_resources alongside setuptools.

https://claude.ai/code/session_012cJQjXx13tvSvVrY3XsMJQ