### PR TITLE
Exclude golang.org/x/vuln testdata vulndb entries from security alerts

### DIFF
--- a/downloadFiles.ps1
+++ b/downloadFiles.ps1
@@ -622,6 +622,8 @@ if ($SUPPLY_CHAIN_SECURITY_AUDIT) {
         }
     } | Where-Object { $_ } | Where-Object {
         -not $allowlistPattern -or $_.Line -notmatch $allowlistPattern
+    } | Where-Object {
+        $_.Line -notmatch "testdata/vulndb-v1/ID/"
     }
 
     if ($securityFindings) {


### PR DESCRIPTION
The GO-[0-9]{4}-[0-9]{4} pattern was matching vulnerability IDs embedded in file paths inside golang.org/x/vuln's test data directories (e.g. testdata/vulndb-v1/ID/GO-2021-0240.json). These are test fixtures, not real findings in the installed tooling. Exclude any line containing testdata/vulndb-v1/ID/ so the filter remains version-agnostic.

https://claude.ai/code/session_01VPwSa5PNohd9xFGtXPtanh