### PR TITLE
Broaden vulndb testdata exclusion to cover vulndb-legacy paths

### DIFF
--- a/downloadFiles.ps1
+++ b/downloadFiles.ps1
@@ -623,7 +623,7 @@ if ($SUPPLY_CHAIN_SECURITY_AUDIT) {
     } | Where-Object { $_ } | Where-Object {
         -not $allowlistPattern -or $_.Line -notmatch $allowlistPattern
     } | Where-Object {
-        $_.Line -notmatch "testdata/vulndb-v1/ID/"
+        $_.Line -notmatch "testdata/vulndb"
     }
 
     if ($securityFindings) {


### PR DESCRIPTION
The previous filter only excluded testdata/vulndb-v1/ID/ paths. The golang.org/x/vuln module also ships testdata/vulndb-legacy/ID/ files which triggered the same false-positive GO-YYYY-NNNN matches. Widen the pattern to testdata/vulndb so all vulndb-* variants are covered.

https://claude.ai/code/session_01VPwSa5PNohd9xFGtXPtanh