### PR TITLE
Switch Packer VMware plugin from hashicorp/vmware to vmware/vmware

### DIFF
--- a/resources/vm/windows_11.pkr.hcl.default
+++ b/resources/vm/windows_11.pkr.hcl.default
@@ -177,8 +177,8 @@ packer {
   required_version = ">= 1.7.0"
   required_plugins {
     vmware = {
-      version = ">= 1.0.0"
-      source  = "github.com/hashicorp/vmware"
+      version = ">= 2.0.0"
+      source  = "github.com/vmware/vmware"
     }
   }
 }


### PR DESCRIPTION
hashicorp/vmware v1.1.0 fails to detect the guest IP from VMware's DHCP lease file with newer VMware Workstation versions, causing Packer to hang indefinitely at "Starting virtual machine..." without ever attempting a WinRM connection. vmware/vmware v2.x is VMware's officially maintained fork with fixes for this guest IP detection issue.

https://claude.ai/code/session_01LCdJTdiGBKafdQkGW2hzeR