### PR TITLE
Fix required fields for vmware/vmware v2.x plugin

### DIFF
--- a/resources/vm/windows_11.pkr.hcl.default
+++ b/resources/vm/windows_11.pkr.hcl.default
@@ -93,10 +93,12 @@ source "vmware-iso" "windows_11" {
                         "./resources/vm/scripts/vm-guest-tools.ps1",
                         "./resources/vm/scripts/win-updates.ps1"
                     ]
-  guest_os_type        = "windows11-64"
-  headless             = "${var.headless}"
-  tools_upload_flavor  = "windows"
-  tools_upload_path    = "c:/Windows/Temp/vmware-tools.iso"
+  guest_os_type           = "windows11-64"
+  headless                = "${var.headless}"
+  network_adapter_type    = "vmxnet3"
+  tools_mode              = "upload"
+  tools_upload_flavor     = "windows"
+  tools_upload_path       = "c:/Windows/Temp/vmware-tools.iso"
   iso_checksum      = "${var.iso_checksum}"
   iso_urls          = [
                         "${var.iso_url_local}",


### PR DESCRIPTION
vmware/vmware v2.x made network_adapter_type and tools_mode required:
- network_adapter_type = "vmxnet3" (best-performing VMware virtual NIC)
- tools_mode = "upload" (matches existing tools_upload_flavor/path config)

https://claude.ai/code/session_01LCdJTdiGBKafdQkGW2hzeR