### PR TITLE
Fix typo in win-updates.ps1 causing Windows Updates to be skipped

### DIFF
--- a/resources/vm/scripts/win-updates.ps1
+++ b/resources/vm/scripts/win-updates.ps1
@@ -50,7 +50,7 @@ function Invoke-ContinueRestartOrEnd() {
             }
 
             LogWrite "No Restart Required"
-            Invoke-WindowsUpdates
+            Invoke-WindowsUpdate
 
             if (($script:MoreUpdates -eq 1) -and ($script:Cycles -le $script:MaxCycles)) {
                 Install-WindowsUpdates
@@ -255,7 +255,7 @@ if ($BeginWithRestart) {
   Invoke-ContinueRestartOrEnd
 }
 
-Invoke-WindowsUpdates
+Invoke-WindowsUpdate
 if ($script:MoreUpdates -eq 1) {
     Install-WindowsUpdate
 } else {


### PR DESCRIPTION
Invoke-WindowsUpdate was called as Invoke-WindowsUpdates (with trailing s) in two places. PowerShell fails silently on the unknown function name, leaving MoreUpdates=0 and causing the script to fall straight through to "Done Installing Windows Updates" without searching for or installing anything.

https://claude.ai/code/session_01LCdJTdiGBKafdQkGW2hzeR