### PR TITLE
Change network adapter from vmxnet3 to e1000e

### DIFF
--- a/resources/vm/windows_11.pkr.hcl.default
+++ b/resources/vm/windows_11.pkr.hcl.default
@@ -95,7 +95,7 @@ source "vmware-iso" "windows_11" {
                     ]
   guest_os_type           = "windows11-64"
   headless                = "${var.headless}"
-  network_adapter_type    = "vmxnet3"
+  network_adapter_type    = "e1000e"
   tools_mode              = "upload"
   tools_upload_flavor     = "windows"
   tools_upload_path       = "c:/Windows/Temp/vmware-tools.iso"


### PR DESCRIPTION
vmxnet3 requires VMware Tools drivers which are not present in a fresh Windows install, leaving the VM with no network adapter during setup. e1000e uses a standard Intel driver built into Windows, ensuring DHCP and WinRM connectivity are available from first boot so Packer can detect the guest IP from the lease file.

https://claude.ai/code/session_01LCdJTdiGBKafdQkGW2hzeR