### PR TITLE
Install VMware Tools via tools_mode=attach to fix Packer guest IP det…

### DIFF
--- a/resources/vm/answer_files/Autounattend.xml
+++ b/resources/vm/answer_files/Autounattend.xml
@@ -268,26 +268,31 @@
                     <Description>Add Windows Defender exclusion for C:\venv</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:\microsoft-updates.bat</CommandLine>
+                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -NonInteractive -ExecutionPolicy Bypass -File a:\install-vmware-tools.ps1</CommandLine>
+                    <Description>Install VMware Tools from attached CD</Description>
                     <Order>98</Order>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c a:\microsoft-updates.bat</CommandLine>
+                    <Order>99</Order>
                     <Description>Enable Microsoft Updates</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\disable-screensaver.ps1</CommandLine>
                     <Description>Disable Screensaver</Description>
-                    <Order>99</Order>
+                    <Order>100</Order>
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\win-updates.ps1</CommandLine>
                     <Description>Install Windows Updates</Description>
-                    <Order>100</Order>
+                    <Order>101</Order>
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c echo Enable-PSRemoting -Force -SkipNetworkProfileCheck > C:\Windows\Temp\ewrm.ps1 &amp;&amp; echo winrm quickconfig -q >> C:\Windows\Temp\ewrm.ps1 &amp;&amp; echo winrm set winrm/config/service '@{AllowUnencrypted="true"}' >> C:\Windows\Temp\ewrm.ps1 &amp;&amp; echo winrm set winrm/config/service/auth '@{Basic="true"}' >> C:\Windows\Temp\ewrm.ps1 &amp;&amp; echo winrm set winrm/config/client/auth '@{Basic="true"}' >> C:\Windows\Temp\ewrm.ps1 &amp;&amp; echo Set-Service winrm -StartupType Automatic >> C:\Windows\Temp\ewrm.ps1 &amp;&amp; echo Restart-Service winrm >> C:\Windows\Temp\ewrm.ps1 &amp;&amp; C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -NonInteractive -ExecutionPolicy Bypass -File C:\Windows\Temp\ewrm.ps1</CommandLine>
                     <Description>Enable WinRM for Packer (fallback when floppy is inaccessible)</Description>
-                    <Order>101</Order>
+                    <Order>102</Order>
                 </SynchronousCommand>
                 <!-- END WITH WINDOWS UPDATES -->
             </FirstLogonCommands>

--- a/resources/vm/scripts/install-vmware-tools.ps1
+++ b/resources/vm/scripts/install-vmware-tools.ps1
@@ -1,0 +1,12 @@
+# Install VMware Tools from attached CD-ROM (tools_mode = "attach" in Packer)
+$ErrorActionPreference = 'SilentlyContinue'
+$drives = @('D:', 'E:', 'F:', 'G:')
+foreach ($drive in $drives) {
+    $setup = Join-Path $drive 'setup64.exe'
+    if (Test-Path $setup) {
+        Write-Output "Installing VMware Tools from $drive"
+        Start-Process -FilePath $setup -ArgumentList '/S /v "/qn REBOOT=R"' -Wait
+        Write-Output "VMware Tools installation completed"
+        break
+    }
+}

--- a/resources/vm/windows_11.pkr.hcl.default
+++ b/resources/vm/windows_11.pkr.hcl.default
@@ -91,14 +91,13 @@ source "vmware-iso" "windows_11" {
                         "./resources/vm/scripts/install-vm-guest-tools.bat",
                         "./resources/vm/scripts/microsoft-updates.bat",
                         "./resources/vm/scripts/vm-guest-tools.ps1",
-                        "./resources/vm/scripts/win-updates.ps1"
+                        "./resources/vm/scripts/win-updates.ps1",
+                        "./resources/vm/scripts/install-vmware-tools.ps1"
                     ]
   guest_os_type           = "windows11-64"
   headless                = "${var.headless}"
   network_adapter_type    = "e1000e"
-  tools_mode              = "upload"
-  tools_upload_flavor     = "windows"
-  tools_upload_path       = "c:/Windows/Temp/vmware-tools.iso"
+  tools_mode              = "attach"
   iso_checksum      = "${var.iso_checksum}"
   iso_urls          = [
                         "${var.iso_url_local}",
@@ -131,23 +130,6 @@ build {
     remote_path     = "/tmp/script.bat"
     scripts         = [
       "./resources/vm/scripts/enable-rdp.bat",
-      ]
-  }
-
-  provisioner "windows-restart" {
-    restart_timeout = "${var.restart_timeout}"
-  }
-
-  provisioner "file" {
-    source      = "./resources/vm/scripts/vm-guest-tools.ps1"
-    destination = "C:/Windows/Temp/vm-guest-tools.ps1"
-  }
-
-  provisioner "windows-shell" {
-    execute_command = "{{ .Vars }} cmd /c \"{{ .Path }}\""
-    remote_path     = "/tmp/script.bat"
-    scripts         = [
-      "./resources/vm/scripts/install-vm-guest-tools.bat",
       ]
   }
 


### PR DESCRIPTION
…ection

Both hashicorp/vmware v1.1.0 and vmware/vmware v2.1.0 fail to read the DHCP lease file to get the guest IP address. The fix is to have VMware Tools running before Packer polls for the IP, enabling vmrun getGuestIPAddress.

Changes:
- windows_11.pkr.hcl.default: switch tools_mode from "upload" to "attach" so the VMware Tools ISO is mounted as a CD-ROM from first boot. Remove tools_upload_flavor, tools_upload_path, the file provisioner that uploaded vm-guest-tools.ps1, the windows-shell provisioner for install-vm-guest-tools.bat, and the windows-restart that followed it. Add install-vmware-tools.ps1 to floppy_files.
- install-vmware-tools.ps1: new script that scans drive letters D-G for setup64.exe on the attached Tools CD-ROM and installs silently (REBOOT=R suppresses an extra reboot so Windows Updates can reboot instead).
- Autounattend.xml: add Order 98 to run install-vmware-tools.ps1 from floppy before Windows Updates. Renumber former 98-101 to 99-102 to make room.

Sequence: Tools CD mounted at boot -> Order 98 installs Tools (no reboot) ->
Order 101 runs Windows Updates -> reboot -> VMTools service starts -> vmrun getGuestIPAddress succeeds -> Packer connects via WinRM.

https://claude.ai/code/session_01LCdJTdiGBKafdQkGW2hzeR