### PR TITLE
Add tools_source_path required by vmware/vmware v2.x with tools_mode=…

### DIFF
--- a/local/defaults/variables.pkr.hcl
+++ b/local/defaults/variables.pkr.hcl
@@ -1,4 +1,5 @@
-autounattend      = "./resources/vm/answer_files/Autounattend.xml"
+autounattend        = "./resources/vm/answer_files/Autounattend.xml"
+tools_source_path   = "C:\\Program Files (x86)\\VMware\\VMware Workstation\\windows.iso"
 cpus              = "4"
 disk_size         = "307200"
 disk_type_id      = "1"

--- a/resources/vm/windows_11.pkr.hcl.default
+++ b/resources/vm/windows_11.pkr.hcl.default
@@ -58,6 +58,11 @@ variable "winrm_timeout" {
   default = "6h"
 }
 
+variable "tools_source_path" {
+  type    = string
+  default = "C:\\Program Files (x86)\\VMware\\VMware Workstation\\windows.iso"
+}
+
 variable "iso_checksum" {
   type    = string
   default = "sha256:ISO_HASH"
@@ -98,6 +103,7 @@ source "vmware-iso" "windows_11" {
   headless                = "${var.headless}"
   network_adapter_type    = "e1000e"
   tools_mode              = "attach"
+  tools_source_path       = "${var.tools_source_path}"
   iso_checksum      = "${var.iso_checksum}"
   iso_urls          = [
                         "${var.iso_url_local}",


### PR DESCRIPTION
…attach

When tools_mode="attach", the vmware/vmware v2.x plugin requires tools_source_path pointing to the VMware Tools ISO on the host. Default is the standard VMware Workstation installation path. Override in local/variables.pkr.hcl if your installation differs.

https://claude.ai/code/session_01LCdJTdiGBKafdQkGW2hzeR