### PR TITLE
Combine WinRM+VMware Tools into single Order 98 to prevent split by r…

### DIFF
--- a/resources/vm/answer_files/Autounattend.xml
+++ b/resources/vm/answer_files/Autounattend.xml
@@ -268,8 +268,8 @@
                     <Description>Add Windows Defender exclusion for C:\venv</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -NonInteractive -ExecutionPolicy Bypass -Command "Enable-PSRemoting -Force -SkipNetworkProfileCheck;Set-Item WSMan:\localhost\Service\AllowUnencrypted $true;Set-Item WSMan:\localhost\Service\Auth\Basic $true;Set-Item WSMan:\localhost\Client\Auth\Basic $true;Set-Service winrm -StartupType Automatic;Restart-Service winrm"</CommandLine>
-                    <Description>Enable WinRM for Packer</Description>
+                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -NonInteractive -ExecutionPolicy Bypass -Command "Enable-PSRemoting -Force -SkipNetworkProfileCheck;Set-Item WSMan:\localhost\Service\AllowUnencrypted $true;Set-Item WSMan:\localhost\Service\Auth\Basic $true;Set-Item WSMan:\localhost\Client\Auth\Basic $true;Set-Service winrm -StartupType Automatic;Restart-Service winrm;$log='C:\Windows\Temp\ivmt.log';$s='';foreach($d in 'D:','E:','F:','G:','H:'){$t=$d+'\setup64.exe';if(Test-Path $t){$s=$t;break};$t=$d+'\setup.exe';if(Test-Path $t){$s=$t;break}};Add-Content $log ('setup: '+$s);if($s){Start-Process -FilePath $s -ArgumentList '/S /v /qn' -Wait;Add-Content $log 'done'}else{Add-Content $log 'not found'}"</CommandLine>
+                    <Description>Enable WinRM and install VMware Tools from attached CD</Description>
                     <Order>98</Order>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
@@ -288,11 +288,6 @@
                     <Description>Install Windows Updates</Description>
                     <Order>101</Order>
                     <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -NonInteractive -ExecutionPolicy Bypass -Command "$log='C:\Windows\Temp\ivmt.log';$s='';foreach($d in 'D:','E:','F:','G:','H:'){$t=$d+'\setup64.exe';if(Test-Path $t){$s=$t;break};$t=$d+'\setup.exe';if(Test-Path $t){$s=$t;break}};Add-Content $log ('setup: '+$s);if($s){Start-Process -FilePath $s -ArgumentList '/S /v /qn' -Wait;Add-Content $log 'done'}else{Add-Content $log 'not found'}"</CommandLine>
-                    <Description>Install VMware Tools from attached CD</Description>
-                    <Order>102</Order>
                 </SynchronousCommand>
                 <!-- END WITH WINDOWS UPDATES -->
             </FirstLogonCommands>


### PR DESCRIPTION
…eboot

FirstLogonCommands fire exactly once. Windows Update restarts the VM mid-sequence, so Order 102 (Tools install) was never reached.

Fix: merge WinRM setup and VMware Tools install into a single Order 98 command. Both operations complete atomically within one powershell -Command invocation (~3 min) before Windows Update can trigger a restart. Removes the now-redundant Order 102.

https://claude.ai/code/session_01LCdJTdiGBKafdQkGW2hzeR