### PR TITLE
Revert tools_mode=attach (caused /S Windows Setup error) back to upload

### DIFF
--- a/local/defaults/variables.pkr.hcl
+++ b/local/defaults/variables.pkr.hcl
@@ -1,5 +1,4 @@
 autounattend        = "./resources/vm/answer_files/Autounattend.xml"
-tools_source_path   = "C:\\Program Files (x86)\\VMware\\VMware Workstation\\windows.iso"
 cpus              = "4"
 disk_size         = "307200"
 disk_type_id      = "1"

--- a/resources/vm/windows_11.pkr.hcl.default
+++ b/resources/vm/windows_11.pkr.hcl.default
@@ -58,11 +58,6 @@ variable "winrm_timeout" {
   default = "6h"
 }
 
-variable "tools_source_path" {
-  type    = string
-  default = "C:\\Program Files (x86)\\VMware\\VMware Workstation\\windows.iso"
-}
-
 variable "iso_checksum" {
   type    = string
   default = "sha256:ISO_HASH"
@@ -101,8 +96,9 @@ source "vmware-iso" "windows_11" {
   guest_os_type           = "windows11-64"
   headless                = "${var.headless}"
   network_adapter_type    = "e1000e"
-  tools_mode              = "attach"
-  tools_source_path       = "${var.tools_source_path}"
+  tools_mode              = "upload"
+  tools_upload_flavor     = "windows"
+  tools_upload_path       = "c:/Windows/Temp/vmware-tools.iso"
   iso_checksum      = "${var.iso_checksum}"
   iso_urls          = [
                         "${var.iso_url_local}",
@@ -135,6 +131,23 @@ build {
     remote_path     = "/tmp/script.bat"
     scripts         = [
       "./resources/vm/scripts/enable-rdp.bat",
+      ]
+  }
+
+  provisioner "windows-restart" {
+    restart_timeout = "${var.restart_timeout}"
+  }
+
+  provisioner "file" {
+    source      = "./resources/vm/scripts/vm-guest-tools.ps1"
+    destination = "C:/Windows/Temp/vm-guest-tools.ps1"
+  }
+
+  provisioner "windows-shell" {
+    execute_command = "{{ .Vars }} cmd /c \"{{ .Path }}\""
+    remote_path     = "/tmp/script.bat"
+    scripts         = [
+      "./resources/vm/scripts/install-vm-guest-tools.bat",
       ]
   }
 


### PR DESCRIPTION
The /S error at 'Setup is starting' was introduced by commit 05cede8 which set tools_mode=attach+tools_source_path. Attaching the VMware Tools ISO as a second CD-ROM causes Windows PE to find setup.exe on that ISO and attempt to launch it, triggering the error.

Reverts to tools_mode=upload with tools_upload_flavor/path, and restores the build provisioners (file, windows-shell, windows-restart) that install VMware Tools after Packer connects via WinRM.

Also removes tools_source_path variable and its defaults entry.

https://claude.ai/code/session_01LCdJTdiGBKafdQkGW2hzeR