### PR TITLE
Fix MSYS2 package update by killing background processes

### DIFF
--- a/setup/install/install_msys2.ps1
+++ b/setup/install/install_msys2.ps1
@@ -33,6 +33,11 @@ if (Test-Path -Path "C:\Tools\msys64\usr\bin\bash.exe") {
     & "C:\Tools\msys64\usr\bin\bash.exe" -lc 'pacman-key --populate' 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"
     & "C:\Tools\msys64\usr\bin\bash.exe" -lc 'pacman-key --populate' 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"
     & "C:\Tools\msys64\usr\bin\bash.exe" -lc 'pacman --noconfirm -Syuu' 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"
+    # Kill gpg-agent and other background processes that hold msys-gcrypt DLL open,
+    # otherwise the second -Syuu cannot replace libgcrypt and GPGME breaks.
+    & "C:\Tools\msys64\usr\bin\bash.exe" -lc 'gpgconf --kill all' 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"
+    Get-Process | Where-Object { try { $_.MainModule.FileName -like "C:\Tools\msys64\*" } catch { $false } } | Stop-Process -Force -ErrorAction SilentlyContinue
+    Start-Sleep -Seconds 3
     & "C:\Tools\msys64\usr\bin\bash.exe" -lc 'pacman --noconfirm -Syuu' 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"
     & "C:\Tools\msys64\usr\bin\bash.exe" -lc 'pacman --noconfirm -Syu bc binutils cpio expect git gnu-netcat mingw-w64-ucrt-x86_64-autotools mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-make mingw-w64-ucrt-x86_64-toolchain nasm ncurses ncurses-devel pv rsync tree zsh vim' 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"
     Write-DateLog "MSYS2 installation done." 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"


### PR DESCRIPTION
## Summary
This change fixes a critical issue in the MSYS2 installation script where background processes (specifically gpg-agent) were holding locks on DLL files, preventing the second pacman system update from completing successfully.

## Key Changes
- Added `gpgconf --kill all` command to terminate GPG-related background processes
- Added PowerShell logic to forcefully stop any remaining MSYS2 processes that may hold file locks
- Added a 3-second sleep to allow processes to fully terminate before proceeding with the second system update

## Implementation Details
The fix addresses a specific problem where libgcrypt and GPGME would break during the second `-Syuu` (full system upgrade) operation because background processes were keeping the msys-gcrypt DLL locked. The solution:
1. Kills all GPG agents and related processes via `gpgconf --kill all`
2. Terminates any remaining MSYS2 processes using PowerShell's `Stop-Process`
3. Waits 3 seconds to ensure all file handles are released
4. Proceeds with the second pacman system update which can now successfully replace the locked libraries

https://claude.ai/code/session_01Bcqu2H6oUfo8x5RrhwnSdu