### PR TITLE
Kill gpg-agent before first pacman -Syuu, not only between runs

### DIFF
--- a/setup/install/install_msys2.ps1
+++ b/setup/install/install_msys2.ps1
@@ -32,9 +32,12 @@ if (Test-Path -Path "C:\Tools\msys64\usr\bin\bash.exe") {
     & "C:\Tools\msys64\usr\bin\bash.exe" -lc 'pacman-key --populate msys2' 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"
     & "C:\Tools\msys64\usr\bin\bash.exe" -lc 'pacman-key --populate' 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"
     & "C:\Tools\msys64\usr\bin\bash.exe" -lc 'pacman-key --populate' 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"
+    # pacman-key starts gpg-agent which holds msys-gcrypt-20.dll open; kill it before
+    # pacman upgrade so libgcrypt can be replaced (otherwise GPGME breaks for all later runs).
+    & "C:\Tools\msys64\usr\bin\bash.exe" -lc 'gpgconf --kill all' 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"
+    Get-Process | Where-Object { try { $_.MainModule.FileName -like "C:\Tools\msys64\*" } catch { $false } } | Stop-Process -Force -ErrorAction SilentlyContinue
+    Start-Sleep -Seconds 3
     & "C:\Tools\msys64\usr\bin\bash.exe" -lc 'pacman --noconfirm -Syuu' 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"
-    # Kill gpg-agent and other background processes that hold msys-gcrypt DLL open,
-    # otherwise the second -Syuu cannot replace libgcrypt and GPGME breaks.
     & "C:\Tools\msys64\usr\bin\bash.exe" -lc 'gpgconf --kill all' 2>&1 | ForEach-Object{ "$_" } >> "C:\log\msys2.txt"
     Get-Process | Where-Object { try { $_.MainModule.FileName -like "C:\Tools\msys64\*" } catch { $false } } | Stop-Process -Force -ErrorAction SilentlyContinue
     Start-Sleep -Seconds 3


### PR DESCRIPTION
The previous fix killed background processes between the two -Syuu calls, but gpg-agent is already holding msys-gcrypt-20.dll open by the time the first -Syuu runs (started by pacman-key --populate). Move the kill+sleep to before the first upgrade attempt so libgcrypt can be replaced cleanly, and keep a second kill before the follow-up -Syuu for the same reason.

https://claude.ai/code/session_01Bcqu2H6oUfo8x5RrhwnSdu