### PR TITLE
Simplify WinRM setup in Autounattend.xml, remove VMware Tools installation

### DIFF
--- a/resources/vm/answer_files/Autounattend.xml
+++ b/resources/vm/answer_files/Autounattend.xml
@@ -268,8 +268,8 @@
                     <Description>Add Windows Defender exclusion for C:\venv</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -NonInteractive -ExecutionPolicy Bypass -Command "Enable-PSRemoting -Force -SkipNetworkProfileCheck;Set-Item WSMan:\localhost\Service\AllowUnencrypted $true;Set-Item WSMan:\localhost\Service\Auth\Basic $true;Set-Item WSMan:\localhost\Client\Auth\Basic $true;Set-Service winrm -StartupType Automatic;Restart-Service winrm;$log='C:\Windows\Temp\ivmt.log';$s='';foreach($d in 'D:','E:','F:','G:','H:'){$t=$d+'\setup64.exe';if(Test-Path $t){$s=$t;break};$t=$d+'\setup.exe';if(Test-Path $t){$s=$t;break}};Add-Content $log ('setup: '+$s);if($s){$ia=[char]47+'S '+[char]47+'v '+[char]47+'qn';Start-Process -FilePath $s -ArgumentList $ia -Wait;Add-Content $log 'done'}else{Add-Content $log 'not found'}"</CommandLine>
-                    <Description>Enable WinRM and install VMware Tools from attached CD</Description>
+                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -NonInteractive -ExecutionPolicy Bypass -Command "Enable-PSRemoting -Force -SkipNetworkProfileCheck;Set-Item WSMan:\localhost\Service\AllowUnencrypted $true;Set-Item WSMan:\localhost\Service\Auth\Basic $true;Set-Item WSMan:\localhost\Client\Auth\Basic $true;Set-Service winrm -StartupType Automatic;Restart-Service winrm"</CommandLine>
+                    <Description>Enable WinRM for Packer</Description>
                     <Order>98</Order>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">


### PR DESCRIPTION
## Summary
This change simplifies the WinRM configuration step in the Windows unattended installation file by removing the VMware Tools installation logic and focusing solely on enabling WinRM for Packer communication.

## Key Changes
- Removed VMware Tools installation code that searched for and executed setup files from drives D through H
- Removed logging functionality that tracked setup file discovery and installation status
- Simplified the PowerShell command to only configure WinRM settings (PSRemoting, AllowUnencrypted, Basic auth, and service startup)
- Updated the command description from "Enable WinRM and install VMware Tools from attached CD" to "Enable WinRM for Packer"

## Implementation Details
The command now focuses exclusively on WinRM configuration without the additional complexity of VMware Tools installation. This reduces the scope of this particular setup step and likely means VMware Tools installation is handled separately or through a different mechanism in the provisioning workflow.

https://claude.ai/code/session_01MeV6jCSDzU84NwRdt2AMXV