### PR TITLE
Move WinRM configuration to PowerShell script for Windows 11 24H2 compatibility

### DIFF
--- a/resources/vm/answer_files/Autounattend.xml
+++ b/resources/vm/answer_files/Autounattend.xml
@@ -268,11 +268,6 @@
                     <Description>Add Windows Defender exclusion for C:\venv</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -NonInteractive -ExecutionPolicy Bypass -Command "Enable-PSRemoting -Force -SkipNetworkProfileCheck;Set-Item WSMan:\localhost\Service\AllowUnencrypted $true;Set-Item WSMan:\localhost\Service\Auth\Basic $true;Set-Item WSMan:\localhost\Client\Auth\Basic $true;Set-Service winrm -StartupType Automatic;Restart-Service winrm"</CommandLine>
-                    <Description>Enable WinRM for Packer</Description>
-                    <Order>98</Order>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c a:\microsoft-updates.bat</CommandLine>
                     <Order>99</Order>
                     <Description>Enable Microsoft Updates</Description>

--- a/resources/vm/scripts/win-updates.ps1
+++ b/resources/vm/scripts/win-updates.ps1
@@ -10,6 +10,9 @@ function Enable-WinRMForPacker {
     $Connections = $NetworkListManager.GetNetworkConnections()
     $Connections | ForEach-Object { $_.GetNetwork().SetCategory(1) }
 
+    # Override any Group Policy that blocks unencrypted WinRM (Windows 11 24H2+)
+    reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service" /v AllowUnencrypted /t REG_DWORD /d 1 /f | Out-Null
+
     Enable-PSRemoting -Force
     winrm quickconfig -q
     winrm quickconfig -transport:http


### PR DESCRIPTION
## Summary
Refactored WinRM setup for Packer by moving the configuration from the Autounattend.xml answer file to the win-updates.ps1 PowerShell script, and added registry override for Group Policy restrictions in Windows 11 24H2+.

## Key Changes
- Removed WinRM enablement command from Autounattend.xml (Order 98)
- Added WinRM configuration to the `Enable-WinRMForPacker` function in win-updates.ps1
- Added registry override to allow unencrypted WinRM when Group Policy blocks it (Windows 11 24H2+)

## Implementation Details
The WinRM setup now includes a registry modification that explicitly enables unencrypted WinRM at `HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service\AllowUnencrypted`. This addresses compatibility issues with Windows 11 24H2 where Group Policy may block unencrypted WinRM connections by default. The configuration is executed as part of the PowerShell script rather than during the initial Windows setup phase, allowing for better error handling and logging.

https://claude.ai/code/session_01QJ3vTVjeb2TGZJ7jFN9sQb