### PR TITLE
Enable vTPM for Windows 11 VM in VMware ISO builder

### DIFF
--- a/resources/vm/windows_11.pkr.hcl.default
+++ b/resources/vm/windows_11.pkr.hcl.default
@@ -114,6 +114,7 @@ source "vmware-iso" "windows_11" {
                         "RemoteDisplay.vnc.enabled" = "false"
                         "RemoteDisplay.vnc.port"    = "5900"
                         "Firmware"                  = "efi"
+                        "managedVM.autoAddVTPM"     = "software"
                         "Annotation"                = "Packer version: ${packer.version}|0D|0AVM creation time: ${formatdate("DD MMM YYYY hh:mm ZZZ", timestamp())}|0D|0AUsername: ${var.username}|0D|0APassword: ${var.password}|0D|0A|0D|0AWindows 11 with dfirws installed.",
                     }
   vnc_port_max                   = 5980


### PR DESCRIPTION
## Summary
This change enables virtual Trusted Platform Module (vTPM) support for Windows 11 virtual machines built using the VMware ISO builder in Packer.

## Key Changes
- Added `managedVM.autoAddVTPM = "software"` configuration to the VMware ISO source block for Windows 11
- This enables automatic addition of a software-based vTPM device to the VM

## Implementation Details
The vTPM configuration is set to "software" mode, which provides TPM 2.0 functionality through a software implementation. This is necessary for Windows 11 compatibility, as Windows 11 can require TPM 2.0 for certain security features and may perform better with vTPM available during the build process.

https://claude.ai/code/session_01EqHXGA9JZuzTTQ2LCzEkGU