### PR TITLE
Use vtpm.present for Workstation instead of managedVM.autoAddVTPM

### DIFF
--- a/resources/vm/windows_11.pkr.hcl.default
+++ b/resources/vm/windows_11.pkr.hcl.default
@@ -114,7 +114,8 @@ source "vmware-iso" "windows_11" {
                         "RemoteDisplay.vnc.enabled" = "false"
                         "RemoteDisplay.vnc.port"    = "5900"
                         "Firmware"                  = "efi"
-                        "managedVM.autoAddVTPM"     = "software"
+                        "uefi.secureBoot.enabled"   = "TRUE"
+                        "vtpm.present"              = "TRUE"
                         "Annotation"                = "Packer version: ${packer.version}|0D|0AVM creation time: ${formatdate("DD MMM YYYY hh:mm ZZZ", timestamp())}|0D|0AUsername: ${var.username}|0D|0APassword: ${var.password}|0D|0A|0D|0AWindows 11 with dfirws installed.",
                     }
   vnc_port_max                   = 5980


### PR DESCRIPTION
managedVM.autoAddVTPM is a vSphere-managed setting and is ignored by standalone VMware Workstation, so no TPM device showed up in the VM hardware after the previous change.

Switch to the Workstation-native VMX keys: vtpm.present = TRUE and uefi.secureBoot.enabled = TRUE. Workstation 17.5+ supports a software vTPM without requiring full VM encryption.