### PR TITLE
Fix 7-Zip path detection to check PATH before hardcoded locations

### DIFF
--- a/VMinstall.ps1
+++ b/VMinstall.ps1
@@ -41,6 +41,7 @@ param (
 )
 
 function Find-SevenZip {
+    if (Get-Command "7z.exe" -ErrorAction SilentlyContinue) { return "7z.exe" }
     foreach ($c in @("${env:ProgramFiles}\7-Zip\7z.exe", "${env:ProgramFiles(x86)}\7-Zip\7z.exe")) {
         if (Test-Path $c) { return $c }
     }

--- a/downloadFiles.ps1
+++ b/downloadFiles.ps1
@@ -219,8 +219,11 @@ if (! (Get-Command "rclone.exe" -ErrorAction SilentlyContinue)) {
 }
 
 if (! (Get-Command "7z.exe" -ErrorAction SilentlyContinue)) {
-    Write-DateLog "Error: 7z.exe not found. Please install 7-Zip and add it to PATH."
-    Exit
+    $found = @("${env:ProgramFiles}\7-Zip\7z.exe", "${env:ProgramFiles(x86)}\7-Zip\7z.exe") | Where-Object { Test-Path $_ } | Select-Object -First 1
+    if (! $found) {
+        Write-DateLog "Error: 7z.exe not found. Please install 7-Zip."
+        Exit
+    }
 }
 
 if (! (Get-Command "winget.exe" -ErrorAction SilentlyContinue)) {

--- a/local/defaults/Microsoft.PowerShell_profile.ps1
+++ b/local/defaults/Microsoft.PowerShell_profile.ps1
@@ -115,7 +115,7 @@ function Restore-Quarantine {
 
 	if (Test-Path "C:\Users\${env:USERNAME}\Desktop\readonly\Quarantine.zip") {
 		Remove-Item -r -Force "C:\tmp\Quarantine" > $null 2>&1
-		& "$env:ProgramFiles\7-Zip\7z.exe" x "C:\Users\${env:USERNAME}\Desktop\readonly\Quarantine.zip" -oc:\tmp > $null
+		& $SEVENZIP x "C:\Users\${env:USERNAME}\Desktop\readonly\Quarantine.zip" -oc:\tmp > $null
 		if (!(Test-Path "C:\tmp\Quarantine")) {
 			Write-Output "Zip file didn't contain directory Quarantine."
 			return

--- a/local/defaults/customize-sandbox.ps1
+++ b/local/defaults/customize-sandbox.ps1
@@ -23,8 +23,8 @@ Add-Shortcut -SourceLnk "${HOME}\Desktop\CyberChef.lnk" -DestinationPath "C:\Too
 
 if ($WSDFIR_NOTEPAD -eq "Yes") {
     # Configure Notepad++
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\comparePlus.zip" -o"${env:ProgramFiles}\Notepad++\Plugins\ComparePlus" | Out-Null
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\DSpellCheck.zip" -o"${env:ProgramFiles}\Notepad++\Plugins\DSpellCheck" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\comparePlus.zip" -o"${env:ProgramFiles}\Notepad++\Plugins\ComparePlus" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\DSpellCheck.zip" -o"${env:ProgramFiles}\Notepad++\Plugins\DSpellCheck" | Out-Null
     New-Item -Path "${env:USERPROFILE}\AppData\Roaming\Notepad++\plugins\config\Hunspell" -ItemType Directory -Force | Out-Null
     if ("${WSDFIR_DARK}" -eq "Yes") {
         if (Test-Path "${LOCAL_PATH}\notepad++_dark.xml") {

--- a/resources/contrib/sync/sync_to_usb.ps1
+++ b/resources/contrib/sync/sync_to_usb.ps1
@@ -3,8 +3,15 @@ $SOURCE_DIRECTORY="$HOME\Documents\workspace\dfirws"
 $CURRENT="$PWD"
 
 if ($args -contains "--zip") {
+    # Resolve 7-Zip path: check PATH first, then common install locations
+    if (Get-Command "7z.exe" -ErrorAction SilentlyContinue) {
+        $SEVENZIP = "7z.exe"
+    } else {
+        $SEVENZIP = @("${env:ProgramFiles}\7-Zip\7z.exe", "${env:ProgramFiles(x86)}\7-Zip\7z.exe") |
+            Where-Object { Test-Path $_ } | Select-Object -First 1
+    }
     Set-Location "$SOURCE_DIRECTORY"
-    Start-Process -Wait 'C:\Program Files\7-Zip\7z.exe' -Argumentlist "a .\tmp\dfirws.zip .\downloads .\enrichment .\mount .\setup"
+    Start-Process -Wait $SEVENZIP -Argumentlist "a .\tmp\dfirws.zip .\downloads .\enrichment .\mount .\setup"
     Get-Job | Receive-Job
     Get-Job | Remove-Job
     Copy-Item ".\tmp\dfirws.zip" "$CURRENT"

--- a/resources/download/basic.ps1
+++ b/resources/download/basic.ps1
@@ -185,7 +185,7 @@ if ($all -or $Python) {
     Write-SynchronizedLog "winget: Downloading uv."
     $status = Get-WinGet "astral-sh.uv" "uv*.zip" "uv" -check "data"
     if ($status) {
-        & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa ".\downloads\uv\uv*.zip" -o"${TOOLS}\bin" | Out-Null
+        & $SEVENZIP x -aoa ".\downloads\uv\uv*.zip" -o"${TOOLS}\bin" | Out-Null
     }
 
     # DotNet 6 Desktop runtime - installed during startup
@@ -202,7 +202,7 @@ if ($all -or $Python) {
             if (Test-Path "${TOOLS}\ghidra") {
                 Remove-Item "${TOOLS}\ghidra" -Recurse -Force
             }
-            & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\ghidra.zip" -o"${TOOLS}" | Out-Null
+            & $SEVENZIP x -aoa "${SETUP_PATH}\ghidra.zip" -o"${TOOLS}" | Out-Null
             New-Item -ItemType Directory -Force -Path "${TOOLS}\ghidra" | Out-Null
             Move-Item ${TOOLS}\ghidra_1* "${TOOLS}\ghidra\"
             Copy-Item "${TOOLS}\ghidra\*\support\ghidra.ico" "${TOOLS}\ghidra" -Recurse -Force

--- a/resources/download/common.ps1
+++ b/resources/download/common.ps1
@@ -20,6 +20,15 @@ if (!(Test-Path variable:GIT_FILE)) {
     $GIT_FILE = "C:\Program Files\Git\usr\bin\file.exe"
 }
 
+# Resolve 7-Zip path: check PATH first, then common install locations
+if (Get-Command "7z.exe" -ErrorAction SilentlyContinue) {
+    $SEVENZIP = "7z.exe"
+} else {
+    $SEVENZIP = @("${env:ProgramFiles}\7-Zip\7z.exe", "${env:ProgramFiles(x86)}\7-Zip\7z.exe") |
+        Where-Object { Test-Path $_ } | Select-Object -First 1
+}
+$null = $SEVENZIP
+
 function ConvertTo-Icon {
     Param(
         [Parameter(Mandatory=$True)] $bitmapPath,

--- a/resources/download/enrichment.ps1
+++ b/resources/download/enrichment.ps1
@@ -227,9 +227,9 @@ $status = Get-FileFromUri -uri "https://github.com/YARAHQ/yara-forge/releases/la
 $null = $status
 
 # Unzip yara signatures
-& "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${yaraSaveDirectory}\yara-forge-rules-core.zip" -o"${yaraSaveDirectory}" | Out-Null
-& "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${yaraSaveDirectory}\yara-forge-rules-extended.zip" -o"${yaraSaveDirectory}" | Out-Null
-& "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${yaraSaveDirectory}\yara-forge-rules-full.zip" -o"${yaraSaveDirectory}" | Out-Null
+& $SEVENZIP x -aoa "${yaraSaveDirectory}\yara-forge-rules-core.zip" -o"${yaraSaveDirectory}" | Out-Null
+& $SEVENZIP x -aoa "${yaraSaveDirectory}\yara-forge-rules-extended.zip" -o"${yaraSaveDirectory}" | Out-Null
+& $SEVENZIP x -aoa "${yaraSaveDirectory}\yara-forge-rules-full.zip" -o"${yaraSaveDirectory}" | Out-Null
 
 # Get CVE data
 Write-DateLog "Downloading CVE data"

--- a/resources/download/git.ps1
+++ b/resources/download/git.ps1
@@ -114,7 +114,7 @@ if (Test-Path -Path ".\reconstructer.org\OfficeMalScanner.zip") {
     if (Test-Path -Path "..\Tools\OfficeMalScanner") {
         Remove-Item -Force -Recurse "..\Tools\OfficeMalScanner"
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa ".\reconstructer.org\OfficeMalScanner.zip" -o"..\Tools\" | Out-Null
+    & $SEVENZIP x -aoa ".\reconstructer.org\OfficeMalScanner.zip" -o"..\Tools\" | Out-Null
 }
 
 # Extract SmartDeblur
@@ -122,11 +122,11 @@ if (Test-Path -Path ".\SmartDeblur\dist\SmartDeblur-1.*-win.zip") {
     if (Test-Path -Path "..\Tools\SmartDeblur") {
         Remove-Item -Force -Recurse "..\Tools\SmartDeblur"
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa ".\SmartDeblur\dist\SmartDeblur-1.*-win.zip" -o"..\Tools\" | Out-Null
+    & $SEVENZIP x -aoa ".\SmartDeblur\dist\SmartDeblur-1.*-win.zip" -o"..\Tools\" | Out-Null
     Move-Item ..\Tools\SmartDeblur-* ..\Tools\SmartDeblur
 }
 
-& "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "ASL\exeinfope.zip" -o"..\Tools" | Out-Null
+& $SEVENZIP x -aoa "ASL\exeinfope.zip" -o"..\Tools" | Out-Null
 
 Set-Location ..\..
 

--- a/resources/download/http.ps1
+++ b/resources/download/http.ps1
@@ -153,7 +153,7 @@ if ($status) {
     if (Test-Path -Path "${TOOLS}\sysinternals") {
         Remove-Item -Recurse -Force "${TOOLS}\sysinternals" | Out-Null 2>&1
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\sysinternals.zip" -o"${TOOLS}\sysinternals" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\sysinternals.zip" -o"${TOOLS}\sysinternals" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1179,7 +1179,7 @@ if ($status) {
     if (Test-Path -Path "${TOOLS}\exiftool") {
         Remove-Item -Recurse -Force "${TOOLS}\exiftool" | Out-Null 2>&1
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\exiftool.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\exiftool.zip" -o"${TOOLS}" | Out-Null
     Start-Sleep -Seconds 3
     Move-Item ${TOOLS}\exiftool-* "${TOOLS}\exiftool" -Force
     Copy-Item "${TOOLS}\exiftool\exiftool(-k).exe" ${TOOLS}\exiftool\exiftool.exe
@@ -1232,7 +1232,7 @@ if ($status) {
     if (Test-Path -Path "${TOOLS}\pestudio") {
         Remove-Item -Recurse -Force "${TOOLS}\pestudio" | Out-Null 2>&1
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\pestudio.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\pestudio.zip" -o"${TOOLS}" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1280,7 +1280,7 @@ if ($status) {
     if (Test-Path -Path "${TOOLS}\hxd") {
         Remove-Item -Recurse -Force "${TOOLS}\hxd" | Out-Null 2>&1
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\hxd.zip" -o"${TOOLS}\hxd" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\hxd.zip" -o"${TOOLS}\hxd" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1325,11 +1325,11 @@ $TOOL_DEFINITIONS += @{
 # Get trid and triddefs
 $status = Get-FileFromUri -uri "https://mark0.net/download/trid_w32.zip" -FilePath ".\downloads\trid.zip" -check "Zip archive data"
 if ($status) {
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\trid.zip" -o"${TOOLS}\trid" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\trid.zip" -o"${TOOLS}\trid" | Out-Null
 }
 $status = Get-FileFromUri -uri "https://mark0.net/download/triddefs.zip" -FilePath ".\downloads\triddefs.zip" -check "Zip archive data"
 if ($status) {
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\triddefs.zip" -o"${TOOLS}\trid" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\triddefs.zip" -o"${TOOLS}\trid" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1378,7 +1378,7 @@ if ($status) {
     if (Test-Path -Path "${TOOLS}\malcat") {
         Remove-Item -Recurse -Force "${TOOLS}\malcat" | Out-Null 2>&1
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\malcat.zip" -o"${TOOLS}\malcat" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\malcat.zip" -o"${TOOLS}\malcat" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1427,7 +1427,7 @@ if ($status) {
     if (Test-Path -Path "${TOOLS}\ssview") {
         Remove-Item -Recurse -Force "${TOOLS}\ssview" | Out-Null 2>&1
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\ssview.zip" -o"${TOOLS}\ssview" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\ssview.zip" -o"${TOOLS}\ssview" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1476,7 +1476,7 @@ if ($status) {
     if (Test-Path -Path "${TOOLS}\FullEventLogView") {
         Remove-Item -Recurse -Force "${TOOLS}\FullEventLogView" | Out-Null 2>&1
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\logview.zip" -o"${TOOLS}\FullEventLogView" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\logview.zip" -o"${TOOLS}\FullEventLogView" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1525,7 +1525,7 @@ if ($status) {
     if (Test-Path -Path "${TOOLS}\pstwalker") {
         Remove-Item -Recurse -Force "${TOOLS}\pstwalker" | Out-Null 2>&1
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\pstwalker.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\pstwalker.zip" -o"${TOOLS}" | Out-Null
     Start-Sleep -Seconds 3
     Move-Item ${TOOLS}\pstwalker*portable "${TOOLS}\pstwalker"
 }
@@ -1576,7 +1576,7 @@ if ($status) {
     if (Test-Path -Path "${TOOLS}\WinApiSearch") {
         Remove-Item -Recurse -Force "${TOOLS}\WinApiSearch" | Out-Null 2>&1
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\WinApiSearch.zip" -o"${TOOLS}\WinApiSearch" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\WinApiSearch.zip" -o"${TOOLS}\WinApiSearch" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1709,7 +1709,7 @@ if ($status) {
     if (Test-Path -Path "${TOOLS}\MailView") {
         Remove-Item -Recurse -Force "${TOOLS}\MailView" | Out-Null 2>&1
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\mailview.zip" -o"${TOOLS}\MailView" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\mailview.zip" -o"${TOOLS}\MailView" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1758,7 +1758,7 @@ if (Test-ToolIncluded -ToolName "Volatility Workbench 3") {
         if (Test-Path -Path "${TOOLS}\VolatilityWorkbench") {
             Remove-Item -Recurse -Force "${TOOLS}\VolatilityWorkbench" | Out-Null 2>&1
         }
-        & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\volatilityworkbench.zip" -o"${TOOLS}\VolatilityWorkbench" | Out-Null
+        & $SEVENZIP x -aoa "${SETUP_PATH}\volatilityworkbench.zip" -o"${TOOLS}\VolatilityWorkbench" | Out-Null
     }
     $status = Get-FileFromUri -uri "https://downloads.volatilityfoundation.org/volatility3/symbols/linux.zip" -FilePath "${TOOLS}\VolatilityWorkbench\Symbols\linux.zip" -check "Zip archive data"
     $status = Get-FileFromUri -uri "https://downloads.volatilityfoundation.org/volatility3/symbols/mac.zip" -FilePath "${TOOLS}\VolatilityWorkbench\Symbols\mac.zip" -check "Zip archive data"
@@ -1811,7 +1811,7 @@ if (Test-ToolIncluded -ToolName "Volatility Workbench 2.1") {
         if (Test-Path -Path "${TOOLS}\VolatilityWorkbench2") {
             Remove-Item -Recurse -Force "${TOOLS}\VolatilityWorkbench2" | Out-Null 2>&1
         }
-        & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\volatilityworkbench2.zip" -o"${TOOLS}\VolatilityWorkbench2" | Out-Null
+        & $SEVENZIP x -aoa "${SETUP_PATH}\volatilityworkbench2.zip" -o"${TOOLS}\VolatilityWorkbench2" | Out-Null
     }
 }
 
@@ -1867,7 +1867,7 @@ if (Test-Path -Path "${TOOLS}\ntemp") {
 
 $status = Get-FileFromUri -uri "https://www.nirsoft.net/utils/lastactivityview.zip" -FilePath ".\downloads\lastactivityview.zip" -check "Zip archive data"
 if ($status) {
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\lastactivityview.zip" -o"${TOOLS}\ntemp" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\lastactivityview.zip" -o"${TOOLS}\ntemp" | Out-Null
     if (Test-Path -Path ${TOOLS}\ntemp\readme.txt) {
         Copy-Item "${TOOLS}\ntemp\readme.txt" "${TOOLS}\ntemp\lastactivityview.txt"
     }
@@ -1877,7 +1877,7 @@ if ($status) {
 
 $status = Get-FileFromUri -uri "https://www.nirsoft.net/utils/iecv.zip" -FilePath ".\downloads\iecookiesview.zip" -check "Zip archive data"
 if ($status) {
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\iecookiesview.zip" -o"${TOOLS}\ntemp" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\iecookiesview.zip" -o"${TOOLS}\ntemp" | Out-Null
     if (Test-Path -Path ${TOOLS}\ntemp\readme.txt) {
         Copy-Item "${TOOLS}\ntemp\readme.txt" "${TOOLS}\ntemp\iecookiesview.txt"
     }
@@ -1887,7 +1887,7 @@ if ($status) {
 
 $status = Get-FileFromUri -uri "https://www.nirsoft.net/utils/mzcv-x64.zip" -FilePath ".\downloads\MZCookiesView.zip" -check "Zip archive data"
 if ($status) {
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\MZCookiesView.zip" -o"${TOOLS}\ntemp" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\MZCookiesView.zip" -o"${TOOLS}\ntemp" | Out-Null
     if (Test-Path -Path "${TOOLS}\ntemp\readme.txt") {
         Copy-Item "${TOOLS}\ntemp\readme.txt" "${TOOLS}\ntemp\MZCookiesView.txt"
     }
@@ -1897,7 +1897,7 @@ if ($status) {
 
 $status = Get-FileFromUri -uri "https://www.nirsoft.net/utils/chromecacheview.zip" -FilePath ".\downloads\chromecacheview.zip" -check "Zip archive data"
 if ($status) {
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\chromecacheview.zip" -o"${TOOLS}\ntemp" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\chromecacheview.zip" -o"${TOOLS}\ntemp" | Out-Null
     if (Test-Path -Path "${TOOLS}\ntemp\readme.txt") {
         Copy-Item "${TOOLS}\ntemp\readme.txt" "${TOOLS}\ntemp\chromecacheview.txt"
     }
@@ -1907,7 +1907,7 @@ Remove-Item -Recurse -Force "${TOOLS}\ntemp" | Out-Null 2>&1
 
 $status = Get-FileFromUri -uri "https://www.nirsoft.net/utils/mzcacheview.zip" -FilePath ".\downloads\mzcacheview.zip" -check "Zip archive data"
 if ($status) {
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\mzcacheview.zip" -o"${TOOLS}\ntemp" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\mzcacheview.zip" -o"${TOOLS}\ntemp" | Out-Null
     if (Test-Path -Path ${TOOLS}\ntemp\readme.txt) {
         Copy-Item "${TOOLS}\ntemp\readme.txt" "${TOOLS}\ntemp\mzcacheview.txt"
     }
@@ -1917,7 +1917,7 @@ if ($status) {
 
 $status = Get-FileFromUri -uri "https://www.nirsoft.net/utils/iecacheview.zip" -FilePath ".\downloads\iecacheview.zip" -check "Zip archive data"
 if ($status) {
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\iecacheview.zip" -o"${TOOLS}\ntemp" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\iecacheview.zip" -o"${TOOLS}\ntemp" | Out-Null
     if (Test-Path -Path "${TOOLS}\ntemp\readme.txt") {
         Copy-Item "${TOOLS}\ntemp\readme.txt" "${TOOLS}\ntemp\iecacheview.txt"
     }
@@ -1927,7 +1927,7 @@ if ($status) {
 
 $status = Get-FileFromUri -uri "https://www.nirsoft.net/utils/browsinghistoryview-x64.zip" -FilePath ".\downloads\browsinghistoryview.zip" -check "Zip archive data"
 if ($status) {
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\browsinghistoryview.zip" -o"${TOOLS}\ntemp" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\browsinghistoryview.zip" -o"${TOOLS}\ntemp" | Out-Null
     if (Test-Path -Path "${TOOLS}\ntemp\readme.txt") {
         Copy-Item "${TOOLS}\ntemp\readme.txt" "${TOOLS}\ntemp\browsinghistoryview.txt"
     }
@@ -2215,7 +2215,7 @@ if ($status) {
     if (Test-Path -Path ${SETUP_PATH}\dcode) {
         Remove-Item -Recurse -Force ${SETUP_PATH}\dcode | Out-Null 2>&1
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\dcode.zip" -o"${SETUP_PATH}\dcode" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\dcode.zip" -o"${SETUP_PATH}\dcode" | Out-Null
     Start-Sleep -Seconds 3
     Move-Item ${SETUP_PATH}\dcode\Dcode-* "${SETUP_PATH}\dcode\dcode.exe" | Out-Null
 }
@@ -2430,7 +2430,7 @@ if (Test-ToolIncluded -ToolName "capa Explorer Web") {
         if (Test-Path -Path "${TOOLS}\capa-explorer-web") {
             Remove-Item -Recurse -Force "${TOOLS}\capa-explorer-web" | Out-Null 2>&1
         }
-        & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\capa-explorer-web.zip" -o"${TOOLS}" | Out-Null
+        & $SEVENZIP x -aoa "${SETUP_PATH}\capa-explorer-web.zip" -o"${TOOLS}" | Out-Null
     }
 }
 
@@ -2554,7 +2554,7 @@ if ($status) {
     if (Test-Path -Path "${TOOLS}\sqlite") {
         Remove-Item -Recurse -Force "${TOOLS}\sqlite" | Out-Null 2>&1
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\sqlite.zip" -o"${TOOLS}\sqlite" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\sqlite.zip" -o"${TOOLS}\sqlite" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -2600,7 +2600,7 @@ if ($status) {
     if (Test-Path -Path "${TOOLS}\bulk_extractor") {
         Remove-Item -Recurse -Force "${TOOLS}\bulk_extractor" | Out-Null 2>&1
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\bulk_extractor.zip" -o"${TOOLS}\bulk_extractor" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\bulk_extractor.zip" -o"${TOOLS}\bulk_extractor" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -2649,7 +2649,7 @@ if ($status) {
     if (Test-Path -Path "${TOOLS}\bin\densityscout.exe") {
         Remove-Item -Recurse -Force "${TOOLS}\bin\densityscout.exe" | Out-Null 2>&1
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\DensityScout.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\DensityScout.zip" -o"${TOOLS}" | Out-Null
     Start-Sleep -Seconds 3
     Move-Item "${TOOLS}\win64\densityscout.exe" "${TOOLS}\bin\densityscout.exe"
 }
@@ -2700,7 +2700,7 @@ if (Test-ToolIncluded -ToolName "NetworkMiner") {
         if (Test-Path -Path "${TOOLS}\NetworkMiner") {
             Remove-Item -Recurse -Force "${TOOLS}\NetworkMiner" | Out-Null 2>&1
         }
-        & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\NetworkMiner.zip" -o"${TOOLS}" | Out-Null
+        & $SEVENZIP x -aoa "${SETUP_PATH}\NetworkMiner.zip" -o"${TOOLS}" | Out-Null
         Move-Item ${TOOLS}\NetworkMiner_* "${TOOLS}\NetworkMiner"
     }
 }
@@ -2748,7 +2748,7 @@ if (Test-ToolIncluded -ToolName "PolarProxy") {
         if (Test-Path -Path "${TOOLS}\PolarProxy") {
             Remove-Item -Recurse -Force "${TOOLS}\PolarProxy" | Out-Null 2>&1
         }
-        & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\PolarProxy.zip" -o"${TOOLS}\PolarProxy" | Out-Null
+        & $SEVENZIP x -aoa "${SETUP_PATH}\PolarProxy.zip" -o"${TOOLS}\PolarProxy" | Out-Null
         Move-Item ${TOOLS}\PolarProxy_* "${TOOLS}\PolarProxy"
     }
 }
@@ -2797,7 +2797,7 @@ if ($status) {
     if (Test-Path -Path "${TOOLS}\nmap") {
         Remove-Item -Recurse -Force "${TOOLS}\nmap" | Out-Null 2>&1
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\nmap.exe" -o"${TOOLS}\nmap" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\nmap.exe" -o"${TOOLS}\nmap" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -2843,7 +2843,7 @@ if ($status) {
     if (Test-Path -Path "${TOOLS}\fasm") {
         Remove-Item -Recurse -Force "${TOOLS}\fasm" | Out-Null 2>&1
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\fasm.zip" -o"${TOOLS}\fasm" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\fasm.zip" -o"${TOOLS}\fasm" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -2921,7 +2921,7 @@ if (Test-ToolIncluded -ToolName "ProcDOT") {
         if (Test-Path -Path "${TOOLS}\procdot") {
             Remove-Item -Recurse -Force "${TOOLS}\procdot" | Out-Null 2>&1
         }
-        & "${env:ProgramFiles}\7-Zip\7z.exe" x -pprocdot -aoa "${SETUP_PATH}\procdot.zip" -o"${TOOLS}\procdot" | Out-Null
+        & $SEVENZIP x -pprocdot -aoa "${SETUP_PATH}\procdot.zip" -o"${TOOLS}\procdot" | Out-Null
     }
 }
 
@@ -2972,7 +2972,7 @@ if ($status) {
     if (Test-Path -Path "${TOOLS}\geolocus") {
         Remove-Item -Recurse -Force "${TOOLS}\geolocus" | Out-Null 2>&1
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\geolocus.zip" -o"${TOOLS}\geolocus" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\geolocus.zip" -o"${TOOLS}\geolocus" | Out-Null
     Copy-Item "${TOOLS}\geolocus\geolocus-cli-windows.exe" -Destination "${TOOLS}\bin\geolocus-cli.exe" -Force
     Remove-Item -Recurse -Force "${TOOLS}\geolocus\__MACOSX" | Out-Null 2>&1
 }
@@ -3105,7 +3105,7 @@ if ($status) {
     if (Test-Path -Path "${TOOLS}\javafx-sdk") {
         Remove-Item -Recurse -Force "${TOOLS}\javafx-sdk" | Out-Null 2>&1
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\openjfx.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\openjfx.zip" -o"${TOOLS}" | Out-Null
     Start-Sleep -Seconds 3
     Move-Item ${TOOLS}\javafx-sdk-* "${TOOLS}\javafx-sdk"
 }
@@ -3189,7 +3189,7 @@ if ($status) {
     if (Test-Path -Path "${TOOLS}\php") {
         Remove-Item -Recurse -Force "${TOOLS}\php" | Out-Null 2>&1
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\php.zip" -o"${TOOLS}\php" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\php.zip" -o"${TOOLS}\php" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -3239,7 +3239,7 @@ if (Test-ToolIncluded -ToolName "hashcat") {
         if (Test-Path -Path "${TOOLS}\hashcat") {
             Remove-Item -Recurse -Force "${TOOLS}\hashcat" | Out-Null 2>&1
         }
-        & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\hashcat.7z" -o"${TOOLS}" | Out-Null
+        & $SEVENZIP x -aoa "${SETUP_PATH}\hashcat.7z" -o"${TOOLS}" | Out-Null
         Start-Sleep -Seconds 3
         Move-Item ${TOOLS}\hashcat-* "${TOOLS}\hashcat" | Out-Null
     }
@@ -3293,8 +3293,8 @@ if (Test-ToolIncluded -ToolName "hashcat") {
 # Mex for WinDbg
 $status = Get-FileFromUri -uri "https://download.microsoft.com/download/0/c/4/0c4c45e3-bf02-49bf-8d68-6fa611f442e6/Mex.exe" -FilePath ".\downloads\mex.exe" -CheckURL "Yes" -check "PE32"
 if ($status) {
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\mex.exe" -o"${SETUP_PATH}" | Out-Null
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\mex.zip" -o"${TOOLS}\mex" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\mex.exe" -o"${SETUP_PATH}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\mex.zip" -o"${TOOLS}\mex" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -3328,7 +3328,7 @@ if ($status) {
     if (Test-Path -Path "${TOOLS}\ResourceHacker") {
         Remove-Item -Recurse -Force "${TOOLS}\ResourceHacker" | Out-Null 2>&1
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\resourcehacker.zip" -o"${TOOLS}\ResourceHacker" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\resourcehacker.zip" -o"${TOOLS}\ResourceHacker" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -3374,7 +3374,7 @@ $TOOL_DEFINITIONS += @{
 if (Test-ToolIncluded -ToolName "Azure CLI") {
     $status = Get-FileFromUri -uri "https://aka.ms/installazurecliwindowszipx64" -FilePath ".\downloads\azurecli.zip" -CheckURL "Yes" -check "Zip archive data"
     if ($status) {
-        & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\azurecli.zip" -o"${TOOLS}\AzureCLI" | Out-Null
+        & $SEVENZIP x -aoa "${SETUP_PATH}\azurecli.zip" -o"${TOOLS}\AzureCLI" | Out-Null
     }
 }
 
@@ -3424,7 +3424,7 @@ if (Test-ToolIncluded -ToolName "Android SDK Platform Tools") {
         if (Test-Path -Path "${TOOLS}\AndroidSDK") {
             Remove-Item -Recurse -Force "${TOOLS}\AndroidSDK" | Out-Null 2>&1
         }
-        & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\android_sdk.zip" -o"${TOOLS}\AndroidSDK" | Out-Null
+        & $SEVENZIP x -aoa "${SETUP_PATH}\android_sdk.zip" -o"${TOOLS}\AndroidSDK" | Out-Null
     }
 }
 

--- a/resources/download/kape.ps1
+++ b/resources/download/kape.ps1
@@ -12,7 +12,7 @@ if (test-path .\local\kape.zip) {
 }
 
 if (! (Test-Path -Path "$SETUP_PATH\KAPE" )) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa ".\local\kape.zip" -o"$SETUP_PATH" | Out-Null
+    & $SEVENZIP x -aoa ".\local\kape.zip" -o"$SETUP_PATH" | Out-Null
     if (Test-Path "$SETUP_PATH\Get-KAPEUpdate.ps1") {
         Remove-Item "$SETUP_PATH\Get-KAPEUpdate.ps1"  -Force
     }

--- a/resources/download/release.ps1
+++ b/resources/download/release.ps1
@@ -4,7 +4,7 @@ $TOOL_DEFINITIONS = @()
 # artemis
 $status = Get-GitHubRelease -repo "puffyCid/artemis" -path "${SETUP_PATH}\artemis.zip" -match "x86_64-pc-windows-msvc.zip$" -check "Zip archive data"
 if ($status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\artemis.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\artemis.zip" -o"${TOOLS}" | Out-Null
     if (Test-Path "${TOOLS}\artemis") {
         Remove-Item "${TOOLS}\artemis" -Recurse -Force
     }
@@ -53,7 +53,7 @@ if (Test-ToolIncluded -ToolName "godap") {
         if (Test-Path "${TOOLS}\godap") {
             Remove-Item "${TOOLS}\godap" -Recurse -Force
         }
-        & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\godap.zip" -o"${TOOLS}\godap" | Out-Null
+        & $SEVENZIP x -aoa "${SETUP_PATH}\godap.zip" -o"${TOOLS}\godap" | Out-Null
         Move-Item ${TOOLS}\godap-* "${TOOLS}\godap"
     }
 }
@@ -96,7 +96,7 @@ $TOOL_DEFINITIONS += @{
 # BeaconHunter - copied to program files during startup
 $status = Get-GitHubRelease -repo "3lp4tr0n/BeaconHunter" -path "${SETUP_PATH}\beaconhunter.zip" -match "BeaconHunter.zip" -check "Zip archive data"
 if ($status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\beaconhunter.zip" -o"${TOOLS}\BeaconHunter" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\beaconhunter.zip" -o"${TOOLS}\BeaconHunter" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -182,7 +182,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\aleapp") {
         Remove-Item "${TOOLS}\aleapp" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\aleapp.zip" -o"${TOOLS}\aleapp" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\aleapp.zip" -o"${TOOLS}\aleapp" | Out-Null
     Copy-Item ${TOOLS}\aleapp\aleapp.exe ${TOOLS}\bin\
     Remove-Item "${TOOLS}\aleapp" -Recurse -Force
 }
@@ -191,7 +191,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\aleappGUI") {
         Remove-Item "${TOOLS}\aleappGUI" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\aleappGUI.zip" -o"${TOOLS}\aleappGUI" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\aleappGUI.zip" -o"${TOOLS}\aleappGUI" | Out-Null
     Copy-Item ${TOOLS}\aleappGUI\aleappGUI.exe ${TOOLS}\bin\
     Remove-Item "${TOOLS}\aleappGUI" -Recurse -Force
 }
@@ -249,7 +249,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\ileapp") {
         Remove-Item "${TOOLS}\ileapp" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\ileapp.zip" -o"${TOOLS}\ileapp" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\ileapp.zip" -o"${TOOLS}\ileapp" | Out-Null
     Copy-Item ${TOOLS}\ileapp\ileapp.exe ${TOOLS}\bin\
     Remove-Item "${TOOLS}\ileapp" -Recurse -Force
 }
@@ -258,7 +258,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\ileappGUI") {
         Remove-Item "${TOOLS}\ileappGUI" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\ileappGUI.zip" -o"${TOOLS}\ileappGUI" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\ileappGUI.zip" -o"${TOOLS}\ileappGUI" | Out-Null
     Copy-Item ${TOOLS}\ileappGUI\ileappGUI.exe ${TOOLS}\bin\
     Remove-Item "${TOOLS}\ileappGUI" -Recurse -Force
 }
@@ -316,7 +316,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\lessmsi") {
         Remove-Item "${TOOLS}\lessmsi" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\lessmsi.zip" -o"${TOOLS}\lessmsi" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\lessmsi.zip" -o"${TOOLS}\lessmsi" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -474,7 +474,7 @@ if (Test-ToolIncluded -ToolName "Audacity") {
         if (Test-Path "${TOOLS}\audacity") {
             Remove-Item "${TOOLS}\audacity" -Recurse -Force
         }
-        & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\audacity.zip" -o"${TOOLS}" | Out-Null
+        & $SEVENZIP x -aoa "${SETUP_PATH}\audacity.zip" -o"${TOOLS}" | Out-Null
         Move-Item ${TOOLS}\audacity-* "${TOOLS}\audacity"
     }
 }
@@ -520,7 +520,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\ares") {
         Remove-Item "${TOOLS}\ares" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\ares.zip" -o"${TOOLS}\ares" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\ares.zip" -o"${TOOLS}\ares" | Out-Null
     Copy-Item "${TOOLS}\ares\ares.exe" "${TOOLS}\bin\" -Force
     Remove-Item "${TOOLS}\ares" -Force -Recurse
 }
@@ -603,7 +603,7 @@ $TOOL_DEFINITIONS += @{
 # RDPCacheStitcher
 $status = Get-GitHubRelease -repo "BSI-Bund/RdpCacheStitcher" -path "${SETUP_PATH}\RdpCacheStitcher.zip" -match "win64" -check "Zip archive data"
 if ($status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\RdpCacheStitcher.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\RdpCacheStitcher.zip" -o"${TOOLS}" | Out-Null
     if (Test-Path "${TOOLS}\RdpCacheStitcher") {
         Remove-Item "${TOOLS}\RdpCacheStitcher" -Recurse -Force
     }
@@ -652,7 +652,7 @@ if (Test-ToolIncluded -ToolName "ffmpeg") {
         if (Test-Path "${TOOLS}\ffmpeg") {
             Remove-Item "${TOOLS}\ffmpeg" -Recurse -Force
         }
-        & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\ffmpeg.zip" -o"${TOOLS}" | Out-Null
+        & $SEVENZIP x -aoa "${SETUP_PATH}\ffmpeg.zip" -o"${TOOLS}" | Out-Null
         Move-Item ${TOOLS}\ffmpeg-* "${TOOLS}\ffmpeg"
     }
 }
@@ -698,7 +698,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\ripgrep") {
         Remove-Item "${TOOLS}\ripgrep" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\ripgrep.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\ripgrep.zip" -o"${TOOLS}" | Out-Null
     Move-Item ${TOOLS}\ripgrep-* "${TOOLS}\ripgrep"
 }
 
@@ -740,7 +740,7 @@ $TOOL_DEFINITIONS += @{
 # binlex
 $status = Get-GitHubRelease -repo "c3rb3ru5d3d53c/binlex" -path "${SETUP_PATH}\binlex.zip" -match "windows" -check "Zip archive data"
 if ($status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\binlex.zip" -o"${TOOLS}\bin" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\binlex.zip" -o"${TOOLS}\bin" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -855,7 +855,7 @@ if (Test-ToolIncluded -ToolName "DBeaver") {
         if (Test-Path "${TOOLS}\dbeaver") {
             Remove-Item "${TOOLS}\dbeaver" -Recurse -Force
         }
-        & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\dbeaver.zip" -o"${TOOLS}" | Out-Null
+        & $SEVENZIP x -aoa "${SETUP_PATH}\dbeaver.zip" -o"${TOOLS}" | Out-Null
     }
 }
 
@@ -900,7 +900,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\dumpbin") {
         Remove-Item "${TOOLS}\dumpbin" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\dumpbin.zip" -o"${TOOLS}\dumpbin" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\dumpbin.zip" -o"${TOOLS}\dumpbin" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -944,14 +944,14 @@ if ($status) {
     if (Test-Path "${TOOLS}\dnSpy32") {
         Remove-Item "${TOOLS}\dnSpy32" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\dnSpy32.zip" -o"${TOOLS}\dnSpy32" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\dnSpy32.zip" -o"${TOOLS}\dnSpy32" | Out-Null
 }
 $status = Get-GitHubRelease -repo "dnSpyEx/dnSpy" -path "${SETUP_PATH}\dnSpy64.zip" -match "win64" -check "Zip archive data"
 if ($status) {
     if (Test-Path "${TOOLS}\dnSpy64") {
         Remove-Item "${TOOLS}\dnSpy64" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\dnSpy64.zip" -o"${TOOLS}\dnSpy64" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\dnSpy64.zip" -o"${TOOLS}\dnSpy64" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1036,7 +1036,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\mboxviewer") {
         Remove-Item "${TOOLS}\mboxviewer" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\mboxviewer.zip" -o"${TOOLS}\mboxviewer" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\mboxviewer.zip" -o"${TOOLS}\mboxviewer" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1077,7 +1077,7 @@ $TOOL_DEFINITIONS += @{
 # zstd
 $status = Get-GitHubRelease -repo "facebook/zstd" -path "${SETUP_PATH}\zstd.zip" -match "win64.zip$" -check "Zip archive data"
 if ($status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa ".\downloads\zstd.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa ".\downloads\zstd.zip" -o"${TOOLS}" | Out-Null
     if (Test-Path "${TOOLS}\zstd") {
         Remove-Item "${TOOLS}\zstd" -Recurse -Force
     }
@@ -1125,7 +1125,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\CyberChef") {
         Remove-Item "${TOOLS}\CyberChef" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\CyberChef.zip" -o"${TOOLS}\CyberChef" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\CyberChef.zip" -o"${TOOLS}\CyberChef" | Out-Null
     if (Test-Path "${TOOLS}\CyberChef\CyberChef.html") {
         Remove-Item "${TOOLS}\CyberChef\CyberChef.html" -Force
     }
@@ -1191,7 +1191,7 @@ $TOOL_DEFINITIONS += @{
 # redress
 $status = Get-GitHubRelease -repo "goretk/redress" -path "${SETUP_PATH}\redress.zip" -match "windows.zip" -check "Zip archive data"
 if ($status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\redress.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\redress.zip" -o"${TOOLS}" | Out-Null
     if (Test-Path "${TOOLS}\redress") {
         Remove-Item "${TOOLS}\redress" -Recurse -Force
     }
@@ -1240,7 +1240,7 @@ if (Test-ToolIncluded -ToolName "h2database") {
         if (Test-Path "${TOOLS}\h2database") {
             Remove-Item "${TOOLS}\h2database" -Recurse -Force
         }
-        & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\h2database.zip" -o"${TOOLS}\h2database" | Out-Null
+        & $SEVENZIP x -aoa "${SETUP_PATH}\h2database.zip" -o"${TOOLS}\h2database" | Out-Null
     }
     $status = Get-GitHubRelease -repo "h2database/h2database" -path "${SETUP_PATH}\h2.pdf" -match "h2.pdf"
     if ($status) {
@@ -1283,7 +1283,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\INDXRipper") {
         Remove-Item "${TOOLS}\INDXRipper" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\indxripper.zip" -o"${TOOLS}\INDXRipper" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\indxripper.zip" -o"${TOOLS}\INDXRipper" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1401,7 +1401,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\pebear") {
         Remove-Item "${TOOLS}\pebear" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\pebear.zip" -o"${TOOLS}\pebear" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\pebear.zip" -o"${TOOLS}\pebear" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1532,8 +1532,8 @@ if ($status -or $plugin_status) {
     if (Test-Path "${TOOLS}\WinObjEx64") {
         Remove-Item "${TOOLS}\WinObjEx64" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\WinObjEx64.zip" -o"${TOOLS}\WinObjEx64" | Out-Null
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\WinObjEx64_plugins.zip" -o"${TOOLS}\WinObjEx64" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\WinObjEx64.zip" -o"${TOOLS}\WinObjEx64" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\WinObjEx64_plugins.zip" -o"${TOOLS}\WinObjEx64" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1577,7 +1577,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\die") {
         Remove-Item "${TOOLS}\die" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\die.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\die.zip" -o"${TOOLS}" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1626,7 +1626,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\XELFViewer") {
         Remove-Item "${TOOLS}\XELFViewer" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\XELFViewer.zip" -o"${TOOLS}\XELFViewer" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\XELFViewer.zip" -o"${TOOLS}\XELFViewer" | Out-Null
     if (Test-Path "${CONFIGURATION_FILES}\xelfviewer.ini") {
         Copy-Item "${CONFIGURATION_FILES}\xelfviewer.ini" "${TOOLS}\XELFViewer\xelfviewer.ini"
     } else {
@@ -1672,7 +1672,7 @@ $TOOL_DEFINITIONS += @{
 # jd-gui
 $status = Get-GitHubRelease -repo "java-decompiler/jd-gui" -path "${SETUP_PATH}\jd-gui.zip" -match "jd-gui-windows" -check "Zip archive data"
 if ($status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\jd-gui.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\jd-gui.zip" -o"${TOOLS}" | Out-Null
     if (Test-Path "${TOOLS}\jd-gui") {
         Remove-Item "${TOOLS}\jd-gui" -Recurse -Force
     }
@@ -1718,7 +1718,7 @@ $TOOL_DEFINITIONS += @{
 if (Test-ToolIncluded -ToolName "LogBoost") {
     $status = Get-GitHubRelease -repo "joeavanzato/logboost" -path "${SETUP_PATH}\logboost.rar" -match "logboost_release" -check "RAR archive data"
     if ($status) {
-        & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\logboost.rar" -o"${TOOLS}\logboost" | Out-Null
+        & $SEVENZIP x -aoa "${SETUP_PATH}\logboost.rar" -o"${TOOLS}\logboost" | Out-Null
     }
 }
 
@@ -1963,7 +1963,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\gftrace64") {
         Remove-Item "${TOOLS}\gftrace64" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\gftrace.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\gftrace.zip" -o"${TOOLS}" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -2085,7 +2085,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\capa") {
         Remove-Item "${TOOLS}\capa" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\capa-windows.zip" -o"${TOOLS}\capa" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\capa-windows.zip" -o"${TOOLS}\capa" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -2131,7 +2131,7 @@ $TOOL_DEFINITIONS += @{
 # capa-rules
 $status = Get-GitHubRelease -repo "mandiant/capa-rules" -path "${SETUP_PATH}\capa-rules.zip" -match "Source" -check "Zip archive data"
 if ($status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\capa-rules.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\capa-rules.zip" -o"${TOOLS}" | Out-Null
     if (Test-Path "${TOOLS}\capa-rules") {
         Remove-Item "${TOOLS}\capa-rules" -Recurse -Force
     }
@@ -2206,7 +2206,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\pwsh") {
         Remove-Item "${TOOLS}\pwsh" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\pwsh.zip" -o"${TOOLS}\pwsh" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\pwsh.zip" -o"${TOOLS}\pwsh" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -2323,7 +2323,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\floss") {
         Remove-Item "${TOOLS}\floss" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\floss.zip" -o"${TOOLS}\floss" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\floss.zip" -o"${TOOLS}\floss" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -2364,7 +2364,7 @@ $TOOL_DEFINITIONS += @{
 # Flare-Fakenet-NG
 $status = Get-GitHubRelease -repo "mandiant/flare-fakenet-ng" -path "${SETUP_PATH}\fakenet.zip" -match "fakenet" -check "Zip archive data"
 if ($status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\fakenet.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\fakenet.zip" -o"${TOOLS}" | Out-Null
     if (Test-Path "${TOOLS}\fakenet") {
         Remove-Item "${TOOLS}\fakenet" -Recurse -Force
     }
@@ -2412,7 +2412,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\GoReSym") {
         Remove-Item "${TOOLS}\GoReSym" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\GoReSym.zip" -o"${TOOLS}\GoReSym" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\GoReSym.zip" -o"${TOOLS}\GoReSym" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -2456,7 +2456,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\mmdbinspect") {
         Remove-Item "${TOOLS}\mmdbinspect" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\mmdbinspect.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\mmdbinspect.zip" -o"${TOOLS}" | Out-Null
     Move-Item "${TOOLS}\mmdbinspect_*" "${TOOLS}\mmdbinspect"
 }
 
@@ -2498,7 +2498,7 @@ $TOOL_DEFINITIONS += @{
 # Elfparser-ng
 $status = Get-GitHubRelease -repo "mentebinaria/elfparser-ng" -path "${SETUP_PATH}\elfparser-ng.zip" -match "win64" -check "Zip archive data"
 if ($status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\elfparser-ng.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\elfparser-ng.zip" -o"${TOOLS}" | Out-Null
     if (Test-Path "${TOOLS}\elfparser-ng") {
         Remove-Item "${TOOLS}\elfparser-ng" -Recurse -Force
     }
@@ -2543,7 +2543,7 @@ $TOOL_DEFINITIONS += @{
 # readpe
 $status = Get-GitHubRelease -repo "mentebinaria/readpe" -path "${SETUP_PATH}\readpe.zip" -match "win.zip" -check "Zip archive data"
 if ($status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\readpe.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\readpe.zip" -o"${TOOLS}" | Out-Null
     if (Test-Path "${TOOLS}\pev") {
         Remove-Item "${TOOLS}\pev" -Recurse -Force
     }
@@ -2583,7 +2583,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\DitExplorer") {
         Remove-Item "${TOOLS}\DitExplorer" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\DitExplorer.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\DitExplorer.zip" -o"${TOOLS}" | Out-Null
     Move-Item ${TOOLS}\DitExplorer-* "${TOOLS}\DitExplorer"
 }
 
@@ -2686,8 +2686,8 @@ $TOOL_DEFINITIONS += @{
 # jwt-cli
 $status = Get-GitHubRelease -repo "mike-engel/jwt-cli" -path "${SETUP_PATH}\jwt-cli.tar.gz" -match "jwt-windows.tar.gz"
 if ($status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\jwt-cli.tar.gz" -o"${TOOLS}\bin" | Out-Null
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${TOOLS}\bin\jwt-cli.tar" -o"${TOOLS}\bin" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\jwt-cli.tar.gz" -o"${TOOLS}\bin" | Out-Null
+    & $SEVENZIP x -aoa "${TOOLS}\bin\jwt-cli.tar" -o"${TOOLS}\bin" | Out-Null
     if (Test-Path "${TOOLS}\bin\jwt-cli.tar") {
         Remove-Item "${TOOLS}\bin\jwt-cli.tar" -Force
     }
@@ -2717,7 +2717,7 @@ $TOOL_DEFINITIONS += @{
 # dsq
 $status = Get-GitHubRelease -repo "multiprocessio/dsq" -path "${SETUP_PATH}\dsq.zip" -match "dsq-win" -check "Zip archive data"
 if ($status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\dsq.zip" -o"${TOOLS}\bin" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\dsq.zip" -o"${TOOLS}\bin" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -3102,7 +3102,7 @@ $TOOL_DEFINITIONS += @{
 # qpdf
 $status = Get-GitHubRelease -repo "qpdf/qpdf" -path "${SETUP_PATH}\qpdf.zip" -match "msvc64.zip" -check "Zip archive data"
 if ($status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\qpdf.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\qpdf.zip" -o"${TOOLS}" | Out-Null
     if (Test-Path "${TOOLS}\qpdf") {
         Remove-Item "${TOOLS}\qpdf" -Recurse -Force
     }
@@ -3187,7 +3187,7 @@ $TOOL_DEFINITIONS += @{
 # Radare2
 $radare_status = Get-GitHubRelease -repo "radareorg/radare2" -path "${SETUP_PATH}\radare2.zip" -match "w64.zip" -check "Zip archive data"
 if ($radare_status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\radare2.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\radare2.zip" -o"${TOOLS}" | Out-Null
     if (Test-Path "${TOOLS}\radare2") {
         Remove-Item "${TOOLS}\radare2" -Recurse -Force
     }
@@ -3233,7 +3233,7 @@ $TOOL_DEFINITIONS += @{
 # TODO: Not working
 $status = Get-GitHubRelease -repo "radareorg/radare2-mcp" -path "${SETUP_PATH}\r2mcp.zip" -match "windows.zip" -check "Zip archive data"
 if ($status -or $radare_status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\r2mcp.zip" -o"${TOOLS}\radare2\bin" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\r2mcp.zip" -o"${TOOLS}\radare2\bin" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -3261,7 +3261,7 @@ $TOOL_DEFINITIONS += @{
 # TODO: Not working
 $status = Get-GitHubRelease -repo "radareorg/r2ai" -path "${SETUP_PATH}\r2ai.zip" -match "windows-latest" -check "Zip archive data"
 if ($status -or $radare_status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\r2ai.zip" -o"${TOOLS}\r2ai" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\r2ai.zip" -o"${TOOLS}\r2ai" | Out-Null
     Copy-Item "${TOOLS}\r2ai\decai.r2.js" "${TOOLS}\radare2\share\scripts\"
     Copy-Item "${TOOLS}\r2ai\libr2ai.dll" "${TOOLS}\radare2\bin\"
     Copy-Item "${TOOLS}\r2ai\r2ai.exe" "${TOOLS}\radare2\bin\"
@@ -3295,7 +3295,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\iaito") {
         Remove-Item "${TOOLS}\iaito" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\iaito.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\iaito.zip" -o"${TOOLS}" | Out-Null
     if (Test-Path "${TOOLS}\__MACOSX") {
         Remove-Item "${TOOLS}\__MACOSX" -Recurse -Force
     }
@@ -3342,7 +3342,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\hfs") {
         Remove-Item "${TOOLS}\hfs" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\hfs.zip" -o"${TOOLS}\hfs" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\hfs.zip" -o"${TOOLS}\hfs" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -3387,7 +3387,7 @@ if (Test-ToolIncluded -ToolName "obsidian-mitre-attack") {
         if (Test-Path "${TOOLS}\obsidian-mitre-attack") {
             Remove-Item "${TOOLS}\obsidian-mitre-attack" -Recurse -Force
         }
-        & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\obsidian-mitre-attack.zip" -o"${TOOLS}" | Out-Null
+        & $SEVENZIP x -aoa "${SETUP_PATH}\obsidian-mitre-attack.zip" -o"${TOOLS}" | Out-Null
         Move-Item "${TOOLS}\MITRE" "${TOOLS}\obsidian-mitre-attack"
         Remove-Item "${TOOLS}\README.md" -Force
     }
@@ -3418,7 +3418,7 @@ $TOOL_DEFINITIONS += @{
 if (Test-ToolIncluded -ToolName "Cutter") {
     $status = Get-GitHubRelease -repo "rizinorg/cutter" -path "${SETUP_PATH}\cutter.zip" -match "Windows-x86_64.zip" -check "Zip archive data"
     if ($status) {
-        & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\cutter.zip" -o"${TOOLS}" | Out-Null
+        & $SEVENZIP x -aoa "${SETUP_PATH}\cutter.zip" -o"${TOOLS}" | Out-Null
         if (Test-Path "${TOOLS}\cutter") {
             Remove-Item "${TOOLS}\cutter" -Recurse -Force
         }
@@ -3504,7 +3504,7 @@ if (Test-ToolIncluded -ToolName "Strawberry Perl") {
         if (Test-Path "${TOOLS}\perl") {
             Remove-Item "${TOOLS}\perl" -Recurse -Force
         }
-        & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\perl.zip" -o"${TOOLS}\perl" | Out-Null
+        & $SEVENZIP x -aoa "${SETUP_PATH}\perl.zip" -o"${TOOLS}\perl" | Out-Null
     }
 }
 
@@ -3607,7 +3607,7 @@ $TOOL_DEFINITIONS += @{
 # Sleuthkit
 $status = Get-GitHubRelease -repo "sleuthkit/sleuthkit" -path "${SETUP_PATH}\sleuthkit.zip" -match "win32.zip$" -check "Zip archive data"
 if ($status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\sleuthkit.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\sleuthkit.zip" -o"${TOOLS}" | Out-Null
     if (Test-Path "${TOOLS}\sleuthkit") {
         Remove-Item "${TOOLS}\sleuthkit" -Recurse -Force
     }
@@ -3652,7 +3652,7 @@ $TOOL_DEFINITIONS += @{
 # qrtool
 $status = Get-GitHubRelease -repo "sorairolake/qrtool" -path "${SETUP_PATH}\qrtool.zip" -match "x86_64-pc-windows-msvc" -check "Zip archive data"
 if ($status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\qrtool.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\qrtool.zip" -o"${TOOLS}" | Out-Null
     if (Test-Path "${TOOLS}\qrtool") {
         Remove-Item "${TOOLS}\qrtool" -Recurse -Force
     }
@@ -3689,7 +3689,7 @@ $TOOL_DEFINITIONS += @{
 # debloat
 $status = Get-GitHubRelease -repo "Squiblydoo/debloat" -path "${SETUP_PATH}\debloat.zip" -match "Windows" -check "Zip archive data"
 if ($status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\debloat.zip" -o"${TOOLS}\bin" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\debloat.zip" -o"${TOOLS}\bin" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -3733,7 +3733,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\thumbcacheviewer") {
         Remove-Item "${TOOLS}\thumbcacheviewer" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\thumbcacheviewer.zip" -o"${TOOLS}\thumbcacheviewer" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\thumbcacheviewer.zip" -o"${TOOLS}\thumbcacheviewer" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -3774,7 +3774,7 @@ $TOOL_DEFINITIONS += @{
 # gron
 $status = Get-GitHubRelease -repo "tomnomnom/gron" -path "${SETUP_PATH}\gron.zip" -match "gron-windows-amd64" -check "Zip archive data"
 if ($status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\gron.zip" -o"${TOOLS}\bin" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\gron.zip" -o"${TOOLS}\bin" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -3818,7 +3818,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\MemProcFS") {
         Remove-Item "${TOOLS}\MemProcFS" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\memprocfs.zip" -o"${TOOLS}\MemProcFS" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\memprocfs.zip" -o"${TOOLS}\MemProcFS" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -3859,7 +3859,7 @@ $TOOL_DEFINITIONS += @{
 # upx
 $status = Get-GitHubRelease -repo "upx/upx" -path "${SETUP_PATH}\upx.zip" -match "win64" -check "Zip archive data"
 if ($status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\upx.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\upx.zip" -o"${TOOLS}" | Out-Null
     if (Test-Path "${TOOLS}\upx") {
         Remove-Item "${TOOLS}\upx" -Recurse -Force
     }
@@ -3947,7 +3947,7 @@ $TOOL_DEFINITIONS += @{
 # Witr
 $status = Get-GitHubRelease -repo "pranshuparmar/witr" -path "${SETUP_PATH}\witr.zip" -match "witr-windows-amd64.zip" -check "Zip archive data"
 if ($status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\witr.zip" "witr.exe" -o"${TOOLS}\bin" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\witr.zip" "witr.exe" -o"${TOOLS}\bin" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -3974,7 +3974,7 @@ $TOOL_DEFINITIONS += @{
 # fq
 $status = Get-GitHubRelease -repo "wader/fq" -path "${SETUP_PATH}\fq.zip" -match "windows_amd64.zip" -check "Zip archive data"
 if ($status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\fq.zip" -o"${TOOLS}\bin" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\fq.zip" -o"${TOOLS}\bin" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -4058,7 +4058,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\imhex") {
         Remove-Item "${TOOLS}\imhex" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\imhex.zip" -o"${TOOLS}\imhex" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\imhex.zip" -o"${TOOLS}\imhex" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -4107,7 +4107,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\chainsaw") {
         Remove-Item "${TOOLS}\chainsaw" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\chainsaw.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\chainsaw.zip" -o"${TOOLS}" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -4148,7 +4148,7 @@ $TOOL_DEFINITIONS += @{
 # yara
 $status = Get-GitHubRelease -repo "VirusTotal/yara" -path "${SETUP_PATH}\yara.zip" -match "win64" -check "Zip archive data"
 if ($status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\yara.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\yara.zip" -o"${TOOLS}" | Out-Null
     if (Test-Path "${TOOLS}\bin\yara.exe") {
         Remove-Item "${TOOLS}\bin\yara.exe" -Force
     }
@@ -4212,7 +4212,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\bin\yr.exe") {
         Remove-Item "${TOOLS}\bin\yr.exe" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\yara-x.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\yara-x.zip" -o"${TOOLS}" | Out-Null
     Move-Item ${TOOLS}\yr.exe ${TOOLS}\bin\yr.exe
 }
 
@@ -4336,7 +4336,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\hayabusa") {
         Remove-Item "${TOOLS}\hayabusa" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\hayabusa.zip" -o"${TOOLS}\hayabusa" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\hayabusa.zip" -o"${TOOLS}\hayabusa" | Out-Null
     Move-Item ${TOOLS}\hayabusa\hayabusa-* ${TOOLS}\hayabusa\hayabusa.exe
 }
 
@@ -4381,7 +4381,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\takajo") {
         Remove-Item "${TOOLS}\takajo" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\takajo.zip" -o"${TOOLS}\takajo" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\takajo.zip" -o"${TOOLS}\takajo" | Out-Null
     Move-Item ${TOOLS}\takajo\takajo-* "${TOOLS}\takajo\takajo.exe"
 }
 
@@ -4466,7 +4466,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\edit") {
         Remove-Item "${TOOLS}\edit" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\edit.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\edit.zip" -o"${TOOLS}" | Out-Null
     Move-Item ${TOOLS}\edit-* ${TOOLS}\edit
     Copy-Item "${TOOLS}\edit\edit.exe" "${TOOLS}\bin\edit.exe"
 }
@@ -4498,7 +4498,7 @@ if ($status) {
     if (Test-Path -Path "${TOOLS}\DB Browser for SQLite") {
         Remove-Item -Recurse -Force "${TOOLS}\DB Browser for SQLite" | Out-Null 2>&1
     }
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\sqlitebrowser.zip" -o"${TOOLS}\sqlitebrowser" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\sqlitebrowser.zip" -o"${TOOLS}\sqlitebrowser" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -4542,7 +4542,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\NetExt") {
         Remove-Item "${TOOLS}\NetExt" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\netext.zip" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\netext.zip" -o"${TOOLS}" | Out-Null
     Move-Item ${TOOLS}\NetExt-* "${TOOLS}\NetExt"
 }
 
@@ -4574,7 +4574,7 @@ if (Test-ToolIncluded -ToolName "YAMAGoya") {
         if (Test-Path "${TOOLS}\YAMAGoya") {
             Remove-Item "${TOOLS}\YAMAGoya" -Recurse -Force
         }
-        & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\YAMAGoya.zip" -o"${TOOLS}\YAMAGoya" | Out-Null
+        & $SEVENZIP x -aoa "${SETUP_PATH}\YAMAGoya.zip" -o"${TOOLS}\YAMAGoya" | Out-Null
     }
 }
 
@@ -4613,7 +4613,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\RpcView") {
         Remove-Item "${TOOLS}\RpcView" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\rpcview.7z" -o"${TOOLS}" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\rpcview.7z" -o"${TOOLS}" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -4654,7 +4654,7 @@ $TOOL_DEFINITIONS += @{
 # go-size-analyzer
 $status = Get-GitHubRelease -repo "Zxilly/go-size-analyzer" -path "${SETUP_PATH}\go-size-analyzer.zip" -match "go-size-analyzer_.*_windows_amd64.zip" -check "Zip archive data"
 if ($status) {
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\go-size-analyzer.zip" -o"${TOOLS}\bin\" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\go-size-analyzer.zip" -o"${TOOLS}\bin\" | Out-Null
     Remove-Item "${TOOLS}\bin\LICENSE" -Force -ErrorAction SilentlyContinue
     Remove-Item "${TOOLS}\bin\README.md" -Force -ErrorAction SilentlyContinue
     Remove-Item "${TOOLS}\bin\README_zh_CN.md" -Force -ErrorAction SilentlyContinue
@@ -4701,7 +4701,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\ILSpy") {
         Remove-Item "${TOOLS}\ILSpy" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\ilspy.zip" -o"${TOOLS}\ILSpy" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\ilspy.zip" -o"${TOOLS}\ILSpy" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -4745,7 +4745,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\ULogViewer") {
         Remove-Item "${TOOLS}\ULogViewer" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\ULogViewer.zip" -o"${TOOLS}\ULogViewer" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\ULogViewer.zip" -o"${TOOLS}\ULogViewer" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{
@@ -4789,7 +4789,7 @@ if ($status) {
     if (Test-Path "${TOOLS}\Dependencies") {
         Remove-Item "${TOOLS}\Dependencies" -Recurse -Force
     }
-    & "$env:ProgramFiles\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\Dependencies.zip" -o"${TOOLS}\Dependencies" | Out-Null
+    & $SEVENZIP x -aoa "${SETUP_PATH}\Dependencies.zip" -o"${TOOLS}\Dependencies" | Out-Null
 }
 
 $TOOL_DEFINITIONS += @{

--- a/resources/download/winget.ps1
+++ b/resources/download/winget.ps1
@@ -411,7 +411,7 @@ if (Test-ToolIncluded -ToolName "VirusTotal CLI") {
     Write-SynchronizedLog "winget: Downloading VirusTotal CLI."
     $status = Get-WinGet "VirusTotal.vt-cli" "vt-cli*.zip" "vt.zip" -check "Zip archive data"
     if ($status) {
-        & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa ".\downloads\vt.zip" -o"${TOOLS}\bin" | Out-Null
+        & $SEVENZIP x -aoa ".\downloads\vt.zip" -o"${TOOLS}\bin" | Out-Null
     }
 }
 

--- a/resources/vm/copy_files_to_vm.ps1
+++ b/resources/vm/copy_files_to_vm.ps1
@@ -27,11 +27,11 @@ Copy-Item -Recurse -Force ".\enrichment" "${WSDFIR_ROOT}"
 Write-Output "Copying local to the root directory..."
 Copy-Item -Recurse -Force ".\local" "${WSDFIR_ROOT}"
 Write-Output "Extracting git.zip to the root directory..."
-& "${env:ProgramFiles}\7-Zip\7z.exe" x -o"${WSDFIR_ROOT}" ".\tmp\git.zip" | Out-Null
+& $SEVENZIP x -o"${WSDFIR_ROOT}" ".\tmp\git.zip" | Out-Null
 Write-Output "Extracting Tools.zip to the root directory..."
-& "${env:ProgramFiles}\7-Zip\7z.exe" x -o"${WSDFIR_ROOT}" ".\tmp\tools.zip" | Out-Null
+& $SEVENZIP x -o"${WSDFIR_ROOT}" ".\tmp\tools.zip" | Out-Null
 Write-Output "Extracting venv.zip to the root directory..."
-& "${env:ProgramFiles}\7-Zip\7z.exe" x -o"${WSDFIR_ROOT}" ".\tmp\venv.zip" | Out-Null
+& $SEVENZIP x -o"${WSDFIR_ROOT}" ".\tmp\venv.zip" | Out-Null
 
 if (-not (Test-Path -Path "${HOME}\Documents\tools")) {
     New-Item -ItemType Directory -Force -Path "${HOME}\Documents\tools" | Out-Null

--- a/resources/vm/prepare_zip_files.ps1
+++ b/resources/vm/prepare_zip_files.ps1
@@ -2,6 +2,14 @@ if (!(Test-Path -Path ".\tmp")) {
     New-Item -ItemType Directory -Path ".\tmp" -Force | Out-Null
 }
 
+# Resolve 7-Zip path: check PATH first, then common install locations
+if (Get-Command "7z.exe" -ErrorAction SilentlyContinue) {
+    $SEVENZIP = "7z.exe"
+} else {
+    $SEVENZIP = @("${env:ProgramFiles}\7-Zip\7z.exe", "${env:ProgramFiles(x86)}\7-Zip\7z.exe") |
+        Where-Object { Test-Path $_ } | Select-Object -First 1
+}
+
 Write-Output "Creating zip for git"
 
 foreach ($zip in ("git.zip", "tools.zip", "venv.zip")) {
@@ -11,10 +19,10 @@ foreach ($zip in ("git.zip", "tools.zip", "venv.zip")) {
 }
 
 Set-Location ".\mount"
-& "${env:ProgramFiles}\7-Zip\7z.exe" a "..\tmp\git.zip" "git" | Out-Null
+& $SEVENZIP a "..\tmp\git.zip" "git" | Out-Null
 Write-Output "Creating zip for Tools"
-& "${env:ProgramFiles}\7-Zip\7z.exe" a "..\tmp\tools.zip" "Tools" | Out-Null
+& $SEVENZIP a "..\tmp\tools.zip" "Tools" | Out-Null
 Write-Output "Creating zip for venv"
-& "${env:ProgramFiles}\7-Zip\7z.exe" a "..\tmp\venv.zip" "venv" | Out-Null
+& $SEVENZIP a "..\tmp\venv.zip" "venv" | Out-Null
 Set-Location ".."
 Write-Output "Creating zip done"

--- a/resources/vm/scripts/vm-guest-tools.ps1
+++ b/resources/vm/scripts/vm-guest-tools.ps1
@@ -18,7 +18,12 @@ if (!(Test-Path $vmwareToolsIso)) {
 }
 
 Write-Output "Extract VMware Tools ISO"
-& "C:\Program Files\7-Zip\7z.exe" x "$vmwareToolsIso" -o"C:\Windows\Temp\VMWare" | Out-Null
+if (Get-Command "7z.exe" -ErrorAction SilentlyContinue) {
+    $SEVENZIP = "7z.exe"
+} else {
+    $SEVENZIP = "C:\Program Files\7-Zip\7z.exe"
+}
+& $SEVENZIP x "$vmwareToolsIso" -o"C:\Windows\Temp\VMWare" | Out-Null
 
 Write-Output "Install VMware Tools"
 Start-Process -Wait "C:\Windows\Temp\VMWare\setup.exe" -ArgumentList '/S /v "/qn REBOOT=R"'

--- a/setup/install/install_node.ps1
+++ b/setup/install/install_node.ps1
@@ -22,7 +22,7 @@ Write-Output "PowerShell.exe -ExecutionPolicy Bypass -File C:\Progress.ps1" | Ou
 
 # Update path
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User") + ";C:\Tools\node"
-&"${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\nodejs.zip" -o"${TOOLS}\node" 2>&1 | ForEach-Object{ "$_" } >> "C:\log\npm.txt"
+&$SEVENZIP x -aoa "${SETUP_PATH}\nodejs.zip" -o"${TOOLS}\node" 2>&1 | ForEach-Object{ "$_" } >> "C:\log\npm.txt"
 Set-Location "${TOOLS}\node\node-*"
 Move-Item * ..
 

--- a/setup/start_sandbox.ps1
+++ b/setup/start_sandbox.ps1
@@ -620,7 +620,7 @@ if (Test-Path "C:\venv\iocs\mvt") {
 
 # 4n4lDetector
 if (Test-Path "${SETUP_PATH}\4n4lDetector.zip") {
-    & "${env:ProgramFiles}\7-Zip\7z.exe" x "${SETUP_PATH}\4n4lDetector.zip" -o"${env:ProgramFiles}\4n4lDetector" | Out-Null
+    & $SEVENZIP x "${SETUP_PATH}\4n4lDetector.zip" -o"${env:ProgramFiles}\4n4lDetector" | Out-Null
 }
 
 # Config for opencode-ai MCP servers

--- a/setup/utils/ghidrathon.ps1
+++ b/setup/utils/ghidrathon.ps1
@@ -14,7 +14,7 @@ $LATEST_GHIDRA_RELEASE = (Get-ChildItem C:\Tools\ghidra\).Name | findstr.exe PUB
 $LATEST_GHIDRATHON = (Get-ChildItem C:\Tools\ghidra_extensions\).FullName | findstr.exe Ghidrathon | Select-Object -Last 1
 
 if (!(Test-Path -Path "${HOME}\.ghidra\.${LATEST_GHIDRA_RELEASE}\Extensions\ghidrathon")) {
-    & "$env:programfiles\7-Zip\7z.exe" x -o"${HOME}\.ghidra\.${LATEST_GHIDRA_RELEASE}\Extensions" "${LATEST_GHIDRATHON}" | Out-Null
+    & $SEVENZIP x -o"${HOME}\.ghidra\.${LATEST_GHIDRA_RELEASE}\Extensions" "${LATEST_GHIDRATHON}" | Out-Null
 }
 
 & "${TOOLS}\ghidra\${LATEST_GHIDRA_RELEASE}\ghidraRun.bat"

--- a/setup/wscommon.ps1
+++ b/setup/wscommon.ps1
@@ -20,6 +20,15 @@ $null="${MSYS2_DIR}"
 $null="${RUST_DIR}"
 $null="${WSDFIR_TEMP}"
 
+# Resolve 7-Zip path: check PATH first, then common install locations
+if (Get-Command "7z.exe" -ErrorAction SilentlyContinue) {
+    $SEVENZIP = "7z.exe"
+} else {
+    $SEVENZIP = @("${env:ProgramFiles}\7-Zip\7z.exe", "${env:ProgramFiles(x86)}\7-Zip\7z.exe") |
+        Where-Object { Test-Path $_ } | Select-Object -First 1
+}
+$null = $SEVENZIP
+
 # Check if C:\log exists, indicating running downloadFiles.ps1
 # Fix DNS servers if needed
 if (Test-Path -Path "C:\log") {
@@ -521,7 +530,7 @@ function Install-ClamAV {
 function Install-CMDer {
     if (!(Test-Path "${env:ProgramFiles}\dfirws\installed-cmder.txt")) {
         Write-Output "Installing Cmder"
-        & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\cmder.7z" -o"${env:ProgramFiles}\cmder" | Out-Null
+        & $SEVENZIP x -aoa "${SETUP_PATH}\cmder.7z" -o"${env:ProgramFiles}\cmder" | Out-Null
         Add-ToUserPath "${env:ProgramFiles}\cmder"
         Add-ToUserPath "${env:ProgramFiles}\cmder\bin"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\cmder.lnk" -DestinationPath "${env:ProgramFiles}\cmder\cmder.exe" -WorkingDirectory "${HOME}\Desktop"
@@ -636,7 +645,7 @@ function Install-ForensicTimeliner {
         $CLI_TOOL = "${TERMINAL_INSTALL_LOCATION}\wt.exe"
         $CLI_TOOL_ARGS = "-w 0 C:\Program Files\PowerShell\7\pwsh.exe -NoExit"
 
-        & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\ForensicTimeliner.zip" -o"${env:ProgramFiles}" | Out-Null
+        & $SEVENZIP x -aoa "${SETUP_PATH}\ForensicTimeliner.zip" -o"${env:ProgramFiles}" | Out-Null
         Move-Item ${env:ProgramFiles}\ForensicTimeliner* "${env:ProgramFiles}\ForensicTimeliner" -Force
         if (Test-Path "${HOME}\Desktop\dfirws\IR\Forensic Timeliner (runs dfirws-install -ForensicTimeliner).lnk") {
             Remove-Item "${HOME}\Desktop\dfirws\IR\Forensic Timeliner (runs dfirws-install -ForensicTimeliner).lnk" -Force
@@ -778,7 +787,7 @@ function Install-Hashcat {
 function Install-Jadx {
     if (!(Test-Path "${env:ProgramFiles}\dfirws\installed-jadx.txt")) {
         Write-Output "Installing Jadx"
-        & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\jadx.zip" -o"${env:ProgramFiles}\jadx" | Out-Null
+        & $SEVENZIP x -aoa "${SETUP_PATH}\jadx.zip" -o"${env:ProgramFiles}\jadx" | Out-Null
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Programming\Java\jadx-gui.lnk" -DestinationPath "${env:ProgramFiles}\jadx\bin\jadx-gui.bat"
         if (Test-Path "${HOME}\Desktop\dfirws\Programming\Java\Jadx (runs dfirws-install -Jadx).lnk") {
             Remove-Item "${HOME}\Desktop\dfirws\Programming\Java\Jadx (runs dfirws-install -Jadx).lnk" -Force
@@ -870,7 +879,7 @@ function Install-LogBoost {
 function Install-Loki {
     if (!(Test-Path "${env:ProgramFiles}\dfirws\installed-loki.txt")) {
         Write-Output "Installing Loki"
-        & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\loki.zip" -o"${env:ProgramFiles}\" | Out-Null
+        & $SEVENZIP x -aoa "${SETUP_PATH}\loki.zip" -o"${env:ProgramFiles}\" | Out-Null
         Copy-Item ${GIT_PATH}\signature-base "${env:ProgramFiles}\loki" -Recurse -Force
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Signatures and information\loki.lnk" -DestinationPath "${env:ProgramFiles}\loki\loki.exe"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\loki.lnk" -DestinationPath "${env:ProgramFiles}\loki\loki.exe"
@@ -889,7 +898,7 @@ function Install-Loki {
 function Install-Malcat {
     if (!(Test-Path "${env:ProgramFiles}\dfirws\installed-malcat.txt")) {
         Write-Output "Installing Malcat"
-        & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\malcat.zip" -o"${env:ProgramFiles}\malcat" | Out-Null
+        & $SEVENZIP x -aoa "${SETUP_PATH}\malcat.zip" -o"${env:ProgramFiles}\malcat" | Out-Null
         Add-ToUserPath "${env:ProgramFiles}\malcat\bin"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-malcat.txt" | Out-Null
     } else {
@@ -904,7 +913,7 @@ function Install-Neo4j {
         Add-ToUserPath "C:\Windows\System32\WindowsPowerShell\v1.0"
         $env:Path = "C:\Windows\System32\WindowsPowerShell\v1.0;${NEO_JAVA}\bin;" + [System.Environment]::GetEnvironmentVariable("Path", "User") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "Machine")
         Start-Process -Wait msiexec -ArgumentList "/i ${SETUP_PATH}\microsoft-jdk-11.msi ADDLOCAL=FeatureMain,FeatureEnvironment,FeatureJarFileRunWith,FeatureJavaHome INSTALLDIR=$NEO_JAVA /qn /norestart"
-        & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\neo4j.zip" -o"${env:ProgramFiles}" | Out-Null
+        & $SEVENZIP x -aoa "${SETUP_PATH}\neo4j.zip" -o"${env:ProgramFiles}" | Out-Null
         Move-Item ${env:ProgramFiles}\neo4j-community* ${env:ProgramFiles}\neo4j
         $env:JAVA_HOME = "$NEO_JAVA"
         & "${env:ProgramFiles}\neo4j\bin\neo4j-admin" set-initial-password neo4j
@@ -1355,7 +1364,7 @@ function Install-Wireshark {
 function Install-X64dbg {
     if (!(Test-Path "${env:ProgramFiles}\dfirws\installed-x64dbg.txt")) {
         Write-Output "Installing x64dbg"
-        & "${env:ProgramFiles}\7-Zip\7z.exe" x -aoa "${SETUP_PATH}\x64dbg.zip" -o"${env:ProgramFiles}\x64dbg" | Out-Null
+        & $SEVENZIP x -aoa "${SETUP_PATH}\x64dbg.zip" -o"${env:ProgramFiles}\x64dbg" | Out-Null
         Add-ToUserPath "${env:ProgramFiles}\x64dbg\release\x32"
         Add-ToUserPath "${env:ProgramFiles}\x64dbg\release\x64"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Reverse Engineering\x32dbg.lnk" -DestinationPath "${env:ProgramFiles}\x64dbg\release\x32\x32dbg.exe"


### PR DESCRIPTION
Add $SEVENZIP variable in common.ps1 and wscommon.ps1 that resolves
the 7z.exe path by checking PATH first, then falling back to the
default Program Files install locations. Replace all hardcoded
"${env:ProgramFiles}\7-Zip\7z.exe" references across 19 scripts with
$SEVENZIP so that installations in non-default locations are supported.

https://claude.ai/code/session_01RppkHXSsCaFaTSpBqELLqk