### PR TITLE
Re-resolve \$SEVENZIP in start_sandbox.ps1 after 7-Zip is installed

### DIFF
--- a/setup/start_sandbox.ps1
+++ b/setup/start_sandbox.ps1
@@ -50,6 +50,14 @@ if ($proc7zip.ExitCode -ne 0) {
 }
 Write-DateLog "7-Zip installed" | Write-SetupLog
 
+# Re-resolve $SEVENZIP now that 7-Zip is installed
+if (Get-Command "7z.exe" -ErrorAction SilentlyContinue) {
+    $SEVENZIP = "7z.exe"
+} else {
+    $SEVENZIP = @("${env:ProgramFiles}\7-Zip\7z.exe", "${env:ProgramFiles(x86)}\7-Zip\7z.exe") |
+        Where-Object { Test-Path $_ } | Select-Object -First 1
+}
+
 # Install PSDecode module - https://github.com/R3MRUM/PSDecode
 Copy-Item "${HOME}\Documents\tools\utils\PSDecode.psm1" "${env:ProgramFiles}\PowerShell\Modules\PSDecode" -Force | Out-Null
 


### PR DESCRIPTION
wscommon.ps1 sets \$SEVENZIP at load time, before 7-Zip is installed by the MSI on line 47. Re-resolve the variable immediately after installation so subsequent uses (e.g. 4n4lDetector) find the binary.

https://claude.ai/code/session_01RppkHXSsCaFaTSpBqELLqk