### PR TITLE
Fix FQLite installation by extracting MSI from bootstrapper

### DIFF
--- a/setup/wscommon.ps1
+++ b/setup/wscommon.ps1
@@ -681,7 +681,24 @@ function Install-FoxitReader {
 function Install-FQLite {
     if (!(Test-Path "${env:ProgramFiles}\dfirws\installed-fqlite.txt")) {
         Write-Output "Installing FQLite"
-        Start-Process -Wait "${SETUP_PATH}\fqlite.exe" -ArgumentList '/qn /norestart'
+        # fqlite.exe is a jpackage/WiX-Burn wrapper around an MSI. Running the EXE
+        # directly hits a Defender vs. MoveFileEx race when the bootstrapper renames
+        # its extracted payload to main.msi (System error 32). Extract the embedded
+        # MSI with 7-Zip and install it via msiexec to bypass the bootstrapper.
+        $fqliteExtract = "${WSDFIR_TEMP}\fqlite-extract"
+        if (Test-Path $fqliteExtract) {
+            Remove-Item -Recurse -Force $fqliteExtract | Out-Null
+        }
+        & $SEVENZIP x -aoa "${SETUP_PATH}\fqlite.exe" -o"$fqliteExtract" | Out-Null
+        $fqliteMsi = Get-ChildItem -Path $fqliteExtract -Recurse -Filter "*.msi" -ErrorAction SilentlyContinue |
+            Sort-Object Length -Descending | Select-Object -First 1
+        if ($fqliteMsi) {
+            Start-Process -Wait msiexec -ArgumentList "/i `"$($fqliteMsi.FullName)`" /qn /norestart"
+        } else {
+            Write-Output "WARNING: Could not extract MSI from fqlite.exe; falling back to bootstrapper."
+            Start-Process -Wait "${SETUP_PATH}\fqlite.exe" -ArgumentList '/quiet'
+        }
+        Remove-Item -Recurse -Force $fqliteExtract -ErrorAction SilentlyContinue | Out-Null
         if (Test-Path "${HOME}\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Unknown\fqlite.lnk") {
             Copy-Item "${HOME}\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Unknown\fqlite.lnk" "${HOME}\Desktop\dfirws\Files and apps\Database\fqlite.lnk" -Force
             Copy-Item "${HOME}\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Unknown\fqlite.lnk" "${HOME}\Desktop\fqlite.lnk" -Force


### PR DESCRIPTION
## Summary
Modified the FQLite installation process to extract and install the embedded MSI directly instead of running the bootstrapper executable, resolving a race condition with Windows Defender during the installation.

## Key Changes
- Replaced direct execution of `fqlite.exe` bootstrapper with a two-step process:
  - Extract the embedded MSI from the bootstrapper using 7-Zip
  - Install the MSI directly via `msiexec`
- Added fallback logic to use the original bootstrapper if MSI extraction fails
- Implemented proper cleanup of temporary extraction directory
- Added detailed comments explaining the Defender vs. MoveFileEx race condition that necessitated this change

## Implementation Details
- Uses 7-Zip to extract the bootstrapper with `-aoa` (overwrite all) flag
- Searches for the largest `.msi` file in the extracted contents to identify the main installer
- Includes error handling with `SilentlyContinue` for extraction operations
- Cleans up temporary files even if extraction fails
- Maintains backward compatibility with a warning message if extraction is unsuccessful

https://claude.ai/code/session_01EHjA1uinsySauCz48CKHQz