### PR TITLE
Remove explicit exit statement from install script

### DIFF
--- a/setup/install/install_all.ps1
+++ b/setup/install/install_all.ps1
@@ -19,5 +19,3 @@ Write-SynchronizedLog "Install all tools in the sandbox completed."
 if (Test-Path -Path "${TOOLS}\Debug") {
     Read-Host "Press Enter to continue"
 }
-
-exit 0


### PR DESCRIPTION
## Summary
Removed the explicit `exit 0` statement from the installation script to allow PowerShell to exit naturally with the default exit code.

## Key Changes
- Removed the `exit 0` statement at the end of the install script
- Cleaned up trailing whitespace

## Implementation Details
The script will now rely on PowerShell's default exit behavior rather than explicitly returning exit code 0. This is a minor cleanup that simplifies the script while maintaining the same functional behavior, as PowerShell scripts exit with code 0 by default upon successful completion.

https://claude.ai/code/session_01Ai3gXqJmivSQ7kXbaEUP51