### PR TITLE
Ensure verify_done is always written and log verify-block output

### DIFF
--- a/setup/start_sandbox.ps1
+++ b/setup/start_sandbox.ps1
@@ -693,16 +693,26 @@ Set-SandboxProgressReady
 
 # If in verify mode, run install_all and install_verify scripts
 if (Test-Path "C:\log\log.txt") {
-    Write-SynchronizedLog "Running install_all.ps1 script."
-    $env:Path = [System.Environment]::GetEnvironmentVariable("Path","User")
-    & "${HOME}\Documents\tools\install\install_all.ps1" | Out-Null
-    Write-SynchronizedLog "Running install_verify.ps1 script."
-    $env:Path = [System.Environment]::GetEnvironmentVariable("Path","User")
-    & "${HOME}\Documents\tools\install\install_verify.ps1" | Out-Null
-    Get-Job | Wait-Job | Out-Null
-    Get-Job | Receive-Job 2>&1 >> ".\log\jobs.txt"
-    Get-Job | Remove-Job | Out-Null
-    Write-Output "" > "C:\log\verify_done"
+    try {
+        Write-SynchronizedLog "Running install_all.ps1 script."
+        $env:Path = [System.Environment]::GetEnvironmentVariable("Path","User")
+        & "${HOME}\Documents\tools\install\install_all.ps1" 2>&1 | ForEach-Object { Write-SynchronizedLog "install_all: $_" }
+        Write-SynchronizedLog "install_all.ps1 finished."
+        Write-SynchronizedLog "Running install_verify.ps1 script."
+        $env:Path = [System.Environment]::GetEnvironmentVariable("Path","User")
+        & "${HOME}\Documents\tools\install\install_verify.ps1" 2>&1 | ForEach-Object { Write-SynchronizedLog "install_verify: $_" }
+        Write-SynchronizedLog "install_verify.ps1 finished."
+        Get-Job | Wait-Job | Out-Null
+        Get-Job | Receive-Job 2>&1 >> "${WSDFIR_TEMP}\jobs.txt"
+        Get-Job | Remove-Job | Out-Null
+    }
+    catch {
+        Write-SynchronizedLog "ERROR in verify block: $_"
+    }
+    finally {
+        Write-SynchronizedLog "Writing verify_done signal file."
+        New-Item -ItemType File -Path "C:\log\verify_done" -Force | Out-Null
+    }
 }
 
 # Wait for all jobs to finish and clean up


### PR DESCRIPTION
Previous fix removed exit 0 from install_all.ps1 on the theory that it terminated start_sandbox.ps1. That didn't help - verify_done still wasn't being created.

Harden the verify-mode block so the signal file is written even if one of the child scripts errors out, and capture their output in verify.txt so we can see exactly how far execution got when diagnosing.

- Wrap install_all/install_verify in try/catch/finally; write verify_done from the finally block so a throw in either script no longer prevents the host from noticing completion.
- Pipe install_all and install_verify stdout/stderr into Write-SynchronizedLog (verify.txt) so the host-visible log shows each step, not just "install_all.ps1 script running".
- Use New-Item -Force for the signal file instead of Write-Output >, which surfaces errors (e.g. missing C:\log mapping) as exceptions instead of silent non-terminating failures.
- Fix the relative path ".\log\jobs.txt" to use ${WSDFIR_TEMP}\jobs.txt since start_sandbox.ps1's working directory is C:\Windows\System32, not the log folder.

https://claude.ai/code/session_01EXGwB7PoYKM5fbMzaNrTRk