### PR TITLE
Run ZAProxy installer in Start-Job to isolate from start_sandbox.ps1

### DIFF
--- a/setup/wscommon.ps1
+++ b/setup/wscommon.ps1
@@ -1483,16 +1483,26 @@ function Install-X64dbg {
 function Install-ZAProxy {
     if (!(Test-Path "${env:ProgramFiles}\dfirws\installed-zaproxy.txt")) {
         Write-Output "Installing ZAProxy"
-        Write-Output "[ZAProxy] starting installer"
-        $zapProc = Start-Process -PassThru "${SETUP_PATH}\zaproxy.exe" -ArgumentList '-q'
-        if ($zapProc) {
-            if (-not $zapProc.WaitForExit(600000)) {
-                Write-Output "[ZAProxy] installer timed out after 10 minutes, killing"
-                $zapProc | Stop-Process -Force -ErrorAction SilentlyContinue
-            } else {
-                Write-Output "[ZAProxy] installer exited with code $($zapProc.ExitCode)"
-            }
+        Write-Output "[ZAProxy] starting installer in isolated job"
+        # Run the installer in a background job so its process tree is detached
+        # from start_sandbox.ps1 - the ZAP installer has been observed to
+        # terminate its parent PowerShell, which previously killed the entire
+        # verify run before verify_done could be written.
+        $zapJob = Start-Job -Name "install-zaproxy" -ScriptBlock {
+            param($exe)
+            Start-Process -Wait $exe -ArgumentList '-q'
+        } -ArgumentList "${SETUP_PATH}\zaproxy.exe"
+
+        $completed = Wait-Job -Job $zapJob -Timeout 600
+        if (-not $completed) {
+            Write-Output "[ZAProxy] installer job timed out after 10 minutes, stopping"
+            Stop-Job -Job $zapJob -ErrorAction SilentlyContinue
+        } else {
+            Write-Output "[ZAProxy] installer job finished with state $($zapJob.State)"
         }
+        Receive-Job -Job $zapJob 2>&1 | ForEach-Object { Write-Output "[ZAProxy] $_" }
+        Remove-Job -Job $zapJob -Force -ErrorAction SilentlyContinue
+
         Write-Output "[ZAProxy] updating PATH"
         Add-ToUserPath "${env:ProgramFiles}\ZAP\Zed Attack Proxy"
         Write-Output "[ZAProxy] creating shortcut"


### PR DESCRIPTION
Logs from a verify run show start_sandbox.ps1's PowerShell process dies between "[ZAProxy] starting installer" and the WaitForExit result line, without writing verify_done. With the script previously calling Start-Process directly on zaproxy.exe, PowerShell was the immediate parent of the installer; the ZAP installer apparently terminates its parent process tree (an Install4j/UAC quirk under Windows Sandbox).

Run the installer inside Start-Job, which executes in a separate background pwsh.exe worker. If the installer kills its parent it now takes down the job worker only - start_sandbox.ps1 keeps running and the verify block's finally writes verify_done as expected.

Wait-Job has a 10 minute timeout so a hung job no longer blocks the verify run, and Receive-Job forwards installer output through the existing [ZAProxy] log prefix so step-level visibility is preserved.

https://claude.ai/code/session_01Ai3gXqJmivSQ7kXbaEUP51