### PR TITLE
Fix verify run terminating before verify_done is written

### DIFF
--- a/setup/start_sandbox.ps1
+++ b/setup/start_sandbox.ps1
@@ -708,12 +708,14 @@ if (-not (Test-Path "C:\log\verify_done")) {
     try {
         Write-SynchronizedLog "Running install_all.ps1 script."
         $env:Path = [System.Environment]::GetEnvironmentVariable("Path","User")
-        & "${HOME}\Documents\tools\install\install_all.ps1" 2>&1 | ForEach-Object { Write-SynchronizedLog "install_all: $_" }
-        Write-SynchronizedLog "install_all.ps1 finished."
+        # Run in a separate process so that any exit call in a child script
+        # only terminates that subprocess and cannot bypass this finally block.
+        $installAllProc = Start-Process -Wait -PassThru "${POWERSHELL_EXE}" -ArgumentList "-NoProfile -ExecutionPolicy Bypass -File `"${HOME}\Documents\tools\install\install_all.ps1`""
+        Write-SynchronizedLog "install_all.ps1 finished with exit code $($installAllProc.ExitCode)."
         Write-SynchronizedLog "Running install_verify.ps1 script."
         $env:Path = [System.Environment]::GetEnvironmentVariable("Path","User")
-        & "${HOME}\Documents\tools\install\install_verify.ps1" 2>&1 | ForEach-Object { Write-SynchronizedLog "install_verify: $_" }
-        Write-SynchronizedLog "install_verify.ps1 finished."
+        $installVerifyProc = Start-Process -Wait -PassThru "${POWERSHELL_EXE}" -ArgumentList "-NoProfile -ExecutionPolicy Bypass -File `"${HOME}\Documents\tools\install\install_verify.ps1`""
+        Write-SynchronizedLog "install_verify.ps1 finished with exit code $($installVerifyProc.ExitCode)."
         Get-Job | Wait-Job | Out-Null
         Get-Job | Receive-Job 2>&1 >> "${WSDFIR_TEMP}\jobs.txt"
         Get-Job | Remove-Job | Out-Null

--- a/setup/wscommon.ps1
+++ b/setup/wscommon.ps1
@@ -1488,10 +1488,10 @@ function Install-ZAProxy {
         # from start_sandbox.ps1 - the ZAP installer has been observed to
         # terminate its parent PowerShell, which previously killed the entire
         # verify run before verify_done could be written.
+        $zapExePath = "${SETUP_PATH}\zaproxy.exe"
         $zapJob = Start-Job -Name "install-zaproxy" -ScriptBlock {
-            param($exe)
-            Start-Process -Wait $exe -ArgumentList '-q'
-        } -ArgumentList "${SETUP_PATH}\zaproxy.exe"
+            Start-Process -Wait $using:zapExePath -ArgumentList '-q'
+        }
 
         $completed = Wait-Job -Job $zapJob -Timeout 600
         if (-not $completed) {


### PR DESCRIPTION
Two root causes prevented the sandbox from exiting cleanly:

1. install_all.ps1 and install_verify.ps1 were invoked via the & operator inside a pipeline in start_sandbox.ps1. Any exit call in a child script (e.g. install_yarascan.ps1 has several exit 1 calls, and the generated install_release.ps1 indirectly calls Install-ZAProxy) would terminate the entire PowerShell process, bypassing the finally block that writes verify_done. Fixed by running both scripts as separate processes via Start-Process so an exit in a child only kills that subprocess.

2. Start-Job in Install-ZAProxy used param($exe) with -ArgumentList, which PSScriptAnalyzer flags as missing the Using: scope modifier. Fixed by assigning the path to $zapExePath and referencing it as $using:zapExePath inside the script block.

https://claude.ai/code/session_01Ai3gXqJmivSQ7kXbaEUP51