### PR TITLE
Bundle Get-ZimmermanTools.ps1 locally instead of downloading

### DIFF
--- a/resources/download/Get-ZimmermanTools.ps1
+++ b/resources/download/Get-ZimmermanTools.ps1
@@ -326,10 +326,19 @@ while ($matchdetails.Success)
 	}
 	
 	$isnet6 = $newUrl.Contains('/net6/')
-	
+
 	#Write-Host $newUrl
-	
-	$headers = (Invoke-WebRequest @IWRProxyConfig -Uri $newUrl -UseBasicParsing -Method Head).Headers
+
+	try
+	{
+		$headers = (Invoke-WebRequest @IWRProxyConfig -Uri $newUrl -UseBasicParsing -Method Head -ErrorAction Stop).Headers
+	}
+	catch
+	{
+		Write-Color -Text "* ", "Skipping $newUrl ($($_.Exception.Message))" -Color Green, Red
+		$matchdetails = $matchdetails.NextMatch()
+		continue
+	}
 
 	#Write-Host $headers
 	
@@ -457,11 +466,11 @@ foreach ($td in $toDownload)
 	finally
 	{
 		$progressPreference = 'Continue'
-		if ($name.endswith("zip"))
+		if ($name.endswith("zip") -and (Test-Path -Path $destFile))
 		{
-			remove-item -Path $destFile
+			remove-item -Path $destFile -ErrorAction SilentlyContinue
 		}
-		
+
 	}
 	$i += 1
 }

--- a/resources/download/kape.ps1
+++ b/resources/download/kape.ps1
@@ -20,6 +20,7 @@ if (! (Test-Path -Path "$SETUP_PATH\KAPE" )) {
 
 $CURRENT_DIR = $PWD
 Copy-Item ".\resources\external\KAPE-EZToolsAncillaryUpdater.ps1" "$SETUP_PATH\KAPE\KAPE-EZToolsAncillaryUpdater.ps1" -Force
+Copy-Item ".\resources\download\Get-ZimmermanTools.ps1" "$SETUP_PATH\KAPE\Get-ZimmermanTools.ps1" -Force
 Set-Location "$SETUP_PATH\KAPE"
 & .\KAPE-EZToolsAncillaryUpdater.ps1 -silent -net 6 *> $CURRENT_DIR\log\kape.txt
 Set-Location $CURRENT_DIR

--- a/resources/external/KAPE-EZToolsAncillaryUpdater.ps1
+++ b/resources/external/KAPE-EZToolsAncillaryUpdater.ps1
@@ -105,28 +105,21 @@ function Get-Zimmerman {
 		New-Item -ItemType Directory -Path $getZimmermanToolsFolderKape | Out-Null
 	}
 
-	$scriptArgs = @{
-		Dest = "$getZimmermanToolsFolderKape"
+	# Use the locally bundled (hardened) Get-ZimmermanTools.ps1 shipped next to this updater
+	# instead of downloading the upstream zip, which currently 404s on tools without net9 builds.
+	$localGetZimmermanToolsPs1 = Join-Path $PSScriptRoot $getZimmermanToolsFileName
+	if (-not (Test-Path $localGetZimmermanToolsPs1)) {
+		Log -logFilePath $logFilePath -msg "Local $getZimmermanToolsFileName not found at $localGetZimmermanToolsPs1. Skipping Zimmerman update."
+		return
 	}
 
-	try {
-		Start-BitsTransfer -Source $ZTdlUrl -Destination $kapeModulesBin -ErrorAction Stop
-	} catch {
-		Log -logFilePath $logFilePath -msg "Failed to download $ZTZipFile from $ZTdlUrl. Error: $($_.Exception.Message)"
-	}
-
-	Expand-Archive -Path "$getZimmermanToolsZipKape" -DestinationPath "$kapeModulesBin" -Force
-	$getZimmermanToolsPs1 = (Get-ChildItem -Path $kapeModulesBin -Filter $getZimmermanToolsFileName).FullName
-
-	# Move Get-ZimmermanTools.ps1 from .\KAPE\Modules\bin to .\KAPE\Modules\bin\ZimmermanTools
-	Move-Item -Path $getZimmermanToolsPs1 -Destination $getZimmermanToolsFolderKape -Force
-
-	$getZimmermanToolsPs1ZT = (Get-ChildItem -Path $getZimmermanToolsFolderKape -Filter $getZimmermanToolsFileName).FullName
+	$getZimmermanToolsPs1ZT = Join-Path $getZimmermanToolsFolderKape $getZimmermanToolsFileName
+	Copy-Item -Path $localGetZimmermanToolsPs1 -Destination $getZimmermanToolsPs1ZT -Force
 
 	Log -logFilePath $logFilePath -msg "Running $getZimmermanToolsFileName! Downloading .NET 6 version of EZ Tools to $getZimmermanToolsFolderKape"
 
-	# executing .\KAPE\Modules\bin\Get-ZimmermanTools.ps1 -Dest .\KAPE\Modules\bin\ZimmermanTools
-	Start-Process -FilePath "powershell.exe" -ArgumentList "-NoProfile", "-File $getZimmermanToolsPs1ZT", "-Dest $($scriptArgs.Dest)" -Wait -NoNewWindow
+	# executing .\KAPE\Modules\bin\ZimmermanTools\Get-ZimmermanTools.ps1 -Dest .\KAPE\Modules\bin\ZimmermanTools -NetVersion 6
+	Start-Process -FilePath "powershell.exe" -ArgumentList "-NoProfile", "-File `"$getZimmermanToolsPs1ZT`"", "-Dest `"$getZimmermanToolsFolderKape`"", "-NetVersion", "6" -Wait -NoNewWindow
 }
 
 <#


### PR DESCRIPTION
## Summary
This PR refactors the KAPE EZTools update process to use a locally bundled version of `Get-ZimmermanTools.ps1` instead of downloading it from upstream, while also improving error handling and robustness.

## Key Changes

- **Local bundling**: Modified `KAPE-EZToolsAncillaryUpdater.ps1` to use a hardened, locally bundled `Get-ZimmermanTools.ps1` instead of downloading the upstream zip file, which currently returns 404 errors for tools without .NET 9 builds
- **Simplified workflow**: Removed the download and extraction logic, replacing it with a direct copy of the local script to the destination folder
- **Enhanced error handling**: Added try-catch block in `Get-ZimmermanTools.ps1` to gracefully skip URLs that fail HEAD requests instead of crashing
- **Improved cleanup**: Added path existence check before attempting to remove downloaded zip files to prevent errors
- **Updated script invocation**: Modified the PowerShell process call to explicitly pass `-NetVersion 6` parameter and properly quote file paths
- **Distribution update**: Updated `kape.ps1` to copy the bundled `Get-ZimmermanTools.ps1` to the KAPE directory alongside the updater script

## Notable Implementation Details

- The local script path is resolved relative to the updater script location using `$PSScriptRoot`
- If the local script is not found, the update is skipped with a logged message rather than failing
- Error handling improvements prevent the entire download process from failing when individual tool URLs are unreachable
- Whitespace cleanup and formatting improvements for consistency

https://claude.ai/code/session_01Ju5VRHC4CvtDsrKN4xxXn8