### PR TITLE
Fix silent 7z detection in common.ps1

### DIFF
--- a/resources/download/common.ps1
+++ b/resources/download/common.ps1
@@ -702,25 +702,31 @@ function Get-Winget {
             return $false
         }
         if ($FILE_TYPE.Contains("Zip archive data")) {
-            $7Z_TEST = 7z t -pprocdot -bb0 -bd $FileName
-            if (! ($7Z_TEST.Contains("Everything is Ok"))) {
-                Write-SynchronizedLog "Error: Downloaded file, ${FileName}, did not pass 7z test. Result: $7Z_TEST"
-                Remove-Item $FileName -Force | Out-Null
-                return $false
+            if ($SEVENZIP) {
+                $7Z_TEST = & $SEVENZIP t -pprocdot -bb0 -bd $FileName 2>&1
+                if (! ($7Z_TEST -join "" | Select-String -Pattern "Everything is Ok" -Quiet)) {
+                    Write-SynchronizedLog "Error: Downloaded file, ${FileName}, did not pass 7z test. Result: $7Z_TEST"
+                    Remove-Item $FileName -Force | Out-Null
+                    return $false
+                }
             }
         } elseif ($FILE_TYPE.Contains("RAR archive data")) {
-            $RAR_TEST = 7z t -bb0 -bd $FileName
-            if (! ($RAR_TEST.Contains("All OK"))) {
-                Write-SynchronizedLog "Error: Downloaded file, ${FileName}, did not pass 7z test. Result: $RAR_TEST"
-                Remove-Item $FileName -Force | Out-Null
-                return $false
+            if ($SEVENZIP) {
+                $RAR_TEST = & $SEVENZIP t -bb0 -bd $FileName 2>&1
+                if (! ($RAR_TEST -join "" | Select-String -Pattern "All OK" -Quiet)) {
+                    Write-SynchronizedLog "Error: Downloaded file, ${FileName}, did not pass 7z test. Result: $RAR_TEST"
+                    Remove-Item $FileName -Force | Out-Null
+                    return $false
+                }
             }
         } elseif ($FILE_TYPE.Contains("Composite Document File V2 Document")) {
-            $MSI_TEST = 7z t -bb0 -bd $FileName
-            if (! ($MSI_TEST.Contains("Everything is Ok"))) {
-                Write-SynchronizedLog "Error: Downloaded file, ${FileName}, did not pass 7z test. Result: $MSI_TEST"
-                Remove-Item $FileName -Force | Out-Null
-                return $false
+            if ($SEVENZIP) {
+                $MSI_TEST = & $SEVENZIP t -bb0 -bd $FileName 2>&1
+                if (! ($MSI_TEST -join "" | Select-String -Pattern "Everything is Ok" -Quiet)) {
+                    Write-SynchronizedLog "Error: Downloaded file, ${FileName}, did not pass 7z test. Result: $MSI_TEST"
+                    Remove-Item $FileName -Force | Out-Null
+                    return $false
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Replace bare `7z` command calls with `& $SEVENZIP` using the already-resolved variable from `Get-SevenZip`
- Wrap each 7z test block in `if ($SEVENZIP)` so tests are silently skipped when 7z is not found anywhere
- Add `2>&1` redirection to prevent stray stderr output reaching the user
- Use `Select-String` for output matching instead of `.Contains()` on potentially-array output

## Details

The `Get-SevenZip` function at the top of the file already handles PATH + fallback to standard install paths (`Program Files\7-Zip\7z.exe`). However the three 7z test calls (Zip, RAR, MSI) still used bare `7z` directly, causing a visible "not recognized" error before the variable check could ever run, and then a null-dereference on the `.Contains()` call.

https://claude.ai/code/session_01E26neXNEcUUQV3tSFZvsXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01E26neXNEcUUQV3tSFZvsXS)_