### PR TITLE
Track HTTP tool changes in changelog via tools_downloaded.csv

### DIFF
--- a/docs/MISSING_FROM_CHANGELOG.md
+++ b/docs/MISSING_FROM_CHANGELOG.md
@@ -50,9 +50,19 @@ the venv-level tools that have CLI entry points.
 
 ## Direct HTTP downloads
 
-Tools fetched via plain URL (e.g. raw GitHub content, vendor download pages)
-where no GitHub release or winget package exists. Version is sometimes embedded
-in the URL but requires per-tool parsing.
+Tools fetched via plain URL are now **partially tracked** via `tools_downloaded.csv`.
+The changelog compares the URL from the previous run against the current URL:
+
+- If the URL changed and contains a version string (e.g. `/v1.2.3/`), the old and
+  new versions are shown.
+- If the URL changed but contains no parseable version, the entry is flagged as
+  "updated (version not available in URL)" and both URLs are shown.
+- If the URL is unchanged (mutable URL, file content may have changed silently),
+  no entry is generated. This is a known gap.
+
+Tools fetched **inside the sandbox** (raw GitHub scripts downloaded by
+`install_python_tools.ps1`) are not in `tools_downloaded.csv` and therefore
+not tracked at all:
 
 | Tool | Location |
 |------|----------|
@@ -65,7 +75,6 @@ in the URL but requires per-tool parsing.
 | sigs.py | `setup/install/install_python_tools.ps1` (raw GitHub) |
 | defender-dump.py | `setup/install/install_python_tools.ps1` (raw GitHub) |
 | Various (pe2pic, evt2sigma scripts) | `setup/install/install_python_tools.ps1` (raw GitHub) |
-| Many tools in `downloadFiles.ps1` | `downloadFiles.ps1` (direct URL) |
 
 ## MSYS2 packages (`pacman -S`)
 

--- a/resources/download/changelog.ps1
+++ b/resources/download/changelog.ps1
@@ -106,6 +106,62 @@ function Save-ChangelogVersions {
         Set-Content -Path "$changelogDir\versions.json" -Encoding UTF8
 }
 
+# Extracts a version string from a URL, e.g. ".../v1.2.3/..." -> "1.2.3".
+# Returns $null if no version-like pattern is found.
+function Get-VersionFromUrl {
+    param([string]$Url)
+    # Match common patterns: /v1.2.3/, /1.2.3/, _1.2.3_, -1.2.3-, filename-1.2.3.ext
+    if ($Url -match '(?:^|[/_\-v])(\d+\.\d+(?:\.\d+){0,3})(?:[/_\-\.]|$)') {
+        return $Matches[1]
+    }
+    return $null
+}
+
+# Reads tools_downloaded.csv and returns a hashtable keyed by Name with URL values.
+function Get-HttpToolsCurrentSnapshot {
+    $csvFile = "$PSScriptRoot\..\..\downloads\tools_downloaded.csv"
+    $snapshot = [ordered]@{}
+    if (-not (Test-Path $csvFile)) {
+        return $snapshot
+    }
+    try {
+        Import-Csv $csvFile -ErrorAction Stop | ForEach-Object {
+            if ($_.Name -and $_.URL) {
+                $snapshot[$_.Name] = $_.URL
+            }
+        }
+    } catch { }
+    return $snapshot
+}
+
+# Loads the persisted HTTP tools snapshot from .changelog\http_snapshot.json.
+function Get-HttpToolsSavedSnapshot {
+    $snapshotFile = "$PSScriptRoot\..\..\downloads\.changelog\http_snapshot.json"
+    $snapshot = [ordered]@{}
+    if (-not (Test-Path $snapshotFile)) {
+        return $snapshot
+    }
+    try {
+        $raw = Get-Content $snapshotFile -Raw | ConvertFrom-Json -ErrorAction Stop
+        foreach ($prop in $raw.PSObject.Properties) {
+            $snapshot[$prop.Name] = $prop.Value
+        }
+    } catch { }
+    return $snapshot
+}
+
+# Persists the current HTTP tools snapshot to .changelog\http_snapshot.json.
+function Save-HttpToolsSnapshot {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
+    param([object]$Snapshot)
+    $changelogDir = "$PSScriptRoot\..\..\downloads\.changelog"
+    if (-not (Test-Path $changelogDir)) {
+        New-Item -ItemType Directory -Force -Path $changelogDir | Out-Null
+    }
+    $Snapshot | ConvertTo-Json -Depth 2 |
+        Set-Content -Path "$changelogDir\http_snapshot.json" -Encoding UTF8
+}
+
 function Update-ToolChangelog {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     param()
@@ -151,7 +207,46 @@ function Update-ToolChangelog {
         }
     }
 
-    if ($updated.Count -eq 0 -and $added.Count -eq 0) {
+    # HTTP tools: compare URL snapshots
+    $oldHttp = Get-HttpToolsSavedSnapshot
+    $newHttp = Get-HttpToolsCurrentSnapshot
+
+    $httpUpdated = [System.Collections.Generic.List[PSCustomObject]]::new()
+    $httpAdded   = [System.Collections.Generic.List[PSCustomObject]]::new()
+
+    foreach ($name in $newHttp.Keys) {
+        $newUrl = $newHttp[$name]
+        if ($oldHttp.ContainsKey($name)) {
+            $oldUrl = $oldHttp[$name]
+            if ($oldUrl -ne $newUrl) {
+                $oldVer = Get-VersionFromUrl -Url $oldUrl
+                $newVer = Get-VersionFromUrl -Url $newUrl
+                $httpUpdated.Add([PSCustomObject]@{
+                    Name   = $name
+                    OldUrl = $oldUrl
+                    NewUrl = $newUrl
+                    OldVer = $oldVer
+                    NewVer = $newVer
+                })
+            }
+        } else {
+            $ver = Get-VersionFromUrl -Url $newUrl
+            $httpAdded.Add([PSCustomObject]@{
+                Name = $name
+                Url  = $newUrl
+                Ver  = $ver
+            })
+        }
+    }
+
+    $isFirstHttpRun = ($oldHttp.Count -eq 0)
+    Save-HttpToolsSnapshot -Snapshot $newHttp
+
+    if ($isFirstHttpRun) {
+        Write-DateLog "Changelog: HTTP baseline recorded for $($newHttp.Count) tools."
+    }
+
+    if ($updated.Count -eq 0 -and $added.Count -eq 0 -and $httpUpdated.Count -eq 0 -and ($httpAdded.Count -eq 0 -or $isFirstHttpRun)) {
         Write-DateLog "Changelog: No tool version changes detected."
         return
     }
@@ -176,6 +271,20 @@ function Update-ToolChangelog {
         $lines.Add("")
     }
 
+    if ($httpUpdated.Count -gt 0) {
+        $lines.Add("#### Updated Tools (HTTP)")
+        foreach ($t in ($httpUpdated | Sort-Object Name)) {
+            if ($t.OldVer -and $t.NewVer) {
+                $lines.Add("- **$($t.Name)**: $($t.OldVer) -> $($t.NewVer)")
+            } else {
+                $lines.Add("- **$($t.Name)**: updated (version not available in URL)")
+            }
+            $lines.Add("  - old: $($t.OldUrl)")
+            $lines.Add("  - new: $($t.NewUrl)")
+        }
+        $lines.Add("")
+    }
+
     if ($added.Count -gt 0) {
         $lines.Add("#### New Tools")
         foreach ($t in ($added | Sort-Object Name)) {
@@ -187,6 +296,16 @@ function Update-ToolChangelog {
                 default  { "$($t.Source): $($t.Identifier)" }
             }
             $lines.Add("- **$($t.Name)** ($src): $($t.Version)")
+        }
+        $lines.Add("")
+    }
+
+    if (-not $isFirstHttpRun -and $httpAdded.Count -gt 0) {
+        $lines.Add("#### New Tools (HTTP)")
+        foreach ($t in ($httpAdded | Sort-Object Name)) {
+            $verStr = if ($t.Ver) { ": $($t.Ver)" } else { "" }
+            $lines.Add("- **$($t.Name)**$verStr")
+            $lines.Add("  - url: $($t.Url)")
         }
         $lines.Add("")
     }
@@ -206,5 +325,6 @@ function Update-ToolChangelog {
     }
 
     Set-Content -Path $changelogFile -Value $newContent -Encoding UTF8 -NoNewline
-    Write-DateLog "Changelog: $($updated.Count) updated, $($added.Count) new tool(s). See downloads\CHANGELOG.md"
+    $httpCount = $httpUpdated.Count + $(if (-not $isFirstHttpRun) { $httpAdded.Count } else { 0 })
+    Write-DateLog "Changelog: $($updated.Count) updated, $($added.Count) new, $httpCount HTTP change(s). See downloads\CHANGELOG.md"
 }


### PR DESCRIPTION
## Summary

Extends the changelog to cover tools downloaded via plain HTTP by comparing URLs in `tools_downloaded.csv` against a persisted snapshot (`downloads/.changelog/http_snapshot.json`).

### How it works

- On each `downloadFiles.ps1` run, the current Name→URL map from `tools_downloaded.csv` is compared against the previous run's snapshot
- **URL changed, version in URL**: shown as `1.2.3 -> 1.3.0` with old and new URLs
- **URL changed, no parseable version**: flagged as "updated (version not available in URL)" with both URLs shown so the user can compare
- **New tool**: listed in "New Tools (HTTP)" with URL and version if extractable
- **URL unchanged**: not reported (mutable-URL changes remain a known gap)
- First run: baseline recorded, no changelog entry generated

### Example output

```markdown
#### Updated Tools (HTTP)
- **tool.exe**: 1.2.3 -> 1.3.0
  - old: https://example.com/releases/v1.2.3/tool.exe
  - new: https://example.com/releases/v1.3.0/tool.exe

- **other.zip**: updated (version not available in URL)
  - old: https://example.com/download/other-stable.zip
  - new: https://example.com/download/other-latest.zip
```

### Remaining gaps (documented in `docs/MISSING_FROM_CHANGELOG.md`)

- Tools downloaded inside the sandbox (`install_python_tools.ps1` raw GitHub scripts) — not in `tools_downloaded.csv`
- Mutable URLs where file content changes but URL stays the same
- Go, Cargo, MSYS2, uv pip venv packages (unchanged from previous PR)

## Test plan

- [ ] Run `downloadFiles.ps1` once to establish the HTTP baseline snapshot
- [ ] Update one tool URL (e.g. bump a version in `downloadFiles.ps1`) and run again — confirm the changelog entry shows old → new URL with version extracted
- [ ] Confirm a tool with no version in its URL shows the "version not available" message

https://claude.ai/code/session_01XvzBg29yoegFu1krzBNP72

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvzBg29yoegFu1krzBNP72)_