### PR TITLE
Fix ContainsKey on OrderedDictionary in changelog.ps1

### DIFF
--- a/resources/download/changelog.ps1
+++ b/resources/download/changelog.ps1
@@ -187,7 +187,7 @@ function Update-ToolChangelog {
 
     foreach ($key in $newVersions.Keys) {
         $cur = $newVersions[$key]
-        if ($oldVersions.ContainsKey($key)) {
+        if ($oldVersions.Contains($key)) {
             if ($oldVersions[$key].Version -ne $cur.Version) {
                 $updated.Add([PSCustomObject]@{
                     Name       = $cur.Name
@@ -216,7 +216,7 @@ function Update-ToolChangelog {
 
     foreach ($name in $newHttp.Keys) {
         $newUrl = $newHttp[$name]
-        if ($oldHttp.ContainsKey($name)) {
+        if ($oldHttp.Contains($name)) {
             $oldUrl = $oldHttp[$name]
             if ($oldUrl -ne $newUrl) {
                 $oldVer = Get-VersionFromUrl -Url $oldUrl


### PR DESCRIPTION
## Summary

`[ordered]@{}` creates a `System.Collections.Specialized.OrderedDictionary` which does not have a `ContainsKey` method — it uses `Contains` instead. This caused the changelog to throw on every tool version comparison.

Two occurrences fixed:
- `$oldVersions.ContainsKey($key)` → `$oldVersions.Contains($key)`
- `$oldHttp.ContainsKey($name)` → `$oldHttp.Contains($name)`

## Test plan

- [ ] Run `downloadFiles.ps1` and confirm no `InvalidOperation` errors from `changelog.ps1`

https://claude.ai/code/session_01XvzBg29yoegFu1krzBNP72

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvzBg29yoegFu1krzBNP72)_