### PR TITLE
Update SHA256, Size and Path on re-download in Update-ToolsDownloaded

### DIFF
--- a/resources/download/common.ps1
+++ b/resources/download/common.ps1
@@ -635,7 +635,10 @@ function Update-ToolsDownloaded {
 
         $toolsDownloaded.Add($addNewTool)
     } else {
-        $localFile.URL = $URL
+        $localFile.URL    = $URL
+        $localFile.SHA256 = Get-FileHash -Path $Path -Algorithm SHA256 | Select-Object -ExpandProperty Hash
+        $localFile.Size   = Get-Item $Path | Select-Object -ExpandProperty Length
+        $localFile.Path   = Resolve-Path -Path $Path
     }
 
     if($PSCmdlet.ShouldProcess($file.Name)) {


### PR DESCRIPTION
## Summary

`Update-ToolsDownloaded` previously only refreshed the `URL` field when a tool already existed in `tools_downloaded.csv`. `SHA256`, `Size`, and `Path` were left stale from the original download, making hash-based change detection unreliable.

Now all four fields are updated on every re-download, so the CSV always reflects the actual file on disk.

## Test plan

- [ ] Download a tool that already exists in `tools_downloaded.csv` and confirm `SHA256`, `Size`, and `Path` are updated in the CSV

https://claude.ai/code/session_01XvzBg29yoegFu1krzBNP72

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvzBg29yoegFu1krzBNP72)_