### PR TITLE
Fix \Q...\E regex syntax and guard against empty changelog write

### DIFF
--- a/resources/download/changelog.ps1
+++ b/resources/download/changelog.ps1
@@ -313,17 +313,18 @@ function Update-ToolChangelog {
     $newSections   = $sections -join "`n"
     $changelogFile = "$PSScriptRoot\..\..\downloads\CHANGELOG.md"
     $todayHeading  = "### $date"
+    $escapedHeading = [regex]::Escape($todayHeading)
 
     if (Test-Path $changelogFile) {
         $existing = Get-Content $changelogFile -Raw -Encoding UTF8
         # Normalise line endings for matching
         $existingLf = $existing -replace "`r`n", "`n"
 
-        if ($existingLf -match "(?s)(.*\Q$todayHeading\E\n\n)(.*)") {
+        if ($existingLf -match "(?s)(.*$escapedHeading\n\n)(.*)") {
             # An entry for today already exists — append new sections after it.
-            $before      = $Matches[1]
-            $after       = $Matches[2]
-            $newContent  = "${before}${newSections}`n${after}"
+            $before     = $Matches[1]
+            $after      = $Matches[2]
+            $newContent = "${before}${newSections}`n${after}"
         } elseif ($existingLf -match "(?s)^(# DFIRWS Changelog\n\n?)(.*)$") {
             # No entry for today — prepend a new dated section.
             $newContent = "# DFIRWS Changelog`n`n${todayHeading}`n`n${newSections}`n$($Matches[2].TrimStart())"
@@ -332,6 +333,11 @@ function Update-ToolChangelog {
         }
     } else {
         $newContent = "# DFIRWS Changelog`n`n${todayHeading}`n`n${newSections}"
+    }
+
+    if (-not $newContent) {
+        Write-DateLog "Changelog: ERROR - newContent is empty, skipping write to avoid data loss."
+        return
     }
 
     Set-Content -Path $changelogFile -Value $newContent -Encoding UTF8 -NoNewline


### PR DESCRIPTION
## Summary

Two bugs in the same-day merge logic introduced in #396:

1. **`\Q...\E` not supported in .NET regex** — this syntax is Perl/Java only. Replaced with `[regex]::Escape($todayHeading)` which is the correct .NET way to escape a literal string for use in a regex pattern.

2. **0-byte CHANGELOG.md on error** — when the regex threw `OperationStopped`, `$newContent` was never assigned, and `Set-Content` wrote `$null` to the file, wiping it. Added a null-content guard that logs an error and returns early rather than overwriting the file.

## Test plan

- [ ] Run `downloadFiles.ps1` and confirm no `OperationStopped` / `Unrecognized escape sequence \Q` error
- [ ] Run twice in one day and confirm entries are merged under a single `### <date>` heading
- [ ] Confirm `CHANGELOG.md` is non-empty after each run

https://claude.ai/code/session_01XvzBg29yoegFu1krzBNP72

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvzBg29yoegFu1krzBNP72)_