### PR TITLE
fix: add blank line after each heading in CHANGELOG.md output

### DIFF
--- a/resources/download/changelog.ps1
+++ b/resources/download/changelog.ps1
@@ -258,6 +258,7 @@ function Update-ToolChangelog {
 
     if ($updated.Count -gt 0) {
         $sections.Add("#### Updated Tools")
+        $sections.Add("")
         foreach ($t in ($updated | Sort-Object Name)) {
             $src = switch ($t.Source) {
                 "github" { "GitHub: $($t.Identifier)" }
@@ -273,6 +274,7 @@ function Update-ToolChangelog {
 
     if ($httpUpdated.Count -gt 0) {
         $sections.Add("#### Updated Tools (HTTP)")
+        $sections.Add("")
         foreach ($t in ($httpUpdated | Sort-Object Name)) {
             if ($t.OldVer -and $t.NewVer) {
                 $sections.Add("- **$($t.Name)**: $($t.OldVer) -> $($t.NewVer)")
@@ -287,6 +289,7 @@ function Update-ToolChangelog {
 
     if ($added.Count -gt 0) {
         $sections.Add("#### New Tools")
+        $sections.Add("")
         foreach ($t in ($added | Sort-Object Name)) {
             $src = switch ($t.Source) {
                 "github" { "GitHub: $($t.Identifier)" }
@@ -302,6 +305,7 @@ function Update-ToolChangelog {
 
     if (-not $isFirstHttpRun -and $httpAdded.Count -gt 0) {
         $sections.Add("#### New Tools (HTTP)")
+        $sections.Add("")
         foreach ($t in ($httpAdded | Sort-Object Name)) {
             $verStr = if ($t.Ver) { ": $($t.Ver)" } else { "" }
             $sections.Add("- **$($t.Name)**$verStr")


### PR DESCRIPTION
## Summary

- Markdown requires a blank line between a heading and the following list/paragraph to render correctly in editors and viewers
- Each `####` section heading (`Updated Tools`, `Updated Tools (HTTP)`, `New Tools`, `New Tools (HTTP)`) now has an empty line inserted after it in the sections list before the bullet items begin

## Test plan

- [ ] Run `downloadFiles.ps1` twice (to get past the first-run baseline) and confirm `downloads/CHANGELOG.md` has a blank line between each `####` heading and its list items

https://claude.ai/code/session_01PH2CbPmqemAbBXwtHVkcvb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PH2CbPmqemAbBXwtHVkcvb)_