### PR TITLE
Fix stability bugs and deduplicate install boilerplate

### DIFF
--- a/clean.ps1
+++ b/clean.ps1
@@ -3,7 +3,6 @@ param (
     [Switch]$All
 )
 
-# Script to clean up directories created by this tool.
 Remove-Item -Recurse -Force "downloads" 2>&1 | Out-Null
 Remove-Item -Recurse -Force "log" 2>&1 | Out-Null
 Remove-Item -Recurse -Force "mount" 2>&1 | Out-Null

--- a/createVM.ps1
+++ b/createVM.ps1
@@ -87,12 +87,9 @@ if ($NoDownload.IsPresent) {
         }
         Write-Output "Will use link $real_link."
 
-        # Get filename part from the link
         $filename = $real_link.Split("/")[-1]
 
-        # Check if the iso file is already downloaded
         if (! (Test-Path -Path "iso\$filename")) {
-            # Download the iso file
             Set-Location tmp
             curl -O --retry 10 --retry-all-errors $real_link
             Set-Location ..

--- a/createVM.ps1
+++ b/createVM.ps1
@@ -155,11 +155,6 @@ if (! ($NoInstall.IsPresent)) {
     & ".\resources\vm\install_dfirws_in_vm.ps1"
 }
 
-if ($Debloat.IsPresent) {
-    Write-Output "Running debloat.ps1 script"
-    & ".\resources\vm\debloat.ps1"
-}
-
 if (! ($NoCustomize.IsPresent)) {
     if (Test-Path -Path ".\local\customize-vm.ps1") {
         Write-Output "Running local/customize-vm.ps1 script"

--- a/downloadFiles.ps1
+++ b/downloadFiles.ps1
@@ -378,7 +378,7 @@ if ($all -or $Didier.IsPresent -or $GoLang.IsPresent -or $Http.IsPresent -or $Py
     }
 }
 
-if ($all -or $Freshclam.IsPresent -or $GoLang.IsPresent -or $LogBoost.IsPresent -or $MSYS2.IsPresent -or $Node.IsPresent -or $Python.IsPresent -or $Ruby.IsPresent -or $Rust.IsPresent) {
+if ($all -or $Freshclam.IsPresent -or $GoLang.IsPresent -or $LogBoost.IsPresent -or $MSYS2.IsPresent -or $Node.IsPresent -or $Python.IsPresent -or $Rust.IsPresent) {
     Write-DateLog "Download common files needed in Sandboxes for installation."
     .\resources\download\basic.ps1
 }

--- a/downloadFiles.ps1
+++ b/downloadFiles.ps1
@@ -136,12 +136,10 @@ if (Test-Path ".\dfirws-config.ps1") {
     Exit
 }
 
-# Load profile definitions
 if (Test-Path ".\local\defaults\profiles.ps1") {
     . ".\local\defaults\profiles.ps1"
 }
 
-# Load user profile config
 if (Test-Path ".\local\profile-config.ps1") {
     . ".\local\profile-config.ps1"
 }
@@ -266,7 +264,6 @@ if (! $AllowCurlAlias.IsPresent) {
 # Ensure configuration exists for rclone
 rclone.exe config touch | Out-Null
 
-# Check if sandbox is running
 if ( tasklist | Select-String "(WindowsSandboxClient|WindowsSandboxRemote)" ) {
     Write-DateLog "Sandbox can't be running while updating."
     Exit
@@ -364,7 +361,6 @@ if ($DebugDownloads.IsPresent) {
 }
 
 if ($all -or $Didier.IsPresent -or $GoLang.IsPresent -or $Http.IsPresent -or $Python.IsPresent -or $Release.IsPresent) {
-    # Get GitHub password from user input
     if ($GITHUB_USERNAME -ne "YOUR GITHUB USERNAME" -and $GITHUB_TOKEN -ne "YOUR GITHUB TOKEN") {
         $GH_USER = "${GITHUB_USERNAME}"
         $GH_PASS = "${GITHUB_TOKEN}"
@@ -517,7 +513,6 @@ if (Test-Path ".\tmp\msys2") {
     Remove-Item -Recurse -Force .\tmp\msys2\ 2>&1 | Out-Null
 }
 
-# Update tool changelog
 Write-DateLog "Updating tool changelog."
 . ".\resources\download\changelog.ps1"
 Update-ToolChangelog
@@ -526,14 +521,12 @@ if (!(Test-Path ".\mount\golang")){
     New-Item -ItemType Directory -Force -Path ".\mount\golang" 2>&1 | Out-Null
 }
 
-# Verify that tools are available
 if ($Verify.IsPresent) {
     Write-DateLog "Verify that tools are available."
     .\resources\download\verify.ps1 -WorkingDirectory $PWD\resources\download | Out-Null
     Write-DateLog "Verify done."
 }
 
-# Run ClamAV and/or YARA scans of installed tools in sandbox
 if ($ClamScan.IsPresent -and $YaraScan.IsPresent) {
     # Run both scans in the same sandbox: YARA starts as a background job while ClamAV installs and scans.
     Write-DateLog "Run ClamAV and YARA scans in parallel in sandbox."

--- a/resources/download/basic.ps1
+++ b/resources/download/basic.ps1
@@ -299,7 +299,6 @@ $TOOL_DEFINITIONS += @{
     License = "Apache-2.0"
     LicenseUrl = "https://github.com/NationalSecurityAgency/ghidra/blob/master/LICENSE"
     Category = "Reverse Engineering"
-    # Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Reverse Engineering\${VERSION}.lnk" -DestinationPath "${TOOLS}\ghidra\${VERSION}\ghidraRun.bat"
     Shortcuts = @(
         @{
             Lnk      = "`${HOME}\Desktop\dfirws\Reverse Engineering\Ghidra.lnk"

--- a/resources/download/changelog.ps1
+++ b/resources/download/changelog.ps1
@@ -49,8 +49,9 @@ function Get-ChangelogCurrentVersions {
     $githubDir = "$downloadsMetadata\github"
     if (Test-Path $githubDir) {
         Get-ChildItem $githubDir -Filter "*.json" -ErrorAction SilentlyContinue | ForEach-Object {
+            $metadataFile = $_.FullName
             try {
-                $data = Get-Content $_.FullName -Raw | ConvertFrom-Json -ErrorAction Stop
+                $data = Get-Content $metadataFile -Raw | ConvertFrom-Json -ErrorAction Stop
                 if ($data.FullName -and $data.LatestRelease -and $data.LatestRelease.TagName) {
                     if (Test-ChangelogIgnored -IgnoreList $ignoreList -Source "github" -Name $data.Name) {
                         return
@@ -62,15 +63,18 @@ function Get-ChangelogCurrentVersions {
                         Identifier = $data.FullName
                     }
                 }
-            } catch { }
+            } catch {
+                Write-DateLog "Changelog: WARNING - skipping unreadable metadata file ${metadataFile}: $($_.Exception.Message)"
+            }
         }
     }
 
     $wingetDir = "$downloadsMetadata\winget"
     if (Test-Path $wingetDir) {
         Get-ChildItem $wingetDir -Filter "*.json" -ErrorAction SilentlyContinue | ForEach-Object {
+            $metadataFile = $_.FullName
             try {
-                $data = Get-Content $_.FullName -Raw | ConvertFrom-Json -ErrorAction Stop
+                $data = Get-Content $metadataFile -Raw | ConvertFrom-Json -ErrorAction Stop
                 if ($data.AppId -and $data.Version) {
                     if (Test-ChangelogIgnored -IgnoreList $ignoreList -Source "winget" -Name $data.AppId) {
                         return
@@ -82,7 +86,9 @@ function Get-ChangelogCurrentVersions {
                         Identifier = $data.AppId
                     }
                 }
-            } catch { }
+            } catch {
+                Write-DateLog "Changelog: WARNING - skipping unreadable metadata file ${metadataFile}: $($_.Exception.Message)"
+            }
         }
     }
 
@@ -94,8 +100,9 @@ function Get-ChangelogCurrentVersions {
         $sourceDir = "$toolsMetadata\$source"
         if (Test-Path $sourceDir) {
             Get-ChildItem $sourceDir -Filter "*.json" -ErrorAction SilentlyContinue | ForEach-Object {
+                $metadataFile = $_.FullName
                 try {
-                    $data = Get-Content $_.FullName -Raw | ConvertFrom-Json -ErrorAction Stop
+                    $data = Get-Content $metadataFile -Raw | ConvertFrom-Json -ErrorAction Stop
                     if ($data.Name -and $data.Version) {
                         if (Test-ChangelogIgnored -IgnoreList $ignoreList -Source $source -Name $data.Name) {
                             return
@@ -113,7 +120,9 @@ function Get-ChangelogCurrentVersions {
                             Identifier = $identifier
                         }
                     }
-                } catch { }
+                } catch {
+                    Write-DateLog "Changelog: WARNING - skipping unreadable metadata file ${metadataFile}: $($_.Exception.Message)"
+                }
             }
         }
     }
@@ -134,6 +143,7 @@ function Get-ChangelogSavedVersions {
         }
         return $versions
     } catch {
+        Write-DateLog "Changelog: WARNING - could not read ${versionsFile}, treating as first run: $($_.Exception.Message)"
         return [ordered]@{}
     }
 }
@@ -174,7 +184,9 @@ function Get-UriEtag {
     if (Test-Path $etagFile) {
         try {
             return (Get-Content $etagFile -Raw -ErrorAction Stop).Trim()
-        } catch { }
+        } catch {
+            Write-DateLog "Changelog: WARNING - could not read etag file ${etagFile}: $($_.Exception.Message)"
+        }
     }
     return $null
 }
@@ -210,7 +222,9 @@ function Get-HttpToolsCurrentSnapshot {
                 }
             }
         }
-    } catch { }
+    } catch {
+        Write-DateLog "Changelog: WARNING - could not read ${csvFile}: $($_.Exception.Message)"
+    }
     return $snapshot
 }
 
@@ -226,7 +240,9 @@ function Get-HttpToolsSavedSnapshot {
         foreach ($prop in $raw.PSObject.Properties) {
             $snapshot[$prop.Name] = $prop.Value
         }
-    } catch { }
+    } catch {
+        Write-DateLog "Changelog: WARNING - could not read ${snapshotFile}, treating as first run: $($_.Exception.Message)"
+    }
     return $snapshot
 }
 

--- a/resources/download/common.ps1
+++ b/resources/download/common.ps1
@@ -454,11 +454,12 @@ function Get-GitHubRelease {
     # If still no download URL is found, try getting the tarball URL
     if ( !$Url ) {
         $releases = "https://api.github.com/repos/$repo/releases/latest"
-        $Url = (curl.exe --silent -L -u "${GH_USER}:${GH_PASS}" $releases | ConvertFrom-Json).zipball_url.ToString()
+        $Url = (curl.exe --silent -L -u "${GH_USER}:${GH_PASS}" $releases | ConvertFrom-Json).zipball_url
 
         if ( !$Url) {
-            Write-Error "Can't find a file to download for repo $repo."
-            Exit
+            Write-SynchronizedLog "Error: Can't find a file to download for repo $repo."
+            Write-DateLog "ERROR: Can't find a file to download for repo $repo."
+            return $false
         } else {
             Write-SynchronizedLog "Using tarball URL for $repo."
         }
@@ -485,28 +486,18 @@ function Get-DownloadUrlFromPage {
     $downloadUrl = ""
     $retries = 3
 
+    $curlArgs = @("--silent", "-L")
+    if ($Url -like "*github.com*" -and $GH_USER -ne "" -and $GH_PASS -ne "") {
+        $curlArgs += @("-u", "${GH_USER}:${GH_PASS}")
+    }
+
     while ("$downloadUrl" -eq "") {
         try {
-            if ($Url -contains "github.com") {
-                if ($last) {
-                    if ($GH_USER -eq "" -or $GH_PASS -eq "") {
-                        $downloadUrl = curl.exe --silent -L "$Url" | Select-String -Pattern "$RegEx" | Select-Object -ExpandProperty Matches | Select-Object -ExpandProperty Value | Select-Object -Last 1
-                    } else {
-                        $downloadUrl = curl.exe --silent -L -u "${GH_USER}:${GH_PASS}" "$Url" | Select-String -Pattern "$RegEx" | Select-Object -ExpandProperty Matches | Select-Object -ExpandProperty Value | Select-Object -Last 1
-                    }
-                } else {
-                    if ($GH_USER -eq "" -or $GH_PASS -eq "") {
-                        $downloadUrl = curl.exe --silent -L "$Url" | Select-String -Pattern "$RegEx" | Select-Object -ExpandProperty Matches | Select-Object -ExpandProperty Value | Select-Object -First 1
-                    } else {
-                        $downloadUrl = curl.exe --silent -L -u "${GH_USER}:${GH_PASS}" "$Url" | Select-String -Pattern "$RegEx" | Select-Object -ExpandProperty Matches | Select-Object -ExpandProperty Value | Select-Object -First 1
-                    }
-                }
+            $found = curl.exe @curlArgs "$Url" | Select-String -Pattern "$RegEx" | Select-Object -ExpandProperty Matches | Select-Object -ExpandProperty Value
+            if ($last) {
+                $downloadUrl = $found | Select-Object -Last 1
             } else {
-                if ($last) {
-                    $downloadUrl = curl.exe --silent -L "$Url" | Select-String -Pattern "$RegEx" | Select-Object -ExpandProperty Matches | Select-Object -ExpandProperty Value | Select-Object -Last 1
-                } else {
-                    $downloadUrl = curl.exe --silent -L "$Url" | Select-String -Pattern "$RegEx" | Select-Object -ExpandProperty Matches | Select-Object -ExpandProperty Value | Select-Object -First 1
-                }
+                $downloadUrl = $found | Select-Object -First 1
             }
         }
         catch {
@@ -615,8 +606,34 @@ function Update-ToolsDownloaded {
         $localFile.Path   = Resolve-Path -Path $Path
     }
 
-    if($PSCmdlet.ShouldProcess($file.Name)) {
+    if($PSCmdlet.ShouldProcess($Name)) {
         $toolsDownloaded.ToArray() | Export-Csv "$PSScriptRoot\..\..\downloads\tools_downloaded.csv" -NoTypeInformation
+    }
+}
+
+# Extracts a downloaded archive with 7-Zip and optionally renames the
+# extracted versioned directory to a stable target name. The target is removed
+# before extraction by default; -CleanAfterExtract removes it between
+# extraction and the rename instead (for archives that unpack to a versioned
+# directory next to the target).
+function Install-ToolFromArchive {
+    param (
+        [Parameter(Mandatory=$true)] [string]$Archive,
+        [Parameter(Mandatory=$true)] [string]$Destination,
+        [Parameter(Mandatory=$false)] [string]$Target = "",
+        [Parameter(Mandatory=$false)] [string]$MoveFrom = "",
+        [Parameter(Mandatory=$false)] [switch]$CleanAfterExtract
+    )
+
+    if ($Target -ne "" -and -not $CleanAfterExtract -and (Test-Path $Target)) {
+        Remove-Item $Target -Recurse -Force
+    }
+    & $SEVENZIP x -aoa $Archive -o"$Destination" | Out-Null
+    if ($Target -ne "" -and $CleanAfterExtract -and (Test-Path $Target)) {
+        Remove-Item $Target -Recurse -Force
+    }
+    if ($MoveFrom -ne "") {
+        Move-Item $MoveFrom $Target
     }
 }
 
@@ -722,18 +739,23 @@ function Get-Winget {
 function Wait-Sandbox {
     param (
         [Parameter(Mandatory=$True)] [string]$WSBPath,
-        [Parameter(Mandatory=$True)] [string]$WaitForPath
+        [Parameter(Mandatory=$True)] [string]$WaitForPath,
+        [Parameter(Mandatory=$False)] [int]$TimeoutMinutes = 240
     )
 
-    $sandboxRunning = $true
+    $deadline = (Get-Date).AddMinutes($TimeoutMinutes)
 
-    while ($sandboxRunning) {
+    while ($true) {
         if (Test-Path -Path $WaitForPath) {
             Write-SynchronizedLog "Sandbox finished."
-            $sandboxRunning = $false
-        } else {
-            Start-Sleep -Seconds 5
+            break
         }
+        if ((Get-Date) -gt $deadline) {
+            Write-SynchronizedLog "Error: Sandbox for $WSBPath did not finish within $TimeoutMinutes minutes. Stopping sandbox."
+            Write-DateLog "ERROR: Sandbox for $WSBPath did not finish within $TimeoutMinutes minutes."
+            break
+        }
+        Start-Sleep -Seconds 5
     }
 
     Stop-Sandbox

--- a/resources/download/common.ps1
+++ b/resources/download/common.ps1
@@ -1,9 +1,7 @@
-# Set the default encoding for Out-File to UTF-8
 $PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'
 
 . ".\setup\shared.ps1"
 
-# Variables used by the script
 $CONFIGURATION_FILES = ".\local"
 $SETUP_PATH = ".\downloads"
 $WSDFIR_TEMP = "C:\tmp"
@@ -47,7 +45,6 @@ function ConvertTo-Icon {
     }
 }
 
-# Function to download a file from a given URI and save it to a specified file path.
 function Get-FileFromUri {
     Param (
         [Parameter(Mandatory=$True)] [string]$Uri,
@@ -56,7 +53,6 @@ function Get-FileFromUri {
         [Parameter(Mandatory=$False)] [string]$check = ""
     )
 
-    # Validate URI before attempting download
     if ([string]::IsNullOrWhiteSpace($Uri)) {
         Write-SynchronizedLog "Error: Empty URI provided for $FilePath. Skipping download."
         Write-DateLog "ERROR: Empty URI provided for $FilePath. Skipping download."
@@ -73,7 +69,6 @@ function Get-FileFromUri {
 
     $fileDownloadedOrChanged = $false
 
-    # Check if the file has already been downloaded
     if ((Test-Path -Path "$FilePath") -and $CheckURL -eq "Yes") {
         if (Compare-ToolsDownloaded -URL $Uri -AppName ([System.IO.FileInfo]$FilePath).Name) {
             Write-SynchronizedLog "File $FilePath already downloaded according to tools_downloaded.csv."
@@ -95,12 +90,10 @@ function Get-FileFromUri {
     $downloaded = $false
     $ProgressPreference = 'SilentlyContinue'
 
-    # Ensure the directory for the final file path exists
     If (! ( Test-Path ([System.IO.FileInfo]$FilePath).DirectoryName )) {
         New-Item ([System.IO.FileInfo]$FilePath).DirectoryName -force -type directory | Out-Null
     }
 
-    # Ensure the directory for the temporary file path exists
     If (! ( Test-Path ([System.IO.FileInfo]$TmpFilePath).DirectoryName )) {
         New-Item ([System.IO.FileInfo]$TmpFilePath).DirectoryName -force -type directory | Out-Null
     }
@@ -113,7 +106,6 @@ function Get-FileFromUri {
     $UriHash = $(Get-FileHash -InputStream $stringAsStream -Algorithm SHA256 | Select-Object -ExpandProperty Hash)
     $ETAG_FILE = "$PSScriptRoot\..\..\downloads\.etag\${UriHash}"
 
-    # Remove etag if file doesn't exist
     if (! (Test-Path "$FilePath")) {
         Remove-Item -Force "${ETAG_FILE}" -ErrorAction SilentlyContinue
     }
@@ -134,7 +126,6 @@ function Get-FileFromUri {
         }
     }
 
-    # Attempt to download the file from the specified URI
     while($true) {
         try {
             Remove-Item -Force $TmpFilePath -ErrorAction SilentlyContinue
@@ -168,7 +159,6 @@ function Get-FileFromUri {
             if (Test-Path $TmpFilePath) {
                 Write-SynchronizedLog "Downloaded $Uri to $FilePath."
                 $downloaded = $true
-                # Check if size of ETAG file is less then 10 bytes and remove it if it is
                 if (Test-Path $ETAG_FILE) {
                     if ((Get-Item $ETAG_FILE).length -lt 10) {
                         Remove-Item -Force $ETAG_FILE
@@ -202,7 +192,6 @@ function Get-FileFromUri {
     }
 
     if ($downloaded) {
-        # Check if downloaded file is the correct type with help of $GIT_CHECK and the value of $check
         if ($check -ne "" ) {
             $FILE_TYPE = & "$GIT_FILE" -b "$TmpFilePath"
             # Check if the file type is correct - Git file returns "data" for some zip files
@@ -212,7 +201,6 @@ function Get-FileFromUri {
                 return $false
             }
         }
-        # Copy the temporary file to the final file path and remove the temporary file
         try {
             $result = rclone --log-level ERROR copyto --metadata --inplace --checksum "${TmpFilePath}" "${FilePath}" | Out-String
             if ("" -eq $result) {
@@ -266,7 +254,6 @@ function Save-GitHubRepoMetadata {
         return
     }
 
-    # Extract release info if provided
     $releaseInfo = $null
     if ($null -ne $ReleaseData) {
         $releaseInfo = [ordered]@{
@@ -278,7 +265,6 @@ function Save-GitHubRepoMetadata {
         }
     }
 
-    # Build license info
     $licenseInfo = $null
     if ($null -ne $repoData.license) {
         $licenseInfo = [ordered]@{
@@ -331,13 +317,11 @@ function Save-WingetMetadata {
         return
     }
 
-    # Parse winget show output into a hashtable
     $metadata = [ordered]@{
         AppId     = $AppName
         FetchedAt = (Get-Date).ToString("s")
     }
 
-    # Parse key-value pairs from winget show output
     foreach ($line in ($showOutput -split "`n")) {
         $line = $line.Trim()
         if ($line -match "^(.+?):\s+(.+)$") {
@@ -378,7 +362,6 @@ function Get-DownloadUrl {
         [Parameter(Mandatory=$True)] [string]$match
     )
     try {
-        # Retrieve the download URLs and filter them based on the provided regex match
         if ($GH_USER -eq "" -or $GH_PASS -eq "") {
             $downloads = (curl.exe --silent -L $releases | ConvertFrom-Json)[0].assets.browser_download_url
         } else {
@@ -430,10 +413,7 @@ function Get-GitHubRelease {
     if ($version -eq "latest") {
         Write-SynchronizedLog "Getting the latest release for $repo."
 
-        # Construct the URL to get the latest release information
         $releasesURL = "https://api.github.com/repos/$repo/releases/latest"
-
-        # Get the download URL by matching the specified regex pattern
         $latest_release = curl.exe --silent -L -u "${GH_USER}:${GH_PASS}" $releasesURL | ConvertFrom-Json
 
         foreach ($asset in $latest_release.assets) {
@@ -487,7 +467,6 @@ function Get-GitHubRelease {
     # Cache repository and release metadata for documentation generation
     Save-GitHubRepoMetadata -Repo $repo -ReleaseData $matchedRelease
 
-    # Log the chosen URL and download the file
     Write-SynchronizedLog "Using $Url for $repo."
     if ($download -eq $false) {
         return $Url
@@ -546,7 +525,6 @@ function Get-DownloadUrlFromPage {
     return $downloadUrl
 }
 
-# Function to write a synchronized log to a specified file.
 function Write-SynchronizedLog {
     param (
         [Parameter(Mandatory=$True)] [string]$Message,
@@ -570,7 +548,6 @@ function Write-SynchronizedLog {
     }
 }
 
-# Write a log entry with a timestamp.
 function Write-DateLog {
     param (
         [Parameter(Mandatory=$True)] [string]$Message
@@ -594,12 +571,10 @@ function Compare-ToolsDownloaded {
 
     $localFile = $toolsDownloaded | Where-Object { $_.Name -eq $AppName }
 
-    # No local file found
     if (!$localFile) {
         return $false
     }
 
-    # Is it the same URL?
     if ($localFile.URL -eq $URL) {
         return $true
     } else {
@@ -623,7 +598,6 @@ function Update-ToolsDownloaded {
 
     $localFile = $toolsDownloaded | Where-Object { $_.Name -eq $Name }
 
-    # No local file found
     if (!$localFile) {
         $addNewTool = [PSCustomObject]@{
             URL = $URL
@@ -646,7 +620,6 @@ function Update-ToolsDownloaded {
     }
 }
 
-# Function to clear tmp directory
 function Clear-Tmp {
     param (
         [Parameter(Mandatory=$True)] [string]$Folder
@@ -657,7 +630,6 @@ function Clear-Tmp {
     }
 }
 
-# Function to download via winget
 function Get-Winget {
     param (
         [Parameter(Mandatory=$true)] [string]$AppName,
@@ -747,7 +719,6 @@ function Get-Winget {
     return $true
 }
 
-# Function to wait for the sandbox to finish
 function Wait-Sandbox {
     param (
         [Parameter(Mandatory=$True)] [string]$WSBPath,
@@ -776,8 +747,7 @@ function Wait-Sandbox {
     }
 }
 
-# Function to check if a tool should be downloaded based on the active profile.
-# Returns $true if the tool should be included, $false if excluded by profile.
+# Returns $true if the tool should be included, $false if excluded by the active profile.
 function Test-ToolIncluded {
     param (
         [Parameter(Mandatory=$True)] [string]$ToolName
@@ -802,7 +772,6 @@ function Test-ToolIncluded {
     return $true
 }
 
-# Function to stop the sandbox
 function Stop-Sandbox {
     [CmdletBinding(SupportsShouldProcess)]
     param (

--- a/resources/download/enrichment.ps1
+++ b/resources/download/enrichment.ps1
@@ -4,7 +4,6 @@
 
 $TOOL_DEFINITIONS = @()
 
-# Set directories
 $currentDirectory = "${PWD}"
 $enrichmentDirectory = "${PWD}\enrichment"
 $cveSaveDirectory = "${enrichmentDirectory}\cve"
@@ -23,7 +22,6 @@ $maxmindASNUnpackDirectory = "${maxmindUnpackDirectory}\GeoLite2-ASN"
 $maxmindCityUnpackDirectory = "${maxmindUnpackDirectory}\GeoLite2-City"
 $maxmindCountryUnpackDirectory = "${maxmindUnpackDirectory}\GeoLite2-Country"
 
-# Create directories if they don't exist
 Foreach ($directory in @($enrichmentDirectory, $cveSaveDirectory, $geolocusSaveDirectory, $gitSaveDirectory, $IPinfoSaveDirectory, $manufSaveDirectory, $maxmindCurrentDirectory, $maxmindSaveDirectory, $maxmindUnpackDirectory, $maxmindASNUnpackDirectory, $maxmindCityUnpackDirectory, $maxmindCountryUnpackDirectory, $snortSaveDirectory, $suricataSaveDirectory, $torsaveDirectory, $yaraSaveDirectory)) {
     if (-not (Test-Path -Path "${directory}")) {
         New-Item -ItemType Directory -Path "${directory}" -Force | Out-Null
@@ -45,14 +43,11 @@ if (!(Test-Path -Path "$geolocusSaveDirectory\mmdb")) {
     New-Item -ItemType Directory -Path "$geolocusSaveDirectory\mmdb" -Force | Out-Null
 }
 
-# Get the current date
 $DATE = Get-Date -Format "yyyy-MM-dd"
-
-# Download Tor exit nodes
-$folderUrl = "https://collector.torproject.org/archive/exit-lists/"
 
 #
 # TOR exit nodes
+$folderUrl = "https://collector.torproject.org/archive/exit-lists/"
 $webClient = New-Object System.Net.WebClient
 $webClient.Headers.Add("User-Agent", "Mozilla/5.0")
 $maxRetries = 3
@@ -101,7 +96,6 @@ if (-not "${IPINFO_API_KEY}") {
 } elseif ($IPINFO_API_KEY -eq "YOUR KEY") {
     Write-DateLog "Please enter your key for the IPINFO_API_KEY variable in config.ps1 if you like to download databases from IPinfo."
 } else {
-    # Download IPinfo.io Free IP to Country database
     $folderUrl = "https://ipinfo.io/data/free/country_asn.mmdb?token=${IPINFO_API_KEY}"
     $savePath = Join-Path -Path "${IPinfoSaveDirectory}" -ChildPath "country_asn.mmdb"
     Write-DateLog "Downloading country_asn.mmdb from IPinfo.io"
@@ -111,35 +105,29 @@ if (-not "${IPINFO_API_KEY}") {
 
 #
 # Maxmind GeoLite2 databases
-
-# Check if the Maxmind license key is set
 if (-not "${MAXMIND_LICENSE_KEY}") {
     Write-DateLog "Please set the MAXMIND_LICENSE_KEY variable in config.ps1 if you want to download Maxmind databases"
 } elseif ($MAXMIND_LICENSE_KEY -eq "YOUR KEY") {
     Write-DateLog "Please enter your key for the MAXMIND_LICENSE_KEY variable in config.ps1."
 } else {
-    # Download Maxmind GeoLite2 ASN database
     $folderUrl = "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-ASN&license_key=${MAXMIND_LICENSE_KEY}&suffix=tar.gz"
     $savePath = Join-Path -Path "${maxmindSaveDirectory}" -ChildPath "GeoLite2-ASN.tar.gz"
     Write-DateLog "Downloading GeoLite2-ASN.tar.gz"
     Invoke-WebRequest -Uri "${folderUrl}" -OutFile "${savePath}"
     Copy-Item -Path "${savePath}" -Destination "${maxmindSaveDirectory}\GeoLite2-ASN-${DATE}.tar.gz" -Force
 
-    # Download Maxmind GeoLite2 City database
     $folderUrl = "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=${MAXMIND_LICENSE_KEY}&suffix=tar.gz"
     $savePath = Join-Path -Path "${maxmindSaveDirectory}" -ChildPath "GeoLite2-City.tar.gz"
     Write-DateLog "Downloading GeoLite2-City.tar.gz"
     Invoke-WebRequest -Uri "${folderUrl}" -OutFile "${savePath}"
     Copy-Item -Path "${savePath}" -Destination "${maxmindSaveDirectory}\GeoLite2-City-${DATE}.tar.gz" -Force
 
-    # Download Maxmind GeoLite2 Country database
     $folderUrl = "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=${MAXMIND_LICENSE_KEY}&suffix=tar.gz"
     $savePath = Join-Path -Path "${maxmindSaveDirectory}" -ChildPath "GeoLite2-Country.tar.gz"
     Write-DateLog "Downloading GeoLite2-Country.tar.gz"
     Invoke-WebRequest -Uri "${folderUrl}" -OutFile "${savePath}"
     Copy-Item -Path "${savePath}" -Destination "${maxmindSaveDirectory}\GeoLite2-Country-${DATE}.tar.gz" -Force
 
-    # Unpack latest Maxmind GeoLite2 databases
     Write-DateLog "Unpacking Maxmind GeoLite2 databases"
 
     $maxmindASNUnpackPath = Join-Path -Path "${maxmindSaveDirectory}" -ChildPath "GeoLite2-ASN.tar.gz"
@@ -161,7 +149,6 @@ if (-not "${MAXMIND_LICENSE_KEY}") {
         Copy-Item -Path "${maxmindCurrentDirectory}\*.mmdb" -Destination ".\mount\Tools\logboost\"  -Force
     }
 
-    # Remove unpack directory
     Remove-Item -Path "${maxmindUnpackDirectory}" -Recurse -Force
 }
 
@@ -226,7 +213,6 @@ $status = Get-FileFromUri -uri "https://github.com/YARAHQ/yara-forge/releases/la
 $status = Get-FileFromUri -uri "https://github.com/YARAHQ/yara-forge/releases/latest/download/yara-forge-rules-full.zip" -FilePath ".\enrichment\yara\yara-forge-rules-full.zip"
 $null = $status
 
-# Unzip yara signatures
 & $SEVENZIP x -aoa "${yaraSaveDirectory}\yara-forge-rules-core.zip" -o"${yaraSaveDirectory}" | Out-Null
 & $SEVENZIP x -aoa "${yaraSaveDirectory}\yara-forge-rules-extended.zip" -o"${yaraSaveDirectory}" | Out-Null
 & $SEVENZIP x -aoa "${yaraSaveDirectory}\yara-forge-rules-full.zip" -o"${yaraSaveDirectory}" | Out-Null

--- a/resources/download/http.ps1
+++ b/resources/download/http.ps1
@@ -150,10 +150,7 @@ $status = Get-FileFromUri -uri "https://raw.githubusercontent.com/SwiftOnSecurit
 # Get Sysinternals Suite
 $status = Get-FileFromUri -uri "https://download.sysinternals.com/files/SysinternalsSuite.zip" -FilePath ".\downloads\sysinternals.zip" -check "Zip archive data"
 if ($status) {
-    if (Test-Path -Path "${TOOLS}\sysinternals") {
-        Remove-Item -Recurse -Force "${TOOLS}\sysinternals" | Out-Null 2>&1
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\sysinternals.zip" -o"${TOOLS}\sysinternals" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\sysinternals.zip" -Destination "${TOOLS}\sysinternals" -Target "${TOOLS}\sysinternals"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1229,10 +1226,7 @@ $TOOL_DEFINITIONS += @{
 # Get pestudio
 $status = Get-FileFromUri -uri "https://www.winitor.com/tools/pestudio/current/pestudio.zip" -FilePath ".\downloads\pestudio.zip" -check "Zip archive data"
 if ($status) {
-    if (Test-Path -Path "${TOOLS}\pestudio") {
-        Remove-Item -Recurse -Force "${TOOLS}\pestudio" | Out-Null 2>&1
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\pestudio.zip" -o"${TOOLS}" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\pestudio.zip" -Destination "${TOOLS}" -Target "${TOOLS}\pestudio"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1277,10 +1271,7 @@ $TOOL_DEFINITIONS += @{
 # Get HxD
 $status = Get-FileFromUri -uri "https://mh-nexus.de/downloads/HxDSetup.zip" -FilePath ".\downloads\hxd.zip" -check "Zip archive data"
 if ($status) {
-    if (Test-Path -Path "${TOOLS}\hxd") {
-        Remove-Item -Recurse -Force "${TOOLS}\hxd" | Out-Null 2>&1
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\hxd.zip" -o"${TOOLS}\hxd" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\hxd.zip" -Destination "${TOOLS}\hxd" -Target "${TOOLS}\hxd"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1375,10 +1366,7 @@ $TOOL_DEFINITIONS += @{
 # Get malcat - installed during start - 313 indicates use of Python 3.13
 $status = Get-FileFromUri -uri "https://malcat.fr/latest/malcat_win313_lite.zip" -FilePath ".\downloads\malcat.zip" -check "Zip archive data"
 if ($status) {
-    if (Test-Path -Path "${TOOLS}\malcat") {
-        Remove-Item -Recurse -Force "${TOOLS}\malcat" | Out-Null 2>&1
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\malcat.zip" -o"${TOOLS}\malcat" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\malcat.zip" -Destination "${TOOLS}\malcat" -Target "${TOOLS}\malcat"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1463,10 +1451,7 @@ $TOOL_DEFINITIONS += @{
 # Get ssview
 $status = Get-FileFromUri -uri "https://www.mitec.cz/wp/files/SSView.zip" -FilePath ".\downloads\ssview.zip" -check "Zip archive data"
 if ($status) {
-    if (Test-Path -Path "${TOOLS}\ssview") {
-        Remove-Item -Recurse -Force "${TOOLS}\ssview" | Out-Null 2>&1
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\ssview.zip" -o"${TOOLS}\ssview" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\ssview.zip" -Destination "${TOOLS}\ssview" -Target "${TOOLS}\ssview"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1512,10 +1497,7 @@ $TOOL_DEFINITIONS += @{
 # FullEventLogView
 $status = Get-FileFromUri -uri "https://www.nirsoft.net/utils/fulleventlogview-x64.zip" -FilePath ".\downloads\logview.zip" -check "Zip archive data"
 if ($status) {
-    if (Test-Path -Path "${TOOLS}\FullEventLogView") {
-        Remove-Item -Recurse -Force "${TOOLS}\FullEventLogView" | Out-Null 2>&1
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\logview.zip" -o"${TOOLS}\FullEventLogView" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\logview.zip" -Destination "${TOOLS}\FullEventLogView" -Target "${TOOLS}\FullEventLogView"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1612,10 +1594,7 @@ $TOOL_DEFINITIONS += @{
 # Win API Search
 $status = Get-FileFromUri -uri "https://dennisbabkin.com/php/downloads/WinApiSearch.zip" -FilePath ".\downloads\WinApiSearch.zip" -check "Zip archive data"
 if ($status) {
-    if (Test-Path -Path "${TOOLS}\WinApiSearch") {
-        Remove-Item -Recurse -Force "${TOOLS}\WinApiSearch" | Out-Null 2>&1
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\WinApiSearch.zip" -o"${TOOLS}\WinApiSearch" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\WinApiSearch.zip" -Destination "${TOOLS}\WinApiSearch" -Target "${TOOLS}\WinApiSearch"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1745,10 +1724,7 @@ $TOOL_DEFINITIONS += @{
 # Mail Viewer
 $status = Get-FileFromUri -uri "https://www.mitec.cz/wp/files/MailView.zip" -FilePath ".\downloads\mailview.zip" -check "Zip archive data"
 if ($status) {
-    if (Test-Path -Path "${TOOLS}\MailView") {
-        Remove-Item -Recurse -Force "${TOOLS}\MailView" | Out-Null 2>&1
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\mailview.zip" -o"${TOOLS}\MailView" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\mailview.zip" -Destination "${TOOLS}\MailView" -Target "${TOOLS}\MailView"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1794,10 +1770,7 @@ $TOOL_DEFINITIONS += @{
 if (Test-ToolIncluded -ToolName "Volatility Workbench 3") {
     $status = Get-FileFromUri -uri "https://www.osforensics.com/downloads/VolatilityWorkbench.zip" -FilePath ".\downloads\volatilityworkbench.zip" -check "Zip archive data"
     if ($status) {
-        if (Test-Path -Path "${TOOLS}\VolatilityWorkbench") {
-            Remove-Item -Recurse -Force "${TOOLS}\VolatilityWorkbench" | Out-Null 2>&1
-        }
-        & $SEVENZIP x -aoa "${SETUP_PATH}\volatilityworkbench.zip" -o"${TOOLS}\VolatilityWorkbench" | Out-Null
+        Install-ToolFromArchive -Archive "${SETUP_PATH}\volatilityworkbench.zip" -Destination "${TOOLS}\VolatilityWorkbench" -Target "${TOOLS}\VolatilityWorkbench"
     }
     $status = Get-FileFromUri -uri "https://downloads.volatilityfoundation.org/volatility3/symbols/linux.zip" -FilePath "${TOOLS}\VolatilityWorkbench\Symbols\linux.zip" -check "Zip archive data"
     $status = Get-FileFromUri -uri "https://downloads.volatilityfoundation.org/volatility3/symbols/mac.zip" -FilePath "${TOOLS}\VolatilityWorkbench\Symbols\mac.zip" -check "Zip archive data"
@@ -1847,10 +1820,7 @@ $TOOL_DEFINITIONS += @{
 if (Test-ToolIncluded -ToolName "Volatility Workbench 2.1") {
     $status = Get-FileFromUri -uri "https://www.osforensics.com/downloads/VolatilityWorkbench-v2.1.zip" -FilePath ".\downloads\volatilityworkbench2.zip" -check "Zip archive data"
     if ($status) {
-        if (Test-Path -Path "${TOOLS}\VolatilityWorkbench2") {
-            Remove-Item -Recurse -Force "${TOOLS}\VolatilityWorkbench2" | Out-Null 2>&1
-        }
-        & $SEVENZIP x -aoa "${SETUP_PATH}\volatilityworkbench2.zip" -o"${TOOLS}\VolatilityWorkbench2" | Out-Null
+        Install-ToolFromArchive -Archive "${SETUP_PATH}\volatilityworkbench2.zip" -Destination "${TOOLS}\VolatilityWorkbench2" -Target "${TOOLS}\VolatilityWorkbench2"
     }
 }
 
@@ -2466,10 +2436,7 @@ $TOOL_DEFINITIONS += @{
 if (Test-ToolIncluded -ToolName "capa Explorer Web") {
     $status = Get-FileFromUri -uri "https://mandiant.github.io/capa/explorer/capa-explorer-web.zip" -FilePath ".\downloads\capa-explorer-web.zip" -check "Zip archive data"
     if ($status) {
-        if (Test-Path -Path "${TOOLS}\capa-explorer-web") {
-            Remove-Item -Recurse -Force "${TOOLS}\capa-explorer-web" | Out-Null 2>&1
-        }
-        & $SEVENZIP x -aoa "${SETUP_PATH}\capa-explorer-web.zip" -o"${TOOLS}" | Out-Null
+        Install-ToolFromArchive -Archive "${SETUP_PATH}\capa-explorer-web.zip" -Destination "${TOOLS}" -Target "${TOOLS}\capa-explorer-web"
     }
 }
 
@@ -2590,10 +2557,7 @@ $TOOL_DEFINITIONS += @{
 $SQLiteVersion = Get-DownloadUrlFromPage -Url "https://sqlite.org/download.html" -RegEx '[0-9]+/sqlite-tools-win-x64-[^"]+.zip'
 $status = Get-FileFromUri -uri "https://sqlite.org/${SQLiteVersion}" -FilePath ".\downloads\sqlite.zip" -CheckURL "Yes"
 if ($status) {
-    if (Test-Path -Path "${TOOLS}\sqlite") {
-        Remove-Item -Recurse -Force "${TOOLS}\sqlite" | Out-Null 2>&1
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\sqlite.zip" -o"${TOOLS}\sqlite" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\sqlite.zip" -Destination "${TOOLS}\sqlite" -Target "${TOOLS}\sqlite"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -2636,10 +2600,7 @@ $TOOL_DEFINITIONS += @{
 $digitalcorpora_url = "https://digitalcorpora.s3.amazonaws.com/downloads/bulk_extractor/bulk_extractor-2.0.0-windows.zip"
 $status = Get-FileFromUri -uri "${digitalcorpora_url}" -FilePath ".\downloads\bulk_extractor.zip" -CheckURL "Yes" -check "Zip archive data"
 if ($status) {
-    if (Test-Path -Path "${TOOLS}\bulk_extractor") {
-        Remove-Item -Recurse -Force "${TOOLS}\bulk_extractor" | Out-Null 2>&1
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\bulk_extractor.zip" -o"${TOOLS}\bulk_extractor" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\bulk_extractor.zip" -Destination "${TOOLS}\bulk_extractor" -Target "${TOOLS}\bulk_extractor"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -2833,10 +2794,7 @@ $TOOL_DEFINITIONS += @{
 $nmap_url = Get-DownloadUrlFromPage -url "https://nmap.org/download.html" -RegEx 'https[^"]+setup.exe'
 $status = Get-FileFromUri -uri "${nmap_url}" -FilePath ".\downloads\nmap.exe" -CheckURL "Yes" -check "PE32"
 if ($status) {
-    if (Test-Path -Path "${TOOLS}\nmap") {
-        Remove-Item -Recurse -Force "${TOOLS}\nmap" | Out-Null 2>&1
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\nmap.exe" -o"${TOOLS}\nmap" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\nmap.exe" -Destination "${TOOLS}\nmap" -Target "${TOOLS}\nmap"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -2879,10 +2837,7 @@ $TOOL_DEFINITIONS += @{
 $flatassembler_version = Get-DownloadUrlFromPage -url "https://flatassembler.net/download.php" -RegEx 'fasmw[^"]+zip'
 $status = Get-FileFromUri -uri "https://flatassembler.net/${flatassembler_version}" -FilePath ".\downloads\fasm.zip" -CheckURL "Yes" -check "Zip archive data"
 if ($status) {
-    if (Test-Path -Path "${TOOLS}\fasm") {
-        Remove-Item -Recurse -Force "${TOOLS}\fasm" | Out-Null 2>&1
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\fasm.zip" -o"${TOOLS}\fasm" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\fasm.zip" -Destination "${TOOLS}\fasm" -Target "${TOOLS}\fasm"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -3008,10 +2963,7 @@ $TOOL_DEFINITIONS += @{
 $geolocus_url = Get-DownloadUrlFromPage -url "https://codeberg.org/hrbrmstr/geolocus-cli/releases" -RegEx 'https://[^"]*geolocus-cli-windows\.exe\.zip' -last
 $status = Get-FileFromUri -uri "${geolocus_url}" -FilePath ".\downloads\geolocus.zip" -CheckURL "Yes" -check "Zip archive data"
 if ($status) {
-    if (Test-Path -Path "${TOOLS}\geolocus") {
-        Remove-Item -Recurse -Force "${TOOLS}\geolocus" | Out-Null 2>&1
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\geolocus.zip" -o"${TOOLS}\geolocus" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\geolocus.zip" -Destination "${TOOLS}\geolocus" -Target "${TOOLS}\geolocus"
     Copy-Item "${TOOLS}\geolocus\geolocus-cli-windows.exe" -Destination "${TOOLS}\bin\geolocus-cli.exe" -Force
     Remove-Item -Recurse -Force "${TOOLS}\geolocus\__MACOSX" | Out-Null 2>&1
 }
@@ -3225,10 +3177,7 @@ $TOOL_DEFINITIONS += @{
 $PHP_URL = Get-DownloadUrlFromPage -Url "https://windows.php.net/download" -RegEx '/releases/archives/php-8.[.0-9]+-nts-Win32-vs17-x64.zip'
 $status = Get-FileFromUri -uri "https://downloads.php.net/~windows${PHP_URL}" -FilePath ".\downloads\php.zip" -CheckURL "Yes" -check "Zip archive data"
 if ($status) {
-    if (Test-Path -Path "${TOOLS}\php") {
-        Remove-Item -Recurse -Force "${TOOLS}\php" | Out-Null 2>&1
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\php.zip" -o"${TOOLS}\php" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\php.zip" -Destination "${TOOLS}\php" -Target "${TOOLS}\php"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -3364,10 +3313,7 @@ $TOOL_DEFINITIONS += @{
 # Resource hacker
 $status = Get-FileFromUri -uri "https://www.angusj.com/resourcehacker/resource_hacker.zip" -FilePath ".\downloads\resourcehacker.zip" -CheckURL "No" -check "Zip archive data"
 if ($status) {
-    if (Test-Path -Path "${TOOLS}\ResourceHacker") {
-        Remove-Item -Recurse -Force "${TOOLS}\ResourceHacker" | Out-Null 2>&1
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\resourcehacker.zip" -o"${TOOLS}\ResourceHacker" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\resourcehacker.zip" -Destination "${TOOLS}\ResourceHacker" -Target "${TOOLS}\ResourceHacker"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -3460,10 +3406,7 @@ $TOOL_DEFINITIONS += @{
 if (Test-ToolIncluded -ToolName "Android SDK Platform Tools") {
     $status = Get-FileFromUri -uri "https://dl.google.com/android/repository/platform-tools-latest-windows.zip" -FilePath ".\downloads\android_sdk.zip" -CheckURL "Yes" -check "Zip archive data"
     if ($status) {
-        if (Test-Path -Path "${TOOLS}\AndroidSDK") {
-            Remove-Item -Recurse -Force "${TOOLS}\AndroidSDK" | Out-Null 2>&1
-        }
-        & $SEVENZIP x -aoa "${SETUP_PATH}\android_sdk.zip" -o"${TOOLS}\AndroidSDK" | Out-Null
+        Install-ToolFromArchive -Archive "${SETUP_PATH}\android_sdk.zip" -Destination "${TOOLS}\AndroidSDK" -Target "${TOOLS}\AndroidSDK"
     }
 }
 

--- a/resources/download/release.ps1
+++ b/resources/download/release.ps1
@@ -4,11 +4,7 @@ $TOOL_DEFINITIONS = @()
 # artemis
 $status = Get-GitHubRelease -repo "puffyCid/artemis" -path "${SETUP_PATH}\artemis.zip" -match "x86_64-pc-windows-msvc.zip$" -check "Zip archive data"
 if ($status) {
-    & $SEVENZIP x -aoa "${SETUP_PATH}\artemis.zip" -o"${TOOLS}" | Out-Null
-    if (Test-Path "${TOOLS}\artemis") {
-        Remove-Item "${TOOLS}\artemis" -Recurse -Force
-    }
-    Move-Item ${TOOLS}\artemis-* "${TOOLS}\artemis"
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\artemis.zip" -Destination "${TOOLS}" -Target "${TOOLS}\artemis" -MoveFrom "${TOOLS}\artemis-*" -CleanAfterExtract
 }
 
 $TOOL_DEFINITIONS += @{
@@ -50,11 +46,7 @@ $TOOL_DEFINITIONS += @{
 if (Test-ToolIncluded -ToolName "godap") {
     $status = Get-GitHubRelease -repo "Macmod/godap" -path "${SETUP_PATH}\godap.zip" -match "windows-amd64.zip$" -check "Zip archive data"
     if ($status) {
-        if (Test-Path "${TOOLS}\godap") {
-            Remove-Item "${TOOLS}\godap" -Recurse -Force
-        }
-        & $SEVENZIP x -aoa "${SETUP_PATH}\godap.zip" -o"${TOOLS}\godap" | Out-Null
-        Move-Item ${TOOLS}\godap-* "${TOOLS}\godap"
+        Install-ToolFromArchive -Archive "${SETUP_PATH}\godap.zip" -Destination "${TOOLS}\godap" -Target "${TOOLS}\godap" -MoveFrom "${TOOLS}\godap-*"
     }
 }
 
@@ -179,19 +171,13 @@ $TOOL_DEFINITIONS += @{
 # aLEAPP
 $status = Get-GitHubRelease -repo "abrignoni/aLEAPP" -path "${SETUP_PATH}\aleapp.zip" -match "aleapp-.*Windows.zip" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\aleapp") {
-        Remove-Item "${TOOLS}\aleapp" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\aleapp.zip" -o"${TOOLS}\aleapp" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\aleapp.zip" -Destination "${TOOLS}\aleapp" -Target "${TOOLS}\aleapp"
     Copy-Item ${TOOLS}\aleapp\aleapp.exe ${TOOLS}\bin\
     Remove-Item "${TOOLS}\aleapp" -Recurse -Force
 }
 $status = Get-GitHubRelease -repo "abrignoni/aLEAPP" -path "${SETUP_PATH}\aleappGUI.zip" -match "aleappGUI-.*Windows.zip" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\aleappGUI") {
-        Remove-Item "${TOOLS}\aleappGUI" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\aleappGUI.zip" -o"${TOOLS}\aleappGUI" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\aleappGUI.zip" -Destination "${TOOLS}\aleappGUI" -Target "${TOOLS}\aleappGUI"
     Copy-Item ${TOOLS}\aleappGUI\aleappGUI.exe ${TOOLS}\bin\
     Remove-Item "${TOOLS}\aleappGUI" -Recurse -Force
 }
@@ -246,19 +232,13 @@ $TOOL_DEFINITIONS += @{
 # iLEAPP
 $status = Get-GitHubRelease -repo "abrignoni/iLEAPP" -path "${SETUP_PATH}\ileapp.zip" -match "ileapp-.*Windows.zip" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\ileapp") {
-        Remove-Item "${TOOLS}\ileapp" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\ileapp.zip" -o"${TOOLS}\ileapp" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\ileapp.zip" -Destination "${TOOLS}\ileapp" -Target "${TOOLS}\ileapp"
     Copy-Item ${TOOLS}\ileapp\ileapp.exe ${TOOLS}\bin\
     Remove-Item "${TOOLS}\ileapp" -Recurse -Force
 }
 $status = Get-GitHubRelease -repo "abrignoni/iLEAPP" -path "${SETUP_PATH}\ileappGUI.zip" -match "ileappGUI-.*Windows.zip" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\ileappGUI") {
-        Remove-Item "${TOOLS}\ileappGUI" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\ileappGUI.zip" -o"${TOOLS}\ileappGUI" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\ileappGUI.zip" -Destination "${TOOLS}\ileappGUI" -Target "${TOOLS}\ileappGUI"
     Copy-Item ${TOOLS}\ileappGUI\ileappGUI.exe ${TOOLS}\bin\
     Remove-Item "${TOOLS}\ileappGUI" -Recurse -Force
 }
@@ -313,10 +293,7 @@ $TOOL_DEFINITIONS += @{
 # lessmsi
 $status = Get-GitHubRelease -repo "activescott/lessmsi" -path "${SETUP_PATH}\lessmsi.zip" -match "lessmsi-v" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\lessmsi") {
-        Remove-Item "${TOOLS}\lessmsi" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\lessmsi.zip" -o"${TOOLS}\lessmsi" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\lessmsi.zip" -Destination "${TOOLS}\lessmsi" -Target "${TOOLS}\lessmsi"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -471,11 +448,7 @@ $TOOL_DEFINITIONS += @{
 if (Test-ToolIncluded -ToolName "Audacity") {
     $status = Get-GitHubRelease -repo "audacity/audacity" -path "${SETUP_PATH}\audacity.zip" -match "64bit.zip" -check "Zip archive data"
     if ($status) {
-        if (Test-Path "${TOOLS}\audacity") {
-            Remove-Item "${TOOLS}\audacity" -Recurse -Force
-        }
-        & $SEVENZIP x -aoa "${SETUP_PATH}\audacity.zip" -o"${TOOLS}" | Out-Null
-        Move-Item ${TOOLS}\audacity-* "${TOOLS}\audacity"
+        Install-ToolFromArchive -Archive "${SETUP_PATH}\audacity.zip" -Destination "${TOOLS}" -Target "${TOOLS}\audacity" -MoveFrom "${TOOLS}\audacity-*"
     }
 }
 
@@ -517,10 +490,7 @@ $TOOL_DEFINITIONS += @{
 # Ares
 $status = Get-GitHubRelease -repo "bee-san/Ares" -path "${SETUP_PATH}\ares.zip" -match "windows" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\ares") {
-        Remove-Item "${TOOLS}\ares" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\ares.zip" -o"${TOOLS}\ares" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\ares.zip" -Destination "${TOOLS}\ares" -Target "${TOOLS}\ares"
     Copy-Item "${TOOLS}\ares\ares.exe" "${TOOLS}\bin\" -Force
     Remove-Item "${TOOLS}\ares" -Force -Recurse
 }
@@ -603,11 +573,7 @@ $TOOL_DEFINITIONS += @{
 # RDPCacheStitcher
 $status = Get-GitHubRelease -repo "BSI-Bund/RdpCacheStitcher" -path "${SETUP_PATH}\RdpCacheStitcher.zip" -match "win64" -check "Zip archive data"
 if ($status) {
-    & $SEVENZIP x -aoa "${SETUP_PATH}\RdpCacheStitcher.zip" -o"${TOOLS}" | Out-Null
-    if (Test-Path "${TOOLS}\RdpCacheStitcher") {
-        Remove-Item "${TOOLS}\RdpCacheStitcher" -Recurse -Force
-    }
-    Move-Item ${TOOLS}\RdpCacheStitcher_* "${TOOLS}\RdpCacheStitcher"
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\RdpCacheStitcher.zip" -Destination "${TOOLS}" -Target "${TOOLS}\RdpCacheStitcher" -MoveFrom "${TOOLS}\RdpCacheStitcher_*" -CleanAfterExtract
 }
 
 $TOOL_DEFINITIONS += @{
@@ -649,11 +615,7 @@ $TOOL_DEFINITIONS += @{
 if (Test-ToolIncluded -ToolName "ffmpeg") {
     $status = Get-GitHubRelease -repo "BtbN/FFmpeg-Builds" -path "${SETUP_PATH}\ffmpeg.zip" -match "win64-gpl-7" -check "Zip archive data"
     if ($status) {
-        if (Test-Path "${TOOLS}\ffmpeg") {
-            Remove-Item "${TOOLS}\ffmpeg" -Recurse -Force
-        }
-        & $SEVENZIP x -aoa "${SETUP_PATH}\ffmpeg.zip" -o"${TOOLS}" | Out-Null
-        Move-Item ${TOOLS}\ffmpeg-* "${TOOLS}\ffmpeg"
+        Install-ToolFromArchive -Archive "${SETUP_PATH}\ffmpeg.zip" -Destination "${TOOLS}" -Target "${TOOLS}\ffmpeg" -MoveFrom "${TOOLS}\ffmpeg-*"
     }
 }
 
@@ -695,11 +657,7 @@ $TOOL_DEFINITIONS += @{
 # ripgrep
 $status = Get-GitHubRelease -repo "BurntSushi/ripgrep" -path "${SETUP_PATH}\ripgrep.zip" -match "x86_64-pc-windows-msvc.zip$" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\ripgrep") {
-        Remove-Item "${TOOLS}\ripgrep" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\ripgrep.zip" -o"${TOOLS}" | Out-Null
-    Move-Item ${TOOLS}\ripgrep-* "${TOOLS}\ripgrep"
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\ripgrep.zip" -Destination "${TOOLS}" -Target "${TOOLS}\ripgrep" -MoveFrom "${TOOLS}\ripgrep-*"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -852,10 +810,7 @@ $TOOL_DEFINITIONS += @{
 if (Test-ToolIncluded -ToolName "DBeaver") {
     $status = Get-GitHubRelease -repo "dbeaver/dbeaver" -path "${SETUP_PATH}\dbeaver.zip" -match "win32.win32.x86_64.zip" -check "Zip archive data"
     if ($status) {
-        if (Test-Path "${TOOLS}\dbeaver") {
-            Remove-Item "${TOOLS}\dbeaver" -Recurse -Force
-        }
-        & $SEVENZIP x -aoa "${SETUP_PATH}\dbeaver.zip" -o"${TOOLS}" | Out-Null
+        Install-ToolFromArchive -Archive "${SETUP_PATH}\dbeaver.zip" -Destination "${TOOLS}" -Target "${TOOLS}\dbeaver"
     }
 }
 
@@ -897,10 +852,7 @@ $TOOL_DEFINITIONS += @{
 # Dumpbin from Visual Studio
 $status = Get-GitHubRelease -repo "Delphier/dumpbin" -path "${SETUP_PATH}\dumpbin.zip" -match "dumpbin" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\dumpbin") {
-        Remove-Item "${TOOLS}\dumpbin" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\dumpbin.zip" -o"${TOOLS}\dumpbin" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\dumpbin.zip" -Destination "${TOOLS}\dumpbin" -Target "${TOOLS}\dumpbin"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -941,17 +893,11 @@ $TOOL_DEFINITIONS += @{
 # dnSpy 32-bit and 64-bit
 $status = Get-GitHubRelease -repo "dnSpyEx/dnSpy" -path "${SETUP_PATH}\dnSpy32.zip" -match "win32" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\dnSpy32") {
-        Remove-Item "${TOOLS}\dnSpy32" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\dnSpy32.zip" -o"${TOOLS}\dnSpy32" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\dnSpy32.zip" -Destination "${TOOLS}\dnSpy32" -Target "${TOOLS}\dnSpy32"
 }
 $status = Get-GitHubRelease -repo "dnSpyEx/dnSpy" -path "${SETUP_PATH}\dnSpy64.zip" -match "win64" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\dnSpy64") {
-        Remove-Item "${TOOLS}\dnSpy64" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\dnSpy64.zip" -o"${TOOLS}\dnSpy64" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\dnSpy64.zip" -Destination "${TOOLS}\dnSpy64" -Target "${TOOLS}\dnSpy64"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1033,10 +979,7 @@ $TOOL_DEFINITIONS += @{
 # mboxviewer
 $status = Get-GitHubRelease -repo "eneam/mboxviewer" -path "${SETUP_PATH}\mboxviewer.zip" -match "mbox-viewer.exe"
 if ($status) {
-    if (Test-Path "${TOOLS}\mboxviewer") {
-        Remove-Item "${TOOLS}\mboxviewer" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\mboxviewer.zip" -o"${TOOLS}\mboxviewer" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\mboxviewer.zip" -Destination "${TOOLS}\mboxviewer" -Target "${TOOLS}\mboxviewer"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1122,10 +1065,7 @@ $TOOL_DEFINITIONS += @{
 # CyberChef
 $status = Get-GitHubRelease -repo "gchq/CyberChef" -path "${SETUP_PATH}\CyberChef.zip" -match "CyberChef" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\CyberChef") {
-        Remove-Item "${TOOLS}\CyberChef" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\CyberChef.zip" -o"${TOOLS}\CyberChef" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\CyberChef.zip" -Destination "${TOOLS}\CyberChef" -Target "${TOOLS}\CyberChef"
     if (Test-Path "${TOOLS}\CyberChef\CyberChef.html") {
         Remove-Item "${TOOLS}\CyberChef\CyberChef.html" -Force
     }
@@ -1237,10 +1177,7 @@ $TOOL_DEFINITIONS += @{
 if (Test-ToolIncluded -ToolName "h2database") {
     $status = Get-GitHubRelease -repo "h2database/h2database" -path "${SETUP_PATH}\h2database.zip" -match "bundle.jar" -check "Java archive data"
     if ($status) {
-        if (Test-Path "${TOOLS}\h2database") {
-            Remove-Item "${TOOLS}\h2database" -Recurse -Force
-        }
-        & $SEVENZIP x -aoa "${SETUP_PATH}\h2database.zip" -o"${TOOLS}\h2database" | Out-Null
+        Install-ToolFromArchive -Archive "${SETUP_PATH}\h2database.zip" -Destination "${TOOLS}\h2database" -Target "${TOOLS}\h2database"
     }
     $status = Get-GitHubRelease -repo "h2database/h2database" -path "${SETUP_PATH}\h2.pdf" -match "h2.pdf"
     if ($status) {
@@ -1280,10 +1217,7 @@ $TOOL_DEFINITIONS += @{
 # INDXRipper
 $status = Get-GitHubRelease -repo "harelsegev/INDXRipper" -path "${SETUP_PATH}\indxripper.zip" -match "amd64.zip" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\INDXRipper") {
-        Remove-Item "${TOOLS}\INDXRipper" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\indxripper.zip" -o"${TOOLS}\INDXRipper" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\indxripper.zip" -Destination "${TOOLS}\INDXRipper" -Target "${TOOLS}\INDXRipper"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1398,10 +1332,7 @@ $TOOL_DEFINITIONS += @{
 # PE-bear
 $status = Get-GitHubRelease -repo "hasherezade/pe-bear" -path "${SETUP_PATH}\pebear.zip" -match "x64_win_vs19.zip" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\pebear") {
-        Remove-Item "${TOOLS}\pebear" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\pebear.zip" -o"${TOOLS}\pebear" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\pebear.zip" -Destination "${TOOLS}\pebear" -Target "${TOOLS}\pebear"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1529,10 +1460,7 @@ $TOOL_DEFINITIONS += @{
 $status = Get-GitHubRelease -repo "hfiref0x/WinObjEx64" -path "${SETUP_PATH}\WinObjEx64.zip" -match "WinobjEx64.*[0-9].zip" -check "Zip archive data"
 $plugin_status = Get-GitHubRelease -repo "hfiref0x/WinObjEx64" -path "${SETUP_PATH}\WinObjEx64_plugins.zip" -match "WinobjEx64.*plugins.zip" -check "Zip archive data"
 if ($status -or $plugin_status) {
-    if (Test-Path "${TOOLS}\WinObjEx64") {
-        Remove-Item "${TOOLS}\WinObjEx64" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\WinObjEx64.zip" -o"${TOOLS}\WinObjEx64" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\WinObjEx64.zip" -Destination "${TOOLS}\WinObjEx64" -Target "${TOOLS}\WinObjEx64"
     & $SEVENZIP x -aoa "${SETUP_PATH}\WinObjEx64_plugins.zip" -o"${TOOLS}\WinObjEx64" | Out-Null
 }
 
@@ -1574,10 +1502,7 @@ $TOOL_DEFINITIONS += @{
 # Detect It Easy
 $status = Get-GitHubRelease -repo "horsicq/DIE-engine" -path "${SETUP_PATH}\die.zip" -match "die_win64_portable" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\die") {
-        Remove-Item "${TOOLS}\die" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\die.zip" -o"${TOOLS}" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\die.zip" -Destination "${TOOLS}" -Target "${TOOLS}\die"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1623,10 +1548,7 @@ $TOOL_DEFINITIONS += @{
 # XELFViewer
 $status = Get-GitHubRelease -repo "horsicq/XELFViewer" -path "${SETUP_PATH}\XELFViewer.zip" -match "win64_portable" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\XELFViewer") {
-        Remove-Item "${TOOLS}\XELFViewer" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\XELFViewer.zip" -o"${TOOLS}\XELFViewer" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\XELFViewer.zip" -Destination "${TOOLS}\XELFViewer" -Target "${TOOLS}\XELFViewer"
     if (Test-Path "${CONFIGURATION_FILES}\xelfviewer.ini") {
         Copy-Item "${CONFIGURATION_FILES}\xelfviewer.ini" "${TOOLS}\XELFViewer\xelfviewer.ini"
     } else {
@@ -1672,11 +1594,7 @@ $TOOL_DEFINITIONS += @{
 # jd-gui
 $status = Get-GitHubRelease -repo "java-decompiler/jd-gui" -path "${SETUP_PATH}\jd-gui.zip" -match "jd-gui-windows" -check "Zip archive data"
 if ($status) {
-    & $SEVENZIP x -aoa "${SETUP_PATH}\jd-gui.zip" -o"${TOOLS}" | Out-Null
-    if (Test-Path "${TOOLS}\jd-gui") {
-        Remove-Item "${TOOLS}\jd-gui" -Recurse -Force
-    }
-    Move-Item ${TOOLS}\jd-gui* "${TOOLS}\jd-gui"
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\jd-gui.zip" -Destination "${TOOLS}" -Target "${TOOLS}\jd-gui" -MoveFrom "${TOOLS}\jd-gui*" -CleanAfterExtract
 }
 
 $TOOL_DEFINITIONS += @{
@@ -1960,10 +1878,7 @@ $TOOL_DEFINITIONS += @{
 # gftrace
 $status = Get-GitHubRelease -repo "leandrofroes/gftrace" -path "${SETUP_PATH}\gftrace.zip" -match "gftrace64" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\gftrace64") {
-        Remove-Item "${TOOLS}\gftrace64" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\gftrace.zip" -o"${TOOLS}" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\gftrace.zip" -Destination "${TOOLS}" -Target "${TOOLS}\gftrace64"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -2082,10 +1997,7 @@ $TOOL_DEFINITIONS += @{
 # capa
 $status = Get-GitHubRelease -repo "mandiant/capa" -path "${SETUP_PATH}\capa-windows.zip" -match "windows" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\capa") {
-        Remove-Item "${TOOLS}\capa" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\capa-windows.zip" -o"${TOOLS}\capa" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\capa-windows.zip" -Destination "${TOOLS}\capa" -Target "${TOOLS}\capa"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -2131,11 +2043,7 @@ $TOOL_DEFINITIONS += @{
 # capa-rules
 $status = Get-GitHubRelease -repo "mandiant/capa-rules" -path "${SETUP_PATH}\capa-rules.zip" -match "Source" -check "Zip archive data"
 if ($status) {
-    & $SEVENZIP x -aoa "${SETUP_PATH}\capa-rules.zip" -o"${TOOLS}" | Out-Null
-    if (Test-Path "${TOOLS}\capa-rules") {
-        Remove-Item "${TOOLS}\capa-rules" -Recurse -Force
-    }
-    Move-Item ${TOOLS}\mandiant-capa-rules-* "${TOOLS}\capa-rules"
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\capa-rules.zip" -Destination "${TOOLS}" -Target "${TOOLS}\capa-rules" -MoveFrom "${TOOLS}\mandiant-capa-rules-*" -CleanAfterExtract
 }
 
 $TOOL_DEFINITIONS += @{
@@ -2203,10 +2111,7 @@ $TOOL_DEFINITIONS += @{
 # Microsoft PowerShell
 $status = Get-GitHubRelease -repo "PowerShell/PowerShell" -path "${SETUP_PATH}\pwsh.zip" -match "win-x64.zip" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\pwsh") {
-        Remove-Item "${TOOLS}\pwsh" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\pwsh.zip" -o"${TOOLS}\pwsh" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\pwsh.zip" -Destination "${TOOLS}\pwsh" -Target "${TOOLS}\pwsh"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -2320,10 +2225,7 @@ $TOOL_DEFINITIONS += @{
 # Flare-Floss
 $status = Get-GitHubRelease -repo "mandiant/flare-floss" -path "${SETUP_PATH}\floss.zip" -match "windows" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\floss") {
-        Remove-Item "${TOOLS}\floss" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\floss.zip" -o"${TOOLS}\floss" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\floss.zip" -Destination "${TOOLS}\floss" -Target "${TOOLS}\floss"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -2364,11 +2266,7 @@ $TOOL_DEFINITIONS += @{
 # Flare-Fakenet-NG
 $status = Get-GitHubRelease -repo "mandiant/flare-fakenet-ng" -path "${SETUP_PATH}\fakenet.zip" -match "fakenet" -check "Zip archive data"
 if ($status) {
-    & $SEVENZIP x -aoa "${SETUP_PATH}\fakenet.zip" -o"${TOOLS}" | Out-Null
-    if (Test-Path "${TOOLS}\fakenet") {
-        Remove-Item "${TOOLS}\fakenet" -Recurse -Force
-    }
-    Move-Item ${TOOLS}\fakenet* "${TOOLS}\fakenet"
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\fakenet.zip" -Destination "${TOOLS}" -Target "${TOOLS}\fakenet" -MoveFrom "${TOOLS}\fakenet*" -CleanAfterExtract
 }
 
 $TOOL_DEFINITIONS += @{
@@ -2409,10 +2307,7 @@ $TOOL_DEFINITIONS += @{
 # GoReSym
 $status = Get-GitHubRelease -repo "mandiant/GoReSym" -path "${SETUP_PATH}\GoReSym.zip" -match "windows.zip" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\GoReSym") {
-        Remove-Item "${TOOLS}\GoReSym" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\GoReSym.zip" -o"${TOOLS}\GoReSym" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\GoReSym.zip" -Destination "${TOOLS}\GoReSym" -Target "${TOOLS}\GoReSym"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -2498,11 +2393,7 @@ $TOOL_DEFINITIONS += @{
 # Elfparser-ng
 $status = Get-GitHubRelease -repo "mentebinaria/elfparser-ng" -path "${SETUP_PATH}\elfparser-ng.zip" -match "win64" -check "Zip archive data"
 if ($status) {
-    & $SEVENZIP x -aoa "${SETUP_PATH}\elfparser-ng.zip" -o"${TOOLS}" | Out-Null
-    if (Test-Path "${TOOLS}\elfparser-ng") {
-        Remove-Item "${TOOLS}\elfparser-ng" -Recurse -Force
-    }
-    Move-Item ${TOOLS}\elfparser-ng* "${TOOLS}\elfparser-ng"
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\elfparser-ng.zip" -Destination "${TOOLS}" -Target "${TOOLS}\elfparser-ng" -MoveFrom "${TOOLS}\elfparser-ng*" -CleanAfterExtract
 }
 
 $TOOL_DEFINITIONS += @{
@@ -2580,11 +2471,7 @@ $TOOL_DEFINITIONS += @{
 # Dit explorer
 $status = Get-GitHubRelease -repo "trustedsec/DitExplorer" -path "${SETUP_PATH}\DitExplorer.zip" -match "win64-release.zip" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\DitExplorer") {
-        Remove-Item "${TOOLS}\DitExplorer" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\DitExplorer.zip" -o"${TOOLS}" | Out-Null
-    Move-Item ${TOOLS}\DitExplorer-* "${TOOLS}\DitExplorer"
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\DitExplorer.zip" -Destination "${TOOLS}" -Target "${TOOLS}\DitExplorer" -MoveFrom "${TOOLS}\DitExplorer-*"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -3102,11 +2989,7 @@ $TOOL_DEFINITIONS += @{
 # qpdf
 $status = Get-GitHubRelease -repo "qpdf/qpdf" -path "${SETUP_PATH}\qpdf.zip" -match "msvc64.zip" -check "Zip archive data"
 if ($status) {
-    & $SEVENZIP x -aoa "${SETUP_PATH}\qpdf.zip" -o"${TOOLS}" | Out-Null
-    if (Test-Path "${TOOLS}\qpdf") {
-        Remove-Item "${TOOLS}\qpdf" -Recurse -Force
-    }
-    Move-Item ${TOOLS}\qpdf-* "${TOOLS}\qpdf"
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\qpdf.zip" -Destination "${TOOLS}" -Target "${TOOLS}\qpdf" -MoveFrom "${TOOLS}\qpdf-*" -CleanAfterExtract
 }
 
 $TOOL_DEFINITIONS += @{
@@ -3292,10 +3175,7 @@ $TOOL_DEFINITIONS += @{
 # Iaito by Radareorg
 $status = Get-GitHubRelease -repo "radareorg/iaito" -path "${SETUP_PATH}\iaito.zip" -match "iaito.zip" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\iaito") {
-        Remove-Item "${TOOLS}\iaito" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\iaito.zip" -o"${TOOLS}" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\iaito.zip" -Destination "${TOOLS}" -Target "${TOOLS}\iaito"
     if (Test-Path "${TOOLS}\__MACOSX") {
         Remove-Item "${TOOLS}\__MACOSX" -Recurse -Force
     }
@@ -3339,10 +3219,7 @@ $TOOL_DEFINITIONS += @{
 # hfs
 $status = Get-GitHubRelease -repo "rejetto/hfs" -path "${SETUP_PATH}\hfs.zip" -match "hfs-windows-x64" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\hfs") {
-        Remove-Item "${TOOLS}\hfs" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\hfs.zip" -o"${TOOLS}\hfs" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\hfs.zip" -Destination "${TOOLS}\hfs" -Target "${TOOLS}\hfs"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -3501,10 +3378,7 @@ $TOOL_DEFINITIONS += @{
 if (Test-ToolIncluded -ToolName "Strawberry Perl") {
     $status = Get-GitHubRelease -repo "StrawberryPerl/Perl-Dist-Strawberry" -path "${SETUP_PATH}\perl.zip" -match "portable.zip" -check "Zip archive data"
     if ($status) {
-        if (Test-Path "${TOOLS}\perl") {
-            Remove-Item "${TOOLS}\perl" -Recurse -Force
-        }
-        & $SEVENZIP x -aoa "${SETUP_PATH}\perl.zip" -o"${TOOLS}\perl" | Out-Null
+        Install-ToolFromArchive -Archive "${SETUP_PATH}\perl.zip" -Destination "${TOOLS}\perl" -Target "${TOOLS}\perl"
     }
 }
 
@@ -3607,11 +3481,7 @@ $TOOL_DEFINITIONS += @{
 # Sleuthkit
 $status = Get-GitHubRelease -repo "sleuthkit/sleuthkit" -path "${SETUP_PATH}\sleuthkit.zip" -match "win32.zip$" -check "Zip archive data"
 if ($status) {
-    & $SEVENZIP x -aoa "${SETUP_PATH}\sleuthkit.zip" -o"${TOOLS}" | Out-Null
-    if (Test-Path "${TOOLS}\sleuthkit") {
-        Remove-Item "${TOOLS}\sleuthkit" -Recurse -Force
-    }
-    Move-Item ${TOOLS}\sleuthkit-* "${TOOLS}\sleuthkit"
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\sleuthkit.zip" -Destination "${TOOLS}" -Target "${TOOLS}\sleuthkit" -MoveFrom "${TOOLS}\sleuthkit-*" -CleanAfterExtract
 }
 
 $TOOL_DEFINITIONS += @{
@@ -3652,11 +3522,7 @@ $TOOL_DEFINITIONS += @{
 # qrtool
 $status = Get-GitHubRelease -repo "sorairolake/qrtool" -path "${SETUP_PATH}\qrtool.zip" -match "x86_64-pc-windows-msvc" -check "Zip archive data"
 if ($status) {
-    & $SEVENZIP x -aoa "${SETUP_PATH}\qrtool.zip" -o"${TOOLS}" | Out-Null
-    if (Test-Path "${TOOLS}\qrtool") {
-        Remove-Item "${TOOLS}\qrtool" -Recurse -Force
-    }
-    Move-Item ${TOOLS}\qrtool-* "${TOOLS}\qrtool"
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\qrtool.zip" -Destination "${TOOLS}" -Target "${TOOLS}\qrtool" -MoveFrom "${TOOLS}\qrtool-*" -CleanAfterExtract
 }
 
 $TOOL_DEFINITIONS += @{
@@ -3730,10 +3596,7 @@ $TOOL_DEFINITIONS += @{
 # Thumbcacheviewer
 $status = Get-GitHubRelease -repo "thumbcacheviewer/thumbcacheviewer" -path "${SETUP_PATH}\thumbcacheviewer.zip" -match "viewer_64" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\thumbcacheviewer") {
-        Remove-Item "${TOOLS}\thumbcacheviewer" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\thumbcacheviewer.zip" -o"${TOOLS}\thumbcacheviewer" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\thumbcacheviewer.zip" -Destination "${TOOLS}\thumbcacheviewer" -Target "${TOOLS}\thumbcacheviewer"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -3815,10 +3678,7 @@ $TOOL_DEFINITIONS += @{
 # MemProcFS
 $status = Get-GitHubRelease -repo "ufrisk/MemProcFS" -path "${SETUP_PATH}\memprocfs.zip" -match "win_x64" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\MemProcFS") {
-        Remove-Item "${TOOLS}\MemProcFS" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\memprocfs.zip" -o"${TOOLS}\MemProcFS" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\memprocfs.zip" -Destination "${TOOLS}\MemProcFS" -Target "${TOOLS}\MemProcFS"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -3859,11 +3719,7 @@ $TOOL_DEFINITIONS += @{
 # upx
 $status = Get-GitHubRelease -repo "upx/upx" -path "${SETUP_PATH}\upx.zip" -match "win64" -check "Zip archive data"
 if ($status) {
-    & $SEVENZIP x -aoa "${SETUP_PATH}\upx.zip" -o"${TOOLS}" | Out-Null
-    if (Test-Path "${TOOLS}\upx") {
-        Remove-Item "${TOOLS}\upx" -Recurse -Force
-    }
-    Move-Item ${TOOLS}\upx-* "${TOOLS}\upx"
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\upx.zip" -Destination "${TOOLS}" -Target "${TOOLS}\upx" -MoveFrom "${TOOLS}\upx-*" -CleanAfterExtract
 }
 
 $TOOL_DEFINITIONS += @{
@@ -4055,10 +3911,7 @@ $TOOL_DEFINITIONS += @{
 # imhex
 $status = Get-GitHubRelease -repo "WerWolv/ImHex" -path "${SETUP_PATH}\imhex.zip" -match "Portable-NoGPU-x86_64.zip" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\imhex") {
-        Remove-Item "${TOOLS}\imhex" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\imhex.zip" -o"${TOOLS}\imhex" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\imhex.zip" -Destination "${TOOLS}\imhex" -Target "${TOOLS}\imhex"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -4104,10 +3957,7 @@ $TOOL_DEFINITIONS += @{
 # chainsaw
 $status = Get-GitHubRelease -repo "WithSecureLabs/chainsaw" -path "${SETUP_PATH}\chainsaw.zip" -match "x86_64-pc-windows-msvc" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\chainsaw") {
-        Remove-Item "${TOOLS}\chainsaw" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\chainsaw.zip" -o"${TOOLS}" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\chainsaw.zip" -Destination "${TOOLS}" -Target "${TOOLS}\chainsaw"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -4539,11 +4389,7 @@ $TOOL_DEFINITIONS += @{
 # NetExt
 $status = Get-GitHubRelease -repo "rodneyviana/netext" -path "${SETUP_PATH}\netext.zip" -match "NetExt-.*.zip" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\NetExt") {
-        Remove-Item "${TOOLS}\NetExt" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\netext.zip" -o"${TOOLS}" | Out-Null
-    Move-Item ${TOOLS}\NetExt-* "${TOOLS}\NetExt"
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\netext.zip" -Destination "${TOOLS}" -Target "${TOOLS}\NetExt" -MoveFrom "${TOOLS}\NetExt-*"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -4571,10 +4417,7 @@ $TOOL_DEFINITIONS += @{
 if (Test-ToolIncluded -ToolName "YAMAGoya") {
     $status = Get-GitHubRelease -repo "JPCERTCC/YAMAGoya" -path "${SETUP_PATH}\YAMAGoya.zip" -match "YAMAGoya.*.zip" -check "Zip archive data"
     if ($status) {
-        if (Test-Path "${TOOLS}\YAMAGoya") {
-            Remove-Item "${TOOLS}\YAMAGoya" -Recurse -Force
-        }
-        & $SEVENZIP x -aoa "${SETUP_PATH}\YAMAGoya.zip" -o"${TOOLS}\YAMAGoya" | Out-Null
+        Install-ToolFromArchive -Archive "${SETUP_PATH}\YAMAGoya.zip" -Destination "${TOOLS}\YAMAGoya" -Target "${TOOLS}\YAMAGoya"
     }
 }
 
@@ -4610,10 +4453,7 @@ $TOOL_DEFINITIONS += @{
 # RpcView
 $status = Get-GitHubRelease -repo "silverf0x/RpcView" -path "${SETUP_PATH}\rpcview.7z" -match "RpcView64.7z" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\RpcView") {
-        Remove-Item "${TOOLS}\RpcView" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\rpcview.7z" -o"${TOOLS}" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\rpcview.7z" -Destination "${TOOLS}" -Target "${TOOLS}\RpcView"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -4698,10 +4538,7 @@ $TOOL_DEFINITIONS += @{
 # ILSpy
 $status = Get-GitHubRelease -repo "icsharpcode/ILSpy" -path "${SETUP_PATH}\ilspy.zip" -match "ILSpy_selfcontained_.*x64.zip" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\ILSpy") {
-        Remove-Item "${TOOLS}\ILSpy" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\ilspy.zip" -o"${TOOLS}\ILSpy" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\ilspy.zip" -Destination "${TOOLS}\ILSpy" -Target "${TOOLS}\ILSpy"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -4742,10 +4579,7 @@ $TOOL_DEFINITIONS += @{
 # carina-studio/ULogViewer
 $status = Get-GitHubRelease -repo "carina-studio/ULogViewer" -path "${SETUP_PATH}\ULogViewer.zip" -match "ULogViewer-[0-9.]*-win-x64.zip" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\ULogViewer") {
-        Remove-Item "${TOOLS}\ULogViewer" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\ULogViewer.zip" -o"${TOOLS}\ULogViewer" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\ULogViewer.zip" -Destination "${TOOLS}\ULogViewer" -Target "${TOOLS}\ULogViewer"
 }
 
 $TOOL_DEFINITIONS += @{
@@ -4786,10 +4620,7 @@ $TOOL_DEFINITIONS += @{
 # lucasg/Dependencies
 $status = Get-GitHubRelease -repo "lucasg/Dependencies" -path "${SETUP_PATH}\Dependencies.zip" -match "_x64_Release.zip" -check "Zip archive data"
 if ($status) {
-    if (Test-Path "${TOOLS}\Dependencies") {
-        Remove-Item "${TOOLS}\Dependencies" -Recurse -Force
-    }
-    & $SEVENZIP x -aoa "${SETUP_PATH}\Dependencies.zip" -o"${TOOLS}\Dependencies" | Out-Null
+    Install-ToolFromArchive -Archive "${SETUP_PATH}\Dependencies.zip" -Destination "${TOOLS}\Dependencies" -Target "${TOOLS}\Dependencies"
 }
 
 $TOOL_DEFINITIONS += @{

--- a/setup/shared.ps1
+++ b/setup/shared.ps1
@@ -1,4 +1,3 @@
-# Function to create tool files
 function Normalize-ToolDefinitions {
     param(
         [Parameter(Mandatory=$True)] [array]$ToolDefinitions

--- a/setup/start_sandbox.ps1
+++ b/setup/start_sandbox.ps1
@@ -741,7 +741,12 @@ Get-Job | Remove-Job | Out-Null
 
 Write-DateLog "Setup done." | Write-SetupLog
 
+$dfirwsFolderDeadline = (Get-Date).AddMinutes(30)
 While (! (Test-Path "${WSDFIR_TEMP}\dfirws_folder_done.txt")) {
+    if ((Get-Date) -gt $dfirwsFolderDeadline) {
+        Write-DateLog "WARNING: Timed out waiting for dfirws_folder_done.txt. Continuing." | Write-SetupLog
+        break
+    }
     Start-Sleep -Seconds 1
 }
 

--- a/setup/wscommon.ps1
+++ b/setup/wscommon.ps1
@@ -1,4 +1,3 @@
-# Set variables
 $ENRICHMENT = "C:\enrichment"
 $GIT_PATH = "C:\git"
 $LOCAL_PATH = "C:\local"
@@ -52,7 +51,6 @@ if (Test-Path -Path "C:\log") {
     }
 }
 
-# Create required directories
 foreach ($dir in @("${WSDFIR_TEMP}\msys2", "${HOME}\Documents\WindowsPowerShell", "${HOME}\Documents\PowerShell", "${env:ProgramFiles}\PowerShell\Modules\PSDecode", "${env:ProgramFiles}\dfirws", "${HOME}\Documents\jupyter")) {
     if (-not (Test-Path -Path $dir)) {
         New-Item -ItemType Directory -Path $dir -Force | Out-Null
@@ -88,8 +86,6 @@ function Test-ToolIncludedSandbox {
     }
     return $true
 }
-
-# Declare helper functions
 
 # Adds a directory to the user's PATH environment variable.
 function Add-ToUserPath {
@@ -163,7 +159,6 @@ function Add-Shortcut {
     $Shortcut.Save()
 }
 
-# Update the wallpaper for the current users desktop
 function Update-WallPaper {
     [CmdletBinding(SupportsShouldProcess)]
     param (
@@ -175,7 +170,6 @@ function Update-WallPaper {
     & "${TOOLS}\sysinternals\Bginfo64.exe" /NOLICPROMPT /timer:0 "${HOME}\Documents\tools\config.bgi"
 }
 
-# Write a log with a timestamp
 function Write-DateLog {
     param (
         [Parameter(Mandatory=$True)] [string]$Message
@@ -386,7 +380,6 @@ function Close-SandboxProgress {
     }
 }
 
-# Function to verify a command exists and is of a certain type
 function Test-Command {
     [CmdletBinding()]
     param (
@@ -651,8 +644,6 @@ function Install-Firefox {
 function Install-ForensicTimeliner {
     if (!(Test-Path "${env:ProgramFiles}\dfirws\installed-forensictimeliner.txt")) {
         Write-Output "Installing Forensic Timeliner"
-        #$CLI_TOOL = "${POWERSHELL_EXE}"
-        #$CLI_TOOL_ARGS = "-NoExit"
         $TERMINAL_INSTALL_DIR = ((Get-ChildItem "$env:ProgramFiles\Windows Terminal").Name | Select-String "terminal" | Select-Object -Last 1)
         $TERMINAL_INSTALL_LOCATION = "$env:ProgramFiles\Windows Terminal\$TERMINAL_INSTALL_DIR"
         $CLI_TOOL = "${TERMINAL_INSTALL_LOCATION}\wt.exe"
@@ -866,7 +857,6 @@ function Install-Hashcat {
         Copy-Item -Recurse "${TOOLS}\hashcat" "${env:ProgramFiles}" -Force
         Add-ToUserPath "${env:ProgramFiles}\hashcat"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Utilities\Crypto\hashcat.lnk" -DestinationPath "${POWERSHELL_EXE}" -WorkingDirectory "${env:ProgramFiles}\hashcat"
-        #Start-Process -Wait "${SETUP_PATH}\intel_driver.exe" -ArgumentList '--s --a /quiet /norestart'
         if (Test-Path "${HOME}\Desktop\dfirws\Utilities\Crypto\hashcat (runs dfirws-install -Hashcat).lnk") {
             Remove-Item "${HOME}\Desktop\dfirws\Utilities\Crypto\hashcat (runs dfirws-install -Hashcat).lnk" -Force
         }

--- a/setup/wscommon.ps1
+++ b/setup/wscommon.ps1
@@ -159,12 +159,30 @@ function Add-Shortcut {
     $Shortcut.Save()
 }
 
+# Removes a tool's installer shortcut from the dfirws desktop folder together
+# with its start menu mirror created by dfirws_folder.ps1.
+function Remove-InstallerShortcut {
+    param (
+        [Parameter(Mandatory=$true)] [string]$DesktopLnk
+    )
+    $desktopRoot = "${HOME}\Desktop\dfirws\"
+    $relative = $DesktopLnk.Substring($desktopRoot.Length)
+    $lastSeparator = $relative.LastIndexOf("\")
+    $folder = "dfirws - " + $relative.Substring(0, [Math]::Max($lastSeparator, 0)).Replace("\", " - ")
+    $startMenuLnk = "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\${folder}\" + $relative.Substring($lastSeparator + 1)
+    foreach ($lnk in @($DesktopLnk, $startMenuLnk)) {
+        if (Test-Path $lnk) {
+            Remove-Item $lnk -Force
+        }
+    }
+}
+
 function Update-WallPaper {
     [CmdletBinding(SupportsShouldProcess)]
     param (
         [parameter(Mandatory = $true)][String]$path
     )
-    if($PSCmdlet.ShouldProcess(${file}.Name)) {
+    if($PSCmdlet.ShouldProcess(${path})) {
         & "${HOME}\Documents\tools\Update-WallPaper" "${path}"
     }
     & "${TOOLS}\sysinternals\Bginfo64.exe" /NOLICPROMPT /timer:0 "${HOME}\Documents\tools\config.bgi"
@@ -431,12 +449,7 @@ function Install-Autopsy {
         if (!(Test-Path "${HOME}\Desktop\dfirws\Forensics")) {
             New-Item -ItemType Directory -Path "${HOME}\Desktop\dfirws\Forensics" | Out-Null
         }
-        if (Test-Path "${HOME}\Desktop\dfirws\Forensics\Autopsy (runs dfirws-install -Autopsy).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Forensics\Autopsy (runs dfirws-install -Autopsy).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Forensics\Autopsy (runs dfirws-install -Autopsy).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Forensics\Autopsy (runs dfirws-install -Autopsy).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Forensics\Autopsy (runs dfirws-install -Autopsy).lnk"
         Copy-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\Autopsy\Autopsy*.lnk" "${HOME}\Desktop\dfirws\Forensics\Autopsy.lnk" -Force
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-autopsy.txt" | Out-Null
     } else {
@@ -450,12 +463,7 @@ function Install-BinaryNinja {
         Start-Process -Wait "${SETUP_PATH}\binaryninja.exe" -ArgumentList '/S /V"/qn REBOOT=ReallySuppress"'
         Copy-Item "${HOME}\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Binary Ninja\Binary Ninja.lnk" "${HOME}\Desktop\dfirws\Reverse Engineering\Binary Ninja.lnk" -Force
         Copy-Item "${HOME}\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Binary Ninja\Binary Ninja.lnk" "${HOME}\Desktop\Binary Ninja.lnk" -Force
-        if (Test-Path "${HOME}\Desktop\dfirws\Reverse Engineering\Binary Ninja (runs dfirws-install -BinaryNinja).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Reverse Engineering\Binary Ninja (runs dfirws-install -BinaryNinja).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Reverse Engineering\Binary Ninja (runs dfirws-install -BinaryNinja).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Reverse Engineering\Binary Ninja (runs dfirws-install -BinaryNinja).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Reverse Engineering\Binary Ninja (runs dfirws-install -BinaryNinja).lnk"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-binaryninja.txt" | Out-Null
     } else {
         Write-Output "Binary Ninja is already installed"
@@ -469,12 +477,7 @@ function Install-BurpSuite {
         Add-ToUserPath "${env:ProgramFiles}\BurpSuiteCommunity"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\IR\burp.lnk" -DestinationPath "${env:ProgramFiles}\BurpSuiteCommunity\BurpSuiteCommunity.exe" -WorkingDirectory "${HOME}\Desktop" -Iconlocation "${env:ProgramFiles}\BurpSuiteCommunity\BurpSuiteCommunity.exe"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\burp.lnk" -DestinationPath "${env:ProgramFiles}\BurpSuiteCommunity\BurpSuiteCommunity.exe" -WorkingDirectory "${HOME}\Desktop" -Iconlocation "${env:ProgramFiles}\BurpSuiteCommunity\BurpSuiteCommunity.exe"
-        if (Test-Path "${HOME}\Desktop\dfirws\Network\Burp Suite (runs dfirws-install -BurpSuite).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Network\Burp Suite (runs dfirws-install -BurpSuite).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Network\Burp Suite (runs dfirws-install -BurpSuite).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Network\Burp Suite (runs dfirws-install -BurpSuite).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Network\Burp Suite (runs dfirws-install -BurpSuite).lnk"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-burpsuite.txt" | Out-Null
     } else {
         Write-Output "Burp Suite is already installed"
@@ -486,12 +489,7 @@ function Install-Chrome {
         Write-Output "Installing Chrome"
         Start-Process -Wait msiexec -ArgumentList "/i ${SETUP_PATH}\chrome.msi /qn /norestart"
         Add-ToUserPath "${env:ProgramFiles}\Google\Chrome\Application"
-        if (Test-Path "${HOME}\Desktop\dfirws\Utilities\Browsers\Chrome (runs dfirws-install -Chrome).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Utilities\Browsers\Chrome (runs dfirws-install -Chrome).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Utilities - Browsers\Chrome (runs dfirws-install -Chrome).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Utilities - Browsers\Chrome (runs dfirws-install -Chrome).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Utilities\Browsers\Chrome (runs dfirws-install -Chrome).lnk"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-chrome.txt" | Out-Null
     } else {
         Write-Output "Chrome is already installed"
@@ -521,12 +519,7 @@ function Install-ClamAV {
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Malware tools\clamsubmit.exe (Malware and False Positive Reporting Tool).lnk" -DestinationPath "${POWERSHELL_EXE}" -WorkingDirectory "${HOME}\Desktop" -Arguments "-NoExit -command clamsubmit.exe -h"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Malware tools\freshclam.exe (Database Updater).lnk" -DestinationPath "${POWERSHELL_EXE}" -WorkingDirectory "${HOME}\Desktop" -Arguments "-NoExit -command freshclam.exe -h"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Malware tools\sigtool.exe (Signature Tool).lnk" -DestinationPath "${POWERSHELL_EXE}" -WorkingDirectory "${HOME}\Desktop" -Arguments "-NoExit -command sigtool.exe -h"
-        if (Test-Path "${HOME}\Desktop\dfirws\Malware tools\clamav (runs dfirws-install -ClamAV).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Malware tools\clamav (runs dfirws-install -ClamAV).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Malware tools\clamav (runs dfirws-install -ClamAV).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Malware tools\clamav (runs dfirws-install -ClamAV).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Malware tools\clamav (runs dfirws-install -ClamAV).lnk"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-clamav.txt" | Out-Null
     } else {
         Write-Output "ClamAV is already installed"
@@ -543,12 +536,7 @@ function Install-CMDer {
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Utilities\cmder.lnk" -DestinationPath "${env:ProgramFiles}\cmder\cmder.exe" -WorkingDirectory "${HOME}\Desktop"
         Write-Output "$VENV\default\scripts\activate.bat" | Out-File -Append -Encoding "ascii" ${env:ProgramFiles}\cmder\config\user_profile.cmd
         & "${env:ProgramFiles}\cmder\cmder.exe" /REGISTER ALL
-        if (Test-Path "${HOME}\Desktop\dfirws\Utilities\cmder (runs dfirws-install -Cmder).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Utilities\cmder (runs dfirws-install -Cmder).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Utilities\cmder (runs dfirws-install -Cmder).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Utilities\cmder (runs dfirws-install -Cmder).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Utilities\cmder (runs dfirws-install -Cmder).lnk"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-cmder.txt" | Out-Null
     } else {
         Write-Output "Cmder is already installed"
@@ -559,12 +547,7 @@ function Install-DCode {
     if (!(Test-Path "${env:ProgramFiles}\dfirws\installed-dcode.txt")) {
         Write-Output "Installing DCode"
         Start-Process -Wait "${SETUP_PATH}\dcode\dcode.exe" -ArgumentList '/CURRENTUSER /VERYSILENT /NORESTART'
-        if (Test-Path "${HOME}\Desktop\dfirws\Utilities\DCode (runs dfirws-install -DCode).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Utilities\DCode (runs dfirws-install -DCode).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Utilities\DCode (runs dfirws-install -DCode).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Utilities\DCode (runs dfirws-install -DCode).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Utilities\DCode (runs dfirws-install -DCode).lnk"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-dcode.txt" | Out-Null
     } else {
         Write-Output "DCode is already installed"
@@ -577,12 +560,7 @@ function Install-Dbeaver {
         & "C:\Windows\system32\robocopy.exe" /MT:96 /MIR "${TOOLS}\dbeaver" "${env:ProgramFiles}\dbeaver" | Out-Null
         Add-ToUserPath "${env:ProgramFiles}\dbeaver"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-dbeaver.txt" | Out-Null
-        if (Test-Path "${HOME}\Desktop\dfirws\Files and apps\Database\dbeaver (runs dfirws-install -DBeaver).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Files and apps\Database\dbeaver (runs dfirws-install -DBeaver).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Files and apps - Database\dbeaver (runs dfirws-install -DBeaver).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Files and apps - Database\dbeaver (runs dfirws-install -DBeaver).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Files and apps\Database\dbeaver (runs dfirws-install -DBeaver).lnk"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Files and apps\Database\dbeaver (Universal Database Tool).lnk" -DestinationPath "${env:ProgramFiles}\dbeaver\dbeaver.exe"
     } else {
         Write-Output "DBeaver is already installed"
@@ -594,12 +572,7 @@ function Install-Dokany {
     if (!(Test-Path "${env:ProgramFiles}\dfirws\installed-dokany.txt")) {
         Write-Output "Installing Dokany"
         Start-Process -Wait msiexec -ArgumentList "/i ${SETUP_PATH}\dokany.msi /qn /norestart"
-        if (Test-Path "${HOME}\Desktop\dfirws\Memory\Dokany (runs dfirws-install -Dokany).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Memory\Dokany (runs dfirws-install -Dokany).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Memory\Dokany (runs dfirws-install -Dokany).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Memory\Dokany (runs dfirws-install -Dokany).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Memory\Dokany (runs dfirws-install -Dokany).lnk"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-dokany.txt" | Out-Null
     } else {
         Write-Output "Dokany is already installed"
@@ -612,12 +585,7 @@ function Install-Fibratus {
         Start-Process -Wait msiexec -ArgumentList "/i ${SETUP_PATH}\fibratus.msi /qn /norestart"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-fibratus.txt" | Out-Null
         Add-ToUserPath "${env:ProgramFiles}\Fibratus\bin"
-        if (Test-Path "${HOME}\Desktop\dfirws\OS\Windows\fibratus (runs dfirws-install -Fibratus).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\OS\Windows\fibratus (runs dfirws-install -Fibratus).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - OS - Windows\fibratus (runs dfirws-install -Fibratus).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - OS - Windows\fibratus (runs dfirws-install -Fibratus).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\OS\Windows\fibratus (runs dfirws-install -Fibratus).lnk"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\OS\Windows\fibratus documentation (needs internet access).lnk" -DestinationPath "${POWERSHELL_EXE}" -WorkingDirectory "${HOME}\Desktop" -Arguments "-command ${HOME}\Documents\tools\utils\start_fibratus.bat"
     } else {
         Write-Output "Fibratus is already installed"
@@ -628,12 +596,7 @@ function Install-Firefox {
     if (!(Test-Path "${env:ProgramFiles}\dfirws\installed-firefox.txt")) {
         Write-Output "Installing Firefox"
         Start-Process -Wait "${SETUP_PATH}\firefox.exe" -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART"
-        if (Test-Path "${HOME}\Desktop\dfirws\Utilities\Browsers\Firefox (runs dfirws-install -Firefox).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Utilities\Browsers\Firefox (runs dfirws-install -Firefox).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Utilities - Browsers\Firefox (runs dfirws-install -Firefox).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Utilities - Browsers\Firefox (runs dfirws-install -Firefox).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Utilities\Browsers\Firefox (runs dfirws-install -Firefox).lnk"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Utilities\Browsers\Firefox.lnk" -DestinationPath "${env:ProgramFiles}\Mozilla Firefox\firefox.exe"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-firefox.txt" | Out-Null
     } else {
@@ -651,12 +614,7 @@ function Install-ForensicTimeliner {
 
         & $SEVENZIP x -aoa "${SETUP_PATH}\ForensicTimeliner.zip" -o"${env:ProgramFiles}" | Out-Null
         Move-Item ${env:ProgramFiles}\ForensicTimeliner* "${env:ProgramFiles}\ForensicTimeliner" -Force
-        if (Test-Path "${HOME}\Desktop\dfirws\IR\Forensic Timeliner (runs dfirws-install -ForensicTimeliner).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\IR\Forensic Timeliner (runs dfirws-install -ForensicTimeliner).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - IR\Forensic Timeliner (runs dfirws-install -ForensicTimeliner).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - IR\Forensic Timeliner (runs dfirws-install -ForensicTimeliner).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\IR\Forensic Timeliner (runs dfirws-install -ForensicTimeliner).lnk"
         Add-ToUserPath "${env:ProgramFiles}\ForensicTimeliner"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\IR\Forensic Timeliner.lnk" -DestinationPath "${CLI_TOOL}" -WorkingDirectory "${HOME}\Desktop" -Arguments "${CLI_TOOL_ARGS} -command ForensicTimeliner -h"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-forensictimeliner.txt" | Out-Null
@@ -669,12 +627,7 @@ function Install-FoxitReader {
     if (!(Test-Path "${env:ProgramFiles}\dfirws\installed-foxitreader.txt")) {
         Write-Output "Installing Foxit Reader"
         & "${SETUP_PATH}\foxitreader.exe" /quiet /DisableInternet 2>&1 | Out-Null
-        if (Test-Path "${HOME}\Desktop\dfirws\Files and apps\PDF\Foxit Reader for pdf files (runs dfirws-install -FoxitReader).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Files and apps\PDF\Foxit Reader for pdf files (runs dfirws-install -FoxitReader).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Files and apps - PDF\Foxit Reader for pdf files (runs dfirws-install -FoxitReader).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Files and apps - PDF\Foxit Reader for pdf files (runs dfirws-install -FoxitReader).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Files and apps\PDF\Foxit Reader for pdf files (runs dfirws-install -FoxitReader).lnk"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-foxitreader.txt" | Out-Null
     } else {
         Write-Output "Foxit Reader is already installed"
@@ -772,12 +725,7 @@ namespace Dfirws {
             Copy-Item "${HOME}\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Unknown\fqlite.lnk" "${HOME}\Desktop\dfirws\Files and apps\Database\fqlite.lnk" -Force
             Copy-Item "${HOME}\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Unknown\fqlite.lnk" "${HOME}\Desktop\fqlite.lnk" -Force
         }
-        if (Test-Path "${HOME}\Desktop\dfirws\Files and apps\Database\fqlite (runs dfirws-install -FQLite).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Files and apps\Database\fqlite (runs dfirws-install -FQLite).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Files and apps - Database\fqlite (runs dfirws-install -FQLite).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Files and apps - Database\fqlite (runs dfirws-install -FQLite).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Files and apps\Database\fqlite (runs dfirws-install -FQLite).lnk"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-fqlite.txt" | Out-Null
     } else {
         Write-Output "FQLite is already installed"
@@ -804,12 +752,7 @@ function Install-GoLang {
         Write-Output "Installing GoLang"
         Start-Process -Wait msiexec -ArgumentList "/i ${SETUP_PATH}\golang.msi /qn /norestart"
         Add-ToUserPath "${env:ProgramFiles}\Go\bin"
-        if (Test-Path "${HOME}\Desktop\dfirws\Programming\Go\GoLang (runs dfirws-install -GoLang).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Programming\Go\GoLang (runs dfirws-install -GoLang).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Programming - Go\GoLang (runs dfirws-install -GoLang).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Programming - Go\GoLang (runs dfirws-install -GoLang).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Programming\Go\GoLang (runs dfirws-install -GoLang).lnk"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-golang.txt" | Out-Null
     } else {
         Write-Output "GoLang is already installed"
@@ -820,12 +763,7 @@ function Install-GoogleEarth {
     if (!(Test-Path "${env:ProgramFiles}\dfirws\installed-googleearth.txt")) {
         Write-Output "Installing Google Earth"
         Start-Process -Wait "${SETUP_PATH}\googleearth.exe" -ArgumentList 'OMAHA=1'
-        if (Test-Path "${HOME}\Desktop\dfirws\Utilities\Google Earth (runs dfirws-install -GoogleEarth).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Utilities\Google Earth (runs dfirws-install -GoogleEarth).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Utilities\Google Earth (runs dfirws-install -GoogleEarth).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Utilities\Google Earth (runs dfirws-install -GoogleEarth).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Utilities\Google Earth (runs dfirws-install -GoogleEarth).lnk"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Utilities\Google Earth.lnk" -DestinationPath "${env:ProgramFiles}\Google\Google Earth Pro\client\googleearth.exe"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-googleearth.txt" | Out-Null
     } else {
@@ -837,12 +775,7 @@ function Install-Gpg4win {
     if (!(Test-Path "${env:ProgramFiles}\dfirws\installed-gpg4win.txt")) {
         Write-Output "Installing Gpg4win"
         Start-Process -Wait "${SETUP_PATH}\gpg4win.exe" -ArgumentList '/S /V"/qn REBOOT=ReallySuppress"'
-        if (Test-Path "${HOME}\Desktop\dfirws\Utilities\Crypto\gpg4win (runs dfirws-install -Gpg4win).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Utilities\Crypto\gpg4win (runs dfirws-install -Gpg4win).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Utilities - Crypto\gpg4win (runs dfirws-install -Gpg4win).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Utilities - Crypto\gpg4win (runs dfirws-install -Gpg4win).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Utilities\Crypto\gpg4win (runs dfirws-install -Gpg4win).lnk"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Utilities\Crypto\Kleopatra.lnk" -DestinationPath "${env:ProgramFiles(x86)}\Gpg4win\bin\kleopatra.exe"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-gpg4win.txt" | Out-Null
     } else {
@@ -857,12 +790,7 @@ function Install-Hashcat {
         Copy-Item -Recurse "${TOOLS}\hashcat" "${env:ProgramFiles}" -Force
         Add-ToUserPath "${env:ProgramFiles}\hashcat"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Utilities\Crypto\hashcat.lnk" -DestinationPath "${POWERSHELL_EXE}" -WorkingDirectory "${env:ProgramFiles}\hashcat"
-        if (Test-Path "${HOME}\Desktop\dfirws\Utilities\Crypto\hashcat (runs dfirws-install -Hashcat).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Utilities\Crypto\hashcat (runs dfirws-install -Hashcat).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Utilities - Crypto\hashcat (runs dfirws-install -Hashcat).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Utilities - Crypto\hashcat (runs dfirws-install -Hashcat).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Utilities\Crypto\hashcat (runs dfirws-install -Hashcat).lnk"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-hashcat.txt" | Out-Null
     } else {
         Write-Output "Hashcat is already installed"
@@ -874,12 +802,7 @@ function Install-Jadx {
         Write-Output "Installing Jadx"
         & $SEVENZIP x -aoa "${SETUP_PATH}\jadx.zip" -o"${env:ProgramFiles}\jadx" | Out-Null
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Programming\Java\jadx-gui.lnk" -DestinationPath "${env:ProgramFiles}\jadx\bin\jadx-gui.bat"
-        if (Test-Path "${HOME}\Desktop\dfirws\Programming\Java\Jadx (runs dfirws-install -Jadx).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Programming\Java\Jadx (runs dfirws-install -Jadx).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Programming - Java\Jadx (runs dfirws-install -Jadx).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Programming - Java\Jadx (runs dfirws-install -Jadx).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Programming\Java\Jadx (runs dfirws-install -Jadx).lnk"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-jadx.txt" | Out-Null
     } else {
         Write-Output "Jadx is already installed"
@@ -893,12 +816,7 @@ function Install-Kape {
             Copy-Item -Recurse "${SETUP_PATH}\KAPE" "${env:ProgramFiles}" -Force
             Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\IR\gkape.lnk" -DestinationPath "${env:ProgramFiles}\KAPE\gkape.exe" -WorkingDirectory "${HOME}\Desktop" -Iconlocation "${env:ProgramFiles}\KAPE\gkape.exe"
             Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\IR\kape (Krolls Artifact Parser and Extractor).lnk" -DestinationPath "${POWERSHELL_EXE}" -WorkingDirectory "${HOME}\Desktop" -Arguments "-NoExit -command kape --help"
-            if (Test-Path "${HOME}\Desktop\dfirws\IR\Kape (runs dfirws-install -Kape).lnk") {
-                Remove-Item "${HOME}\Desktop\dfirws\IR\Kape (runs dfirws-install -Kape).lnk" -Force
-            }
-            if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - IR\Kape (runs dfirws-install -Kape).lnk") {
-                Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - IR\Kape (runs dfirws-install -Kape).lnk" -Force
-            }
+            Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\IR\Kape (runs dfirws-install -Kape).lnk"
             New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-kape.txt" | Out-Null
         } else {
             Write-Output "KAPE not found in ${SETUP_PATH}"
@@ -914,12 +832,7 @@ function Install-Kanvas {
         Copy-Item -Recurse "${VENV}\kanvas" "${env:ProgramFiles}" -Force | Out-Null
         Add-ToUserPath "${env:ProgramFiles}\Kanvas"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\IR\Kanvas.py (case management for incident response).lnk" -DestinationPath "${POWERSHELL_EXE}" -WorkingDirectory "${HOME}\Desktop" -Arguments "-NoExit -command venv.ps1 -Kanvas ; Kanvas.py"
-        if (Test-Path "${HOME}\Desktop\dfirws\IR\Kanvas (runs dfirws-install -Kanvas).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\IR\Kanvas (runs dfirws-install -Kanvas).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - IR\Kanvas (runs dfirws-install -Kanvas).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - IR\Kanvas (runs dfirws-install -Kanvas).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\IR\Kanvas (runs dfirws-install -Kanvas).lnk"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-kanvas.txt" | Out-Null
     } else {
         Write-Output "Kanvas is already installed"
@@ -930,12 +843,7 @@ function Install-LibreOffice {
     if (!(Test-Path "${env:ProgramFiles}\dfirws\installed-libreoffice.txt")) {
         Write-Output "Installing LibreOffice"
         Start-Process -Wait msiexec -ArgumentList "/qb /i ${SETUP_PATH}\LibreOffice.msi /l* ${WSDFIR_TEMP}\LibreOffice_install_log.txt REGISTER_ALL_MSO_TYPES=1 UI_LANGS=en_US ISCHECKFORPRODUCTUPDATES=0 REBOOTYESNO=No QUICKSTART=0 ADDLOCAL=ALL VC_REDIST=0 REMOVE=gm_o_Onlineupdate,gm_r_ex_Dictionary_Af,gm_r_ex_Dictionary_An,gm_r_ex_Dictionary_Ar,gm_r_ex_Dictionary_Be,gm_r_ex_Dictionary_Bg,gm_r_ex_Dictionary_Bn,gm_r_ex_Dictionary_Bo,gm_r_ex_Dictionary_Br,gm_r_ex_Dictionary_Pt_Br,gm_r_ex_Dictionary_Bs,gm_r_ex_Dictionary_Pt_Pt,gm_r_ex_Dictionary_Ca,gm_r_ex_Dictionary_Cs,gm_r_ex_Dictionary_Da,gm_r_ex_Dictionary_Nl,gm_r_ex_Dictionary_Et,gm_r_ex_Dictionary_Gd,gm_r_ex_Dictionary_Gl,gm_r_ex_Dictionary_Gu,gm_r_ex_Dictionary_He,gm_r_ex_Dictionary_Hi,gm_r_ex_Dictionary_Hu,gm_r_ex_Dictionary_Lt,gm_r_ex_Dictionary_Lv,gm_r_ex_Dictionary_Ne,gm_r_ex_Dictionary_No,gm_r_ex_Dictionary_Oc,gm_r_ex_Dictionary_Pl,gm_r_ex_Dictionary_Ro,gm_r_ex_Dictionary_Ru,gm_r_ex_Dictionary_Si,gm_r_ex_Dictionary_Sk,gm_r_ex_Dictionary_Sl,gm_r_ex_Dictionary_El,gm_r_ex_Dictionary_Es,gm_r_ex_Dictionary_Te,gm_r_ex_Dictionary_Th,gm_r_ex_Dictionary_Tr,gm_r_ex_Dictionary_Uk,gm_r_ex_Dictionary_Vi,gm_r_ex_Dictionary_Zu,gm_r_ex_Dictionary_Sq,gm_r_ex_Dictionary_Hr,gm_r_ex_Dictionary_De,gm_r_ex_Dictionary_Id,gm_r_ex_Dictionary_Is,gm_r_ex_Dictionary_Ko,gm_r_ex_Dictionary_Lo,gm_r_ex_Dictionary_Mn,gm_r_ex_Dictionary_Sr,gm_r_ex_Dictionary_Eo,gm_r_ex_Dictionary_It,gm_r_ex_Dictionary_Fr"
-        if (Test-Path "${HOME}\Desktop\dfirws\Files and apps\Office\LibreOffice (runs dfirws-install -LibreOffice).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Files and apps\Office\LibreOffice (runs dfirws-install -LibreOffice).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Files and apps - Office\LibreOffice (runs dfirws-install -LibreOffice).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Files and apps - Office\LibreOffice (runs dfirws-install -LibreOffice).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Files and apps\Office\LibreOffice (runs dfirws-install -LibreOffice).lnk"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Files and apps\Office\LibreOffice.lnk" -DestinationPath "${env:ProgramFiles}\LibreOffice\program\soffice.exe"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-libreoffice.txt" | Out-Null
     } else {
@@ -949,12 +857,7 @@ function Install-LogBoost {
         Copy-Item -Recurse "${TOOLS}\logboost" "${env:ProgramFiles}" -Force | Out-Null
         Add-ToUserPath "${env:ProgramFiles}\logboost"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Files and apps\Log\logboost.lnk" -DestinationPath "${POWERSHELL_EXE}" -WorkingDirectory "${env:ProgramFiles}\logboost" -Arguments "-NoExit -command logboost.exe -h"
-        if (Test-Path "${HOME}\Desktop\dfirws\Files and apps\Log\logboost (runs dfirws-install -LogBoost).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Files and apps\Log\logboost (runs dfirws-install -LogBoost).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Files and apps - Log\logboost (runs dfirws-install -LogBoost).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Files and apps - Log\logboost (runs dfirws-install -LogBoost).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Files and apps\Log\logboost (runs dfirws-install -LogBoost).lnk"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-logboost.txt" | Out-Null
     } else {
         Write-Output "LogBoost is already installed"
@@ -968,12 +871,7 @@ function Install-Loki {
         Copy-Item ${GIT_PATH}\signature-base "${env:ProgramFiles}\loki" -Recurse -Force
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Signatures and information\loki.lnk" -DestinationPath "${env:ProgramFiles}\loki\loki.exe"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\loki.lnk" -DestinationPath "${env:ProgramFiles}\loki\loki.exe"
-        if (Test-Path "${HOME}\Desktop\dfirws\Signatures and information\loki (runs dfirws-install -Loki).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Signatures and information\loki (runs dfirws-install -Loki).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Signatures and information\loki (runs dfirws-install -Loki).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Signatures and information\loki (runs dfirws-install -Loki).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Signatures and information\loki (runs dfirws-install -Loki).lnk"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-loki.txt" | Out-Null
     } else {
         Write-Output "Loki is already installed"
@@ -1003,12 +901,7 @@ function Install-Neo4j {
         $env:JAVA_HOME = "$NEO_JAVA"
         & "${env:ProgramFiles}\neo4j\bin\neo4j-admin" set-initial-password neo4j
         foreach ($lnkName in @("Neo4j 4 (runs dfirws-install -Neo4j).lnk", "Neo4j (runs dfirws-install -Neo4j).lnk")) {
-            if (Test-Path "${HOME}\Desktop\dfirws\Files and apps\Database\${lnkName}") {
-                Remove-Item "${HOME}\Desktop\dfirws\Files and apps\Database\${lnkName}" -Force
-            }
-            if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Files and apps - Database\${lnkName}") {
-                Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Files and apps - Database\${lnkName}" -Force
-            }
+            Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Files and apps\Database\${lnkName}"
         }
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Files and apps\Database\Neo4j.lnk" -DestinationPath "${POWERSHELL_EXE}" -WorkingDirectory "${HOME}\Desktop" -Arguments "-NoExit -command neo4j.bat console"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-neo4j.txt" | Out-Null
@@ -1021,12 +914,7 @@ function Install-Node {
     if (!(Test-Path "${env:ProgramFiles}\dfirws\installed-node.txt")) {
         Write-Output "Installing Node"
         Copy-Item -r "${TOOLS}\node" "${HOME}\Desktop" -Force
-        if (Test-Path "${HOME}\Desktop\dfirws\Programming\Node\Node (runs dfirws-install -Node).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Programming\Node\Node (runs dfirws-install -Node).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Programming - Node\Node (runs dfirws-install -Node).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Programming - Node\Node (runs dfirws-install -Node).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Programming\Node\Node (runs dfirws-install -Node).lnk"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-node.txt" | Out-Null
     } else {
         Write-Output "Node is already installed"
@@ -1045,12 +933,7 @@ function Install-Obsidian {
             Start-Sleep -Seconds 2
             $retries++
         }
-        if (Test-Path "${HOME}\Desktop\dfirws\Editors\Obsidian (runs dfirws-install -Obsidian).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Editors\Obsidian (runs dfirws-install -Obsidian).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Editors\Obsidian (runs dfirws-install -Obsidian).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Editors\Obsidian (runs dfirws-install -Obsidian).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Editors\Obsidian (runs dfirws-install -Obsidian).lnk"
         if (Test-Path "${HOME}\Desktop\Obsidian.lnk") {
             Copy-Item "${HOME}\Desktop\Obsidian.lnk" "${HOME}\Desktop\dfirws\Editors\Obsidian.lnk" -Force
         } else {
@@ -1067,12 +950,7 @@ function Install-OSFMount {
     if (!(Test-Path "${env:ProgramFiles}\dfirws\installed-osfmount.txt")) {
         Write-Output "Installing OSFMount"
         Start-Process -Wait "${SETUP_PATH}\osfmount.exe" -ArgumentList '/verysilent /norestart /suppressmsgboxes /norun /SP-'
-        if (Test-Path "${HOME}\Desktop\dfirws\Files and apps\Disk\OSFMount (runs dfirws-install -OSFMount).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Files and apps\Disk\OSFMount (runs dfirws-install -OSFMount).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Files and apps - Disk\OSFMount (runs dfirws-install -OSFMount).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Files and apps - Disk\OSFMount (runs dfirws-install -OSFMount).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Files and apps\Disk\OSFMount (runs dfirws-install -OSFMount).lnk"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Files and apps\Disk\osfmount.lnk" -DestinationPath "${env:ProgramFiles}\OSFMount\osfmount.exe"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-osfmount.txt" | Out-Null
     } else {
@@ -1101,12 +979,7 @@ function Install-Neovim {
         Add-ToUserPath "${env:ProgramFiles}\neovim\bin"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Editors\Neovim.lnk" -DestinationPath "${env:ProgramFiles}\neovim\bin\nvim.exe" -WorkingDirectory "${HOME}\Desktop"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\Neovim.lnk" -DestinationPath "${env:ProgramFiles}\neovim\bin\nvim.exe" -WorkingDirectory "${HOME}\Desktop"
-        if (Test-Path "${HOME}\Desktop\dfirws\Editors\Neovim (runs dfirws-install -Neovim).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Editors\Neovim (runs dfirws-install -Neovim).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Editors\Neovim (runs dfirws-install -Neovim).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Editors\Neovim (runs dfirws-install -Neovim).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Editors\Neovim (runs dfirws-install -Neovim).lnk"
         if (!(Test-Path "${env:LOCALAPPDATA}\nvim-data\site\spell")) {
             New-Item -ItemType Directory -Path "${env:LOCALAPPDATA}\nvim-data\site\spell" -Force | Out-Null
         }
@@ -1135,12 +1008,7 @@ function Install-PDFStreamDumper {
         Write-Output "Installing PDFStreamDumper"
         & "${SETUP_PATH}\PDFStreamDumper.exe" /verysilent
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Files and apps\PDF\pdfstreamdumper.lnk" -DestinationPath "${PDFSTREAMDUMPER_PATH}\PDFStreamDumper.exe"
-        if (Test-Path "${HOME}\Desktop\dfirws\Files and apps\PDF\pdfstreamdumper install (runs dfirws-install -PDFStreamDumper).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Files and apps\PDF\pdfstreamdumper install (runs dfirws-install -PDFStreamDumper).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Files and apps - Office\LibreOffice (runs dfirws-install -LibreOffice).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Files and apps - Office\LibreOffice (runs dfirws-install -LibreOffice).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Files and apps\PDF\pdfstreamdumper install (runs dfirws-install -PDFStreamDumper).lnk"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-pdfstreamdumper.txt" | Out-Null
     } else {
         Write-Output "PDFStreamDumper is already installed"
@@ -1158,12 +1026,7 @@ function Install-PuTTY {
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Network\psftp.lnk" -DestinationPath "${POWERSHELL_EXE}" -WorkingDirectory "${HOME}\Desktop" -Arguments "-NoExit -command psftp.exe -h"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Network\putty.lnk" -DestinationPath "${env:ProgramFiles}\PuTTY\putty.exe" -WorkingDirectory "${HOME}\Desktop"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Network\puttygen.lnk" -DestinationPath "${env:ProgramFiles}\PuTTY\puttygen.exe" -WorkingDirectory "${HOME}\Desktop"
-        if (Test-Path "${HOME}\Desktop\dfirws\Network\PuTTY (runs dfirws-install -PuTTY).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Network\PuTTY (runs dfirws-install -PuTTY).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Network\PuTTY (runs dfirws-install -PuTTY).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Network\PuTTY (runs dfirws-install -PuTTY).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Network\PuTTY (runs dfirws-install -PuTTY).lnk"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-putty.txt" | Out-Null
     } else {
         Write-Output "PuTTY is already installed"
@@ -1175,12 +1038,7 @@ function Install-Qemu {
         Write-Output "Installing Qemu"
         Start-Process -Wait "${SETUP_PATH}\qemu.exe" -ArgumentList '/S /V"/qn REBOOT=ReallySuppress"'
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Files and apps\qemu-img (QEMU disk image utility).lnk" -DestinationPath "${POWERSHELL_EXE}" -WorkingDirectory "${HOME}\Desktop" -Arguments "-NoExit -command qemu-img.exe -h"
-        if (Test-Path "${HOME}\Desktop\dfirws\Files and apps\qemu (runs dfirws-install -Qemu).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Files and apps\qemu (runs dfirws-install -Qemu).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Files and apps\Qemu (runs dfirws-install -Qemu).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Files and apps\Qemu (runs dfirws-install -Qemu).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Files and apps\qemu (runs dfirws-install -Qemu).lnk"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-qemu.txt" | Out-Null
     } else {
         Write-Output "Qemu is already installed"
@@ -1193,12 +1051,7 @@ function Install-Ruby {
         & "${SETUP_PATH}\ruby.exe" /verysilent /allusers /dir="${env:ProgramFiles}\ruby"
         Add-ToUserPath "${env:ProgramFiles}\ruby\bin"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Programming\Ruby\ruby.lnk" -DestinationPath "${POWERSHELL_EXE}" -WorkingDirectory "${HOME}\Desktop" -Arguments "-NoExit -command ruby --help"
-        if (Test-Path "${HOME}\Desktop\dfirws\Programming\Ruby\ruby (runs dfirws-install -Ruby).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Programming\Ruby\ruby (runs dfirws-install -Ruby).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Programming - Ruby\Ruby (runs dfirws-install -Ruby).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Programming - Ruby\Ruby (runs dfirws-install -Ruby).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Programming\Ruby\ruby (runs dfirws-install -Ruby).lnk"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-ruby.txt" | Out-Null
     } else {
         Write-Output "Ruby is already installed"
@@ -1209,12 +1062,7 @@ function Install-Rust {
     if (!(Test-Path "${env:ProgramFiles}\dfirws\installed-rust.txt")) {
         Write-Output "Installing Rust"
         Start-Process -Wait msiexec -ArgumentList "/i ${SETUP_PATH}\rust.msi INSTALLDIR=${RUST_DIR} /qn /norestart"
-        if (Test-Path "${HOME}\Desktop\dfirws\Programming\Rust\rust (runs dfirws-install -Rust).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Programming\Rust\rust (runs dfirws-install -Rust).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Programming - Rust\Rust (runs dfirws-install -Rust).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Programming - Rust\Rust (runs dfirws-install -Rust).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Programming\Rust\rust (runs dfirws-install -Rust).lnk"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Programming\Rust\rust.lnk" -DestinationPath "${POWERSHELL_EXE}" -WorkingDirectory "${HOME}\Desktop" -Arguments "-NoExit -command rustc --help"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-rust.txt" | Out-Null
     } else {
@@ -1226,12 +1074,7 @@ function Install-Tor {
     if (!(Test-Path "${env:ProgramFiles}\dfirws\installed-tor.txt")) {
         Write-Output "Installing Tor"
         Start-Process -Wait "${SETUP_PATH}\torbrowser.exe" -ArgumentList '/S /V"/qn REBOOT=ReallySuppress"'
-        if (Test-Path "${HOME}\Desktop\dfirws\Utilities\Browsers\Tor Browser (runs dfirws-install -Tor).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Utilities\Browsers\Tor Browser (runs dfirws-install -Tor).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Utilities - Browsers\Tor Browser (runs dfirws-install -Tor).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Utilities - Browsers\Tor Browser (runs dfirws-install -Tor).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Utilities\Browsers\Tor Browser (runs dfirws-install -Tor).lnk"
         Copy-Item "${HOME}\Desktop\Tor Browser\Tor Browser.lnk" "${HOME}\Desktop\dfirws\Utilities\Browsers\" -Force
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-tor.txt" | Out-Null
     } else {
@@ -1245,12 +1088,7 @@ function Install-Veracrypt {
         Start-Process -Wait msiexec -ArgumentList "/i ${SETUP_PATH}\veracrypt.msi /qn /norestart ACCEPTLICENSE=YES"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-veracrypt.txt" | Out-Null
         Add-ToUserPath "${env:ProgramFiles}\VeraCrypt"
-        if (Test-Path "${HOME}\Desktop\dfirws\Utilities\Crypto\veracrypt (runs dfirws-install -Veracrypt).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Utilities\Crypto\veracrypt (runs dfirws-install -Veracrypt).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Utilities - Crypto\veracrypt (runs dfirws-install -Veracrypt).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Utilities - Crypto\veracrypt (runs dfirws-install -Veracrypt).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Utilities\Crypto\veracrypt (runs dfirws-install -Veracrypt).lnk"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Utilities\Crypto\veracrypt.lnk" -DestinationPath "${env:ProgramFiles}\VeraCrypt\VeraCrypt.exe" -WorkingDirectory "${HOME}\Desktop" -Iconlocation "${env:ProgramFiles}\VeraCrypt\VeraCrypt.exe"
     } else {
         Write-Output "Veracrypt is already installed"
@@ -1272,12 +1110,7 @@ function Install-VisualStudioBuildTool {
         Start-Process -Wait "${TOOLS}\VSLayout\vs_buildtools.exe" -ArgumentList "--noWeb --passive --norestart --force --add Microsoft.VisualStudio.Product.BuildTools --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.Component.TestTools.BuildTools --add Microsoft.VisualStudio.Component.VC.CMake.Project --add Microsoft.VisualStudio.Component.VC.CLI.Support --installPath C:\BuildTools"
         Copy-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\Visual Studio 2019\Visual Studio Tools\Developer PowerShell for VS 2019.lnk" "${env:USERPROFILE}\Desktop"
         Copy-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\Visual Studio 2019\Visual Studio Tools\Developer PowerShell for VS 2019.lnk" "${env:USERPROFILE}\Desktop\dfirws\Programming"
-        if (Test-Path "${HOME}\Desktop\dfirws\Programming\Visual Studio Buildtools (runs dfirws-install -VisualStudioBuildTools).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Programming\Visual Studio Buildtools (runs dfirws-install -VisualStudioBuildTools).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Programming\Visual Studio Buildtools (runs dfirws-install -VisualStudioBuildTools).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Programming\Visual Studio Buildtools (runs dfirws-install -VisualStudioBuildTools).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Programming\Visual Studio Buildtools (runs dfirws-install -VisualStudioBuildTools).lnk"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-vsbuildtools.txt" | Out-Null
         Write-Output "Visual Studio Build Tools installed"
     } else {
@@ -1291,12 +1124,7 @@ function Install-VLC {
         Start-Process -Wait "${SETUP_PATH}\vlc_installer.exe" -ArgumentList "/L=1033 /S"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-vlc.txt" | Out-Null
         Add-ToUserPath "${env:ProgramFiles}\VideoLAN\VLC"
-        if (Test-Path "${HOME}\Desktop\dfirws\Utilities\Media\VLC (runs dfirws-install -VLC).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Utilities\Media\VLC (runs dfirws-install -VLC).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Utilities - Media\VLC (runs dfirws-install -VLC).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Utilities - Media\VLC (runs dfirws-install -VLC).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Utilities\Media\VLC (runs dfirws-install -VLC).lnk"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Utilities\Media\vlc.lnk" -DestinationPath "${env:ProgramFiles}\VideoLAN\VLC\vlc.exe" -WorkingDirectory "${HOME}\Desktop" -Iconlocation "${env:ProgramFiles}\VideoLAN\VLC\vlc.exe"
     } else {
         Write-Output "VLC is already installed"
@@ -1375,12 +1203,7 @@ function Install-VSCode {
             (Get-Content "${LOCAL_PATH}\defaults\vscode\settings.json").Replace("FONT_NAME", "${WSDFIR_FONT_FULL_NAME}") | Set-Content "${HOME}\AppData\Roaming\Code\User\settings.json" -Force
         }
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-vscode.txt" | Out-Null
-        if (Test-Path "${HOME}\Desktop\dfirws\Editors\Visual Studio code (runs dfirws-install -VSCode).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Editors\Visual Studio code (runs dfirws-install -VSCode).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Editors\Visual Studio code (runs dfirws-install -VSCode).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Editors\Visual Studio code (runs dfirws-install -VSCode).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Editors\Visual Studio code (runs dfirws-install -VSCode).lnk"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Editors\Visual Studio Code.lnk" -DestinationPath "${HOME}\AppData\Local\Programs\Microsoft VS Code\Code.exe"
     } else {
         Write-Output "Visual Studio Code is already installed"
@@ -1392,13 +1215,7 @@ function Install-WinDbg {
         Write-Output "Installing WinDbg"
         Start-Process -Wait msiexec -ArgumentList "/i ${SETUP_PATH}\windbg.msi /qn /norestart"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-windbg.txt" | Out-Null
-        Add-AppPackage "${SETUP_PATH}\windbg.msi"
-        if (Test-Path "${HOME}\Desktop\dfirws\Reverse Engineering\WinDbg (runs dfirws-install -WinDbg).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Reverse Engineering\WinDbg (runs dfirws-install -WinDbg).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Reverse Engineering\WinDbg (runs dfirws-install -WinDbg).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Reverse Engineering\WinDbg (runs dfirws-install -WinDbg).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Reverse Engineering\WinDbg (runs dfirws-install -WinDbg).lnk"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Reverse Engineering\windbg.lnk" -DestinationPath "${env:ProgramFiles}\Windows Kits\10\Debuggers\x64\windbg.exe" -WorkingDirectory "${HOME}\Desktop" -Iconlocation "${env:ProgramFiles}\Windows Kits\10\Debuggers\x64\windbg.exe"
     } else {
         Write-Output "WinDbg is already installed"
@@ -1411,12 +1228,7 @@ function Install-WinMerge {
         Start-Process -Wait "${SETUP_PATH}\winmerge.exe" -ArgumentList '/verysilent /norestart /DIR="C:\Program Files\WinMerge" /Tasks=desktopicon,quicklaunchicon'
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-winmerge.txt" | Out-Null
         Add-ToUserPath "${env:ProgramFiles}\WinMerge"
-        if (Test-Path "${HOME}\Desktop\dfirws\Files and apps\WinMerge (runs dfirws-install -WinMerge).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Files and apps\WinMerge (runs dfirws-install -WinMerge).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Files and apps\WinMerge (runs dfirws-install -WinMerge).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Files and apps\WinMerge (runs dfirws-install -WinMerge).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Files and apps\WinMerge (runs dfirws-install -WinMerge).lnk"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Utilities\winmerge.lnk" -DestinationPath "${env:ProgramFiles}\WinMerge\WinMergeU.exe" -WorkingDirectory "${HOME}\Desktop" -Iconlocation "${env:ProgramFiles}\WinMerge\WinMergeU.exe"
     } else {
         Write-Output "WinMerge is already installed"
@@ -1434,12 +1246,7 @@ function Install-Wireshark {
         Add-ToUserPath "${env:ProgramFiles}\Wireshark"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Network\Wireshark.lnk" -DestinationPath "${env:ProgramFiles}\Wireshark\Wireshark.exe" -WorkingDirectory "${HOME}\Desktop" -Iconlocation "${env:ProgramFiles}\Wireshark\Wireshark.exe"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\Wireshark.lnk" -DestinationPath "${env:ProgramFiles}\Wireshark\Wireshark.exe" -WorkingDirectory "${HOME}\Desktop" -Iconlocation "${env:ProgramFiles}\Wireshark\Wireshark.exe"
-        if (Test-Path "${HOME}\Desktop\dfirws\Network\Wireshark (runs dfirws-install -Wireshark).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Network\Wireshark (runs dfirws-install -Wireshark).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Network\Wireshark (runs dfirws-install -Wireshark).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Network\Wireshark (runs dfirws-install -Wireshark).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Network\Wireshark (runs dfirws-install -Wireshark).lnk"
         New-Item -ItemType Directory -Path "${env:APPDATA}\Wireshark\plugins\4.6\epan\" 2>&1 | Out-Null
         Copy-Item "${GIT_PATH}\PacketCircle\installer\windows-x86_64\v.0.4.*\packetcircle.dll" "${env:APPDATA}\Wireshark\plugins\4.6\epan"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-wireshark.txt" | Out-Null
@@ -1458,12 +1265,7 @@ function Install-X64dbg {
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Reverse Engineering\x64dbg.lnk" -DestinationPath "${env:ProgramFiles}\x64dbg\release\x64\x64dbg.exe"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\x32dbg.lnk" -DestinationPath "${env:ProgramFiles}\x64dbg\release\x32\x32dbg.exe"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\x64dbg.lnk" -DestinationPath "${env:ProgramFiles}\x64dbg\release\x64\x64dbg.exe"
-        if (Test-Path "${HOME}\Desktop\dfirws\Reverse Engineering\X64dbg (runs dfirws-install -X64dbg).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Reverse Engineering\X64dbg (runs dfirws-install -X64dbg).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Reverse Engineering\X64dbg (runs dfirws-install -X64dbg).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Reverse Engineering\X64dbg (runs dfirws-install -X64dbg).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Reverse Engineering\X64dbg (runs dfirws-install -X64dbg).lnk"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-x64dbg.txt" | Out-Null
     } else {
         Write-Output "x64dbg is already installed"
@@ -1497,12 +1299,7 @@ function Install-ZAProxy {
         Add-ToUserPath "${env:ProgramFiles}\ZAP\Zed Attack Proxy"
         Write-Output "[ZAProxy] creating shortcut"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Network\zaproxy.lnk" -DestinationPath "${env:ProgramFiles}\ZAP\Zed Attack Proxy\zap.exe" -WorkingDirectory "${HOME}\Desktop" -Iconlocation "${env:ProgramFiles}\ZAP\Zed Attack Proxy\zap.ico"
-        if (Test-Path "${HOME}\Desktop\dfirws\Network\Zaproxy (runs dfirws-install -Zaproxy).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Network\Zaproxy (runs dfirws-install -Zaproxy).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Network\Zaproxy (runs dfirws-install -Zaproxy).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Network\Zaproxy (runs dfirws-install -Zaproxy).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Network\Zaproxy (runs dfirws-install -Zaproxy).lnk"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-zaproxy.txt" | Out-Null
         Write-Output "[ZAProxy] install complete"
     } else {
@@ -1515,12 +1312,7 @@ function Install-Zui {
         Write-Output "Installing Zui"
         & "${SETUP_PATH}\zui.exe" /S /AllUsers
         Add-ToUserPath "${env:ProgramFiles}\Zui"
-        if (Test-Path "${HOME}\Desktop\dfirws\Network\Zui (runs dfirws-install -Zui).lnk") {
-            Remove-Item "${HOME}\Desktop\dfirws\Network\Zui (runs dfirws-install -Zui).lnk" -Force
-        }
-        if (Test-Path "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Network\Zui (runs dfirws-install -Zui).lnk") {
-            Remove-Item "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs\dfirws - Network\Zui (runs dfirws-install -Zui).lnk" -Force
-        }
+        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Network\Zui (runs dfirws-install -Zui).lnk"
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-zui.txt" | Out-Null
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Network\Zui.lnk" -DestinationPath "${env:ProgramFiles}\Zui\Zui.exe" -WorkingDirectory "${HOME}\Desktop" -Iconlocation "${env:ProgramFiles}\Zui\Zui.exe"
     } else {


### PR DESCRIPTION
## What this PR changes

Implements the fixes for every finding reported in #403. This branch includes the #403 comment-cleanup commit (CI only runs for PRs targeting `main`, so this PR is based on `main`; once #403 merges, the diff here shrinks to just the fixes). Net **−396 lines** of fixes with no intended behavior changes beyond the bugs listed below.

### Stability fixes

1. **`common.ps1` `Get-DownloadUrlFromPage`**: `$Url -contains "github.com"` used the collection operator on a string, so the authenticated-GitHub branch never ran. Replaced with `-like "*github.com*"` and collapsed the six duplicated curl invocations into a single code path — GitHub page scrapes now use credentials when configured (rate-limit fix).
2. **Undefined `$file` in `ShouldProcess` calls**: `Update-ToolsDownloaded` (common.ps1) now passes `$Name`; `Update-WallPaper` (wscommon.ps1) now passes `$path`.
3. **`common.ps1` `Get-GitHubRelease`**: the tarball fallback no longer calls `Exit` (which killed the entire download run when one repo had no assets) — it logs the error and returns `$false`. Also dropped `.ToString()` on `zipball_url`, which threw on `$null` instead of reaching the error branch.
4. **`wscommon.ps1` `Install-WinDbg`**: removed the stray `Add-AppPackage` on the MSI — `Add-AppPackage` expects APPX/MSIX and the MSI is already installed by msiexec on the previous line.
5. **`wscommon.ps1` `Install-PDFStreamDumper`**: was deleting *LibreOffice's* start-menu shortcut (copy-paste from `Install-LibreOffice`); now removes its own shortcut pair via the new helper.
6. **Infinite waits**: `Wait-Sandbox` gets a `-TimeoutMinutes` parameter (default 240) that logs an ERROR and stops the sandbox on expiry; the `dfirws_folder_done.txt` wait at the end of `start_sandbox.ps1` gets a 30-minute deadline that logs a WARNING and continues.
7. **Stale parameters**: removed `$Ruby.IsPresent` from `downloadFiles.ps1` (no such parameter) and the `$Debloat` block from `createVM.ps1` (undeclared parameter calling a nonexistent `debloat.ps1`).
8. **`changelog.ps1`**: all six empty `catch { }` blocks now log a `Changelog: WARNING` naming the file that failed to parse, so corrupt metadata/state files no longer silently drop tools from the changelog or silently reset the baseline.

### Maintainability

- **New `Remove-InstallerShortcut` helper** (wscommon.ps1): takes the desktop `.lnk` path and derives the start-menu mirror using the same algorithm `dfirws_folder.ps1` uses to create it. Replaces 45 duplicated desktop+start-menu removal pairs (~270 lines → 45 one-liners). All 45 derivations were verified programmatically against the `dfirws_folder.ps1` reference algorithm — zero mismatches.
- **New `Install-ToolFromArchive` helper** (common.ps1): covers the three uniform clean/extract/rename orderings used by the download scripts (`-Target` cleaned before extraction by default, `-CleanAfterExtract` for the extract-then-clean variant, `-MoveFrom` for the versioned-directory rename). 51 blocks in release.ps1 and 19 in http.ps1 were converted by **exact-shape regex matching only** — each conversion is a mechanical 1:1 mapping that preserves operation order; the ~48 irregular blocks (extra `Copy-Item`s, `-Force` moves, sleeps) were deliberately left untouched.

### Deliberately not changed

- The remaining irregular extract blocks in release.ps1/http.ps1 — converting them requires per-tool knowledge of archive layouts and should be done incrementally with `-Verify` runs, not blind in one PR.
- The duplicated 7-Zip resolution in `resources/contrib/sync/*.ps1` and `resources/vm/prepare_zip_files.ps1` — those scripts are standalone by design (run from USB / before the repo is mounted), so extracting a shared module would break their portability.

### Verification

- All 87 `.ps1` files parse cleanly (PowerShell AST parser).
- All 17 Pester tests in `tests/changelog.Tests.ps1` pass with the new logging.
- `Install-ToolFromArchive` was functionally tested in all three modes with a stubbed 7-Zip (clean-before, clean-after, and rename semantics match the original inline code, including no accidental nesting).
- PSScriptAnalyzer reports no new warnings beyond one `PSUseShouldProcessForStateChangingFunctions` on the new helper, consistent with existing functions in the file.

https://claude.ai/code/session_014P3CorULf5dGQyxKCAoCxp