### PR TITLE
Fix neo4j-admin set-initial-password for Neo4j 2025.x

### DIFF
--- a/setup/wscommon.ps1
+++ b/setup/wscommon.ps1
@@ -899,7 +899,7 @@ function Install-Neo4j {
         & $SEVENZIP x -aoa "${SETUP_PATH}\neo4j.zip" -o"${env:ProgramFiles}" | Out-Null
         Move-Item ${env:ProgramFiles}\neo4j-community* ${env:ProgramFiles}\neo4j
         $env:JAVA_HOME = "$NEO_JAVA"
-        & "${env:ProgramFiles}\neo4j\bin\neo4j-admin" set-initial-password neo4j
+        & "${env:ProgramFiles}\neo4j\bin\neo4j-admin" dbms set-initial-password neo4j
         foreach ($lnkName in @("Neo4j 4 (runs dfirws-install -Neo4j).lnk", "Neo4j (runs dfirws-install -Neo4j).lnk")) {
             Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Files and apps\Database\${lnkName}"
         }


### PR DESCRIPTION
## Summary
- The verify step failed during `Install-Neo4j` with `Unmatched arguments from index 0: 'set-initial-password', 'neo4j' — Did you mean: neo4j-admin dbms set-initial-password`.
- `dfirws-install.ps1` scrapes the Neo4j Deployment Center for the community winzip and now pulls a 2025.x build (per the existing comment "installed during start (required by Neo4j 2025.x)"), which moved `set-initial-password` under a new `dbms` subcommand namespace in `neo4j-admin`.
- Updated the single call site in `setup/wscommon.ps1` (`Install-Neo4j`) from `neo4j-admin set-initial-password neo4j` to `neo4j-admin dbms set-initial-password neo4j`.
- Searched the rest of the codebase for other `neo4j-admin` invocations or Neo4j config touchpoints — this was the only one, so no further changes were needed.

## Test plan
- [ ] Run `dfirws-install.ps1 -Neo4j` (or the full verify pass) on a Windows build and confirm Neo4j installs without the "Unmatched arguments" error and the initial password is set.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGwjfHicpygi8UmH6sLrH7)_