### PR TITLE
Fix cascading install failures behind downloadFiles.ps1 -verify errors

### DIFF
--- a/setup/shared.ps1
+++ b/setup/shared.ps1
@@ -127,7 +127,17 @@ function New-CreateToolFiles {
         $install_verify_command = $ToolDefinitions[$i].InstallVerifyCommand
 
         if ($null -ne $install_verify_command -and $install_verify_command -ne "") {
-            Add-Content -Path "$BASE_PATH\dfirws\install_${source}.ps1" -Value "$install_verify_command"
+            # Wrap each tool's install command in its own try/catch so an unhandled
+            # terminating error from one tool (e.g. a raw .NET exception) can't unwind
+            # the whole script and silently skip every tool listed after it in this file.
+            $installLines = @(
+                "try {"
+                "    $install_verify_command"
+                "} catch {"
+                ('    Write-Output "ERROR: {0} failed: $_"' -f $install_verify_command)
+                "}"
+            )
+            Add-Content -Path "$BASE_PATH\dfirws\install_${source}.ps1" -Value $installLines
         }
 
         # Create helper file dfirws_folder_${source}.ps1 called from dfirws-install.ps1.

--- a/setup/wscommon.ps1
+++ b/setup/wscommon.ps1
@@ -99,8 +99,17 @@ function Add-ToUserPath {
     $path = [Environment]::GetEnvironmentVariable("PATH", [System.EnvironmentVariableTarget]::User)
     if (!(${path}.Contains("${dir}"))) {
         # append dir to path
-        [Environment]::SetEnvironmentVariable("PATH", "${path}" + ";${dir}", [EnvironmentVariableTarget]::User)
-        Write-Output "Added ${dir} to PATH"
+        # SetEnvironmentVariable throws (raw .NET exception, bypasses $ErrorActionPreference)
+        # when the User PATH would exceed ~2047 characters. Left uncaught, that terminating
+        # error unwinds the whole call stack and aborts whichever install_*.ps1 script called
+        # us, silently skipping every tool listed after it in that file.
+        try {
+            [Environment]::SetEnvironmentVariable("PATH", "${path}" + ";${dir}", [EnvironmentVariableTarget]::User)
+            Write-Output "Added ${dir} to PATH"
+        }
+        catch {
+            Write-Output "WARNING: Failed to add ${dir} to PATH: $_"
+        }
         return
     }
     Write-Output "${dir} is already in PATH"
@@ -115,8 +124,13 @@ function Add-MultipleToUserPath {
     )
 
     $path = [Environment]::GetEnvironmentVariable("PATH", [System.EnvironmentVariableTarget]::User)
-    [Environment]::SetEnvironmentVariable("PATH", "${path}" + "${dirs}", [EnvironmentVariableTarget]::User)
-    Write-Output "Added ${dirs} to PATH"
+    try {
+        [Environment]::SetEnvironmentVariable("PATH", "${path}" + "${dirs}", [EnvironmentVariableTarget]::User)
+        Write-Output "Added ${dirs} to PATH"
+    }
+    catch {
+        Write-Output "WARNING: Failed to add ${dirs} to PATH: $_"
+    }
 }
 
 function Add-Shortcut {


### PR DESCRIPTION
## Summary

`.\downloadFiles.ps1 -verify` was reporting a run of "does not exist" errors for tools that appear consecutively in the generated `downloads\dfirws\install_winget.ps1` (PuTTY, QEMU, Ruby, VLC, WinMerge, Google Earth, Wireshark, Firefox, Foxit Reader), even though those tools can be installed manually without issue.

**Root cause:** `Add-ToUserPath` / `Add-MultipleToUserPath` in `setup/wscommon.ps1` call `[Environment]::SetEnvironmentVariable("PATH", ..., User)` directly. Windows throws a raw `System.ArgumentException` from that call once the User-scope `PATH` nears its ~2047 character limit. That's a genuine .NET exception, not a PowerShell cmdlet error, so it bypasses `$ErrorActionPreference` entirely and, left uncaught, unwinds the whole call stack.

In this repo's setup flow, `install_winget.ps1` (autogenerated by `New-CreateToolFiles` in `setup/shared.ps1`) is just a flat list of `dfirws-install.ps1 -X` calls run in a single PowerShell process. Once the cumulative PATH crossed the limit partway through that list (at `PuTTY`'s `Add-ToUserPath "${env:ProgramFiles}\PuTTY"` call), the uncaught exception aborted the *entire* `install_winget.ps1` script, silently skipping every tool listed after PuTTY — exactly the set of tools reported missing by `-verify`. (Neovim, which comes last in that file, still verified fine because `start_sandbox.ps1` also installs it directly, independent of `install_winget.ps1`.)

## Changes

- `setup/wscommon.ps1`: `Add-ToUserPath` and `Add-MultipleToUserPath` now catch the `SetEnvironmentVariable` exception and emit a `WARNING` instead of throwing, so a full/near-limit PATH degrades gracefully instead of crashing the caller.
- `setup/shared.ps1`: `New-CreateToolFiles` now wraps each generated `dfirws-install.ps1 -X` line in its own `try { ... } catch { Write-Output "ERROR: ... failed: $_" }` block when building `install_${source}.ps1`. This applies to every generated install script (winget, http, release, git, zimmerman, etc.), so any future unhandled error in one tool's install can no longer cascade and skip the rest of that file — mirroring the per-file protection `install_all.ps1` already has for whole scripts.

## Test plan

- [ ] Re-run `.\downloadFiles.ps1 -Winget` followed by `.\downloadFiles.ps1 -Verify` (or `-verify` alone) on Windows and confirm PuTTY, QEMU, Ruby, VLC, WinMerge, Google Earth, Wireshark, Firefox, and Foxit Reader all verify successfully.
- [ ] Confirm `downloads\dfirws\install_winget.ps1` is regenerated with each tool call wrapped in `try/catch`.
- [ ] If a tool's install genuinely fails, confirm the error now appears as `ERROR: dfirws-install.ps1 -X failed: ...` in the sandbox log rather than silently truncating the rest of the file.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JLikoRPNQVEd6yAzXhHFKw)_