### PR TITLE
Capture install_*.ps1 stdout/stderr to diagnose remaining -verify failures

### DIFF
--- a/setup/install/install_all.ps1
+++ b/setup/install/install_all.ps1
@@ -6,16 +6,31 @@ $PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'
 # PowerShell subprocess via Start-Process -Wait so that a fatal error in one
 # script (an installer that terminates its parent process, an `exit` call in
 # a generated helper, etc.) cannot prevent the next script from running.
+#
+# stdout/stderr are redirected to C:\log (mapped back to the host) instead of
+# being left in the subprocess's own console window, which closes the moment
+# the process exits. Without this, a hard crash in one of the per-tool
+# install commands (e.g. a COM/Appx deployment failure that takes down the
+# whole PowerShell host rather than raising a catchable .NET exception) is
+# invisible after the fact - only the numeric exit code survives.
+if (! (Test-Path "C:\log\install-logs")) {
+    New-Item -ItemType Directory -Force -Path "C:\log\install-logs" | Out-Null
+}
 $INSTALL_SCRIPTS = Get-ChildItem -Path "${SETUP_PATH}\dfirws" -Filter "install_*.ps1" -ErrorAction SilentlyContinue
 foreach ($script in $INSTALL_SCRIPTS) {
     Write-SynchronizedLog "Started install script: $($script.Name)"
+    $stdoutLog = "C:\log\install-logs\$($script.BaseName).stdout.log"
+    $stderrLog = "C:\log\install-logs\$($script.BaseName).stderr.log"
     try {
         $proc = Start-Process -Wait -PassThru "${POWERSHELL_EXE}" -ArgumentList @(
             "-NoProfile",
             "-ExecutionPolicy", "Bypass",
             "-File", "`"$($script.FullName)`""
-        )
+        ) -RedirectStandardOutput $stdoutLog -RedirectStandardError $stderrLog
         Write-SynchronizedLog "Finished install script: $($script.Name) (exit code $($proc.ExitCode))"
+        if ($proc.ExitCode -ne 0) {
+            Write-SynchronizedLog "ERROR: $($script.Name) exited with code $($proc.ExitCode). See install-logs\$($script.BaseName).stderr.log for details."
+        }
     }
     catch {
         Write-SynchronizedLog "ERROR in install script $($script.Name): $_"


### PR DESCRIPTION
## Summary

Follow-up to #414. That PR fixed a `PATH`-length exception that was cascading and silently aborting `install_winget.ps1`. After merging, `install_winget.ps1` still exits with code 1 and the exact same 9 tools (PuTTY, QEMU, Ruby, VLC, WinMerge, Google Earth, Wireshark, Firefox, Foxit Reader) still fail `-verify`, while the 4 tools listed before them (Burp Suite, Chrome, Obsidian, OhMyPosh) still succeed — confirmed the regenerated `install_winget.ps1` does contain the `try/catch` wrapping from #414.

Since:
- there's no `exit` call anywhere in `setup/wscommon.ps1` or `setup/utils/dfirws-install.ps1` (checked directly),
- the failing `dfirws-install.ps1 -PuTTY` line is already wrapped in `try/catch`,
- yet the *same* 9 tools fail every run, right after the same 4 succeed,

whatever is happening is very likely a hard process-level failure (e.g. a COM/Appx deployment failure, since `Install-OhMyPosh` calls `Add-AppxPackage`, which is a known source of uncatchable failures inside Windows Sandbox) rather than a normal catchable PowerShell exception. I can't reproduce this locally (no Windows/sandbox available in this environment), so guessing further without the actual error text isn't productive.

## Changes

- `setup/install/install_all.ps1`: each `install_*.ps1` subprocess's stdout/stderr is now redirected to `C:\log\install-logs\<name>.std{out,err}.log` (the `C:\log` mapped folder already persists back to the host after the sandbox closes) instead of being left in the subprocess's own console window, which closes the instant the process exits and takes any error text with it.
- A non-zero exit code is now also logged as an explicit `ERROR: ...` line, so this failure surfaces under `downloadFiles.ps1 -ShowErrors` directly instead of requiring a manual `Select-String` through `verify.txt`.

This is a diagnostic change, not a claimed fix for the remaining failures — the goal is to capture the actual exception/crash text on the next `-verify` run so the real root cause can be identified and fixed with real evidence instead of more guessing.

## Test plan

- [ ] Run `.\downloadFiles.ps1 -Winget` then `.\downloadFiles.ps1 -Verify` and confirm `downloads\dfirws\install-logs\` (or `log\install-logs\` post-run) contains `install_winget.stdout.log` / `install_winget.stderr.log`.
- [ ] If PuTTY/QEMU/etc. still fail, inspect `install_winget.stderr.log` for the actual exception/crash text and use it to pinpoint and fix the real root cause in a follow-up change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JLikoRPNQVEd6yAzXhHFKw)_