### PR TITLE
Fix ForensicTimeliner install bug + add tracing for the winget -verify investigation

### DIFF
--- a/setup/wscommon.ps1
+++ b/setup/wscommon.ps1
@@ -627,7 +627,6 @@ function Install-ForensicTimeliner {
         $CLI_TOOL_ARGS = "-w 0 C:\Program Files\PowerShell\7\pwsh.exe -NoExit"
 
         & $SEVENZIP x -aoa "${SETUP_PATH}\ForensicTimeliner.zip" -o"${env:ProgramFiles}\ForensicTimeliner" | Out-Null
-        Move-Item ${env:ProgramFiles}\ForensicTimeliner* "${env:ProgramFiles}\ForensicTimeliner" -Force
         Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\IR\Forensic Timeliner (runs dfirws-install -ForensicTimeliner).lnk"
         Add-ToUserPath "${env:ProgramFiles}\ForensicTimeliner"
         Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\IR\Forensic Timeliner.lnk" -DestinationPath "${CLI_TOOL}" -WorkingDirectory "${HOME}\Desktop" -Arguments "${CLI_TOOL_ARGS} -command ForensicTimeliner -h"

--- a/setup/wscommon.ps1
+++ b/setup/wscommon.ps1
@@ -937,23 +937,38 @@ function Install-Node {
 function Install-Obsidian {
     if (!(Test-Path "${env:ProgramFiles}\dfirws\installed-obsidian.txt")) {
         Write-Output "Installing Obsidian"
-        Start-Process -Wait "${SETUP_PATH}\obsidian.exe" -ArgumentList '/S /V"/qn REBOOT=ReallySuppress"'
-        # Obsidian uses a Squirrel/Electron installer that spawns a child process
-        # (Update.exe) to perform the actual installation. Start-Process -Wait only
-        # waits for the parent process, so the desktop shortcut may not exist yet.
-        $retries = 0
-        while (!(Test-Path "${HOME}\Desktop\Obsidian.lnk") -and $retries -lt 30) {
-            Start-Sleep -Seconds 2
-            $retries++
+        # Diagnostic tracing (temporary): install_winget.ps1 has been observed to stop
+        # producing any further output right after this function starts, with an empty
+        # stderr log, so every tool after Obsidian in that file silently fails to run.
+        # These trace lines + try/catch pinpoint exactly which step never returns/throws.
+        try {
+            Start-Process -Wait "${SETUP_PATH}\obsidian.exe" -ArgumentList '/S /V"/qn REBOOT=ReallySuppress"'
+            Write-Output "TRACE: Obsidian installer process exited"
+            # Obsidian uses a Squirrel/Electron installer that spawns a child process
+            # (Update.exe) to perform the actual installation. Start-Process -Wait only
+            # waits for the parent process, so the desktop shortcut may not exist yet.
+            $retries = 0
+            while (!(Test-Path "${HOME}\Desktop\Obsidian.lnk") -and $retries -lt 30) {
+                Start-Sleep -Seconds 2
+                $retries++
+            }
+            Write-Output "TRACE: Obsidian shortcut wait finished after $retries retries (found: $(Test-Path "${HOME}\Desktop\Obsidian.lnk"))"
+            Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Editors\Obsidian (runs dfirws-install -Obsidian).lnk"
+            Write-Output "TRACE: Removed Obsidian installer shortcut"
+            if (Test-Path "${HOME}\Desktop\Obsidian.lnk") {
+                Copy-Item "${HOME}\Desktop\Obsidian.lnk" "${HOME}\Desktop\dfirws\Editors\Obsidian.lnk" -Force
+            } else {
+                Write-Output "WARNING: Obsidian.lnk not found on Desktop after installation. Creating shortcut manually."
+                Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Editors\Obsidian.lnk" -DestinationPath "${HOME}\AppData\Local\Programs\Obsidian\Obsidian.exe" -WorkingDirectory "${HOME}\Desktop"
+            }
+            Write-Output "TRACE: Obsidian shortcut handling complete"
         }
-        Remove-InstallerShortcut -DesktopLnk "${HOME}\Desktop\dfirws\Editors\Obsidian (runs dfirws-install -Obsidian).lnk"
-        if (Test-Path "${HOME}\Desktop\Obsidian.lnk") {
-            Copy-Item "${HOME}\Desktop\Obsidian.lnk" "${HOME}\Desktop\dfirws\Editors\Obsidian.lnk" -Force
-        } else {
-            Write-Warning "Obsidian.lnk not found on Desktop after installation. Creating shortcut manually."
-            Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Editors\Obsidian.lnk" -DestinationPath "${HOME}\AppData\Local\Programs\Obsidian\Obsidian.exe" -WorkingDirectory "${HOME}\Desktop"
+        catch {
+            Write-Output "ERROR in Install-Obsidian: $($_.Exception.GetType().FullName): $($_.Exception.Message)"
+            Write-Output "ERROR in Install-Obsidian: $($_.ScriptStackTrace)"
         }
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-obsidian.txt" | Out-Null
+        Write-Output "TRACE: Obsidian install marker written"
     } else {
         Write-Output "Obsidian is already installed"
     }
@@ -974,12 +989,25 @@ function Install-OSFMount {
 function Install-OhMyPosh {
     if (!(Test-Path "${env:ProgramFiles}\dfirws\installed-ohmyposh.txt")) {
         Write-Output "Installing OhMyPosh"
-        Add-AppxPackage "${SETUP_PATH}\oh-my-posh.msi"
-        Write-Output "Installing OhMyPosh fonts"
-        Start-Process -Wait "oh-my-posh.exe" -ArgumentList "font install ${SETUP_PATH}\${WSDFIR_FONT_NAME}.zip" | Out-Null
-        Write-Output "Creating new shortcut"
-        Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Utilities\Oh-My-Posh.lnk" -DestinationPath "${POWERSHELL_EXE}" -WorkingDirectory "${HOME}\Desktop" -Arguments "-NoExit -command oh-my-posh.exe --help"
+        # Diagnostic tracing (temporary): Add-AppxPackage is a known source of hard,
+        # uncatchable Appx deployment failures inside Windows Sandbox. See the matching
+        # try/catch + TRACE lines in Install-Obsidian for why this is here.
+        try {
+            Add-AppxPackage "${SETUP_PATH}\oh-my-posh.msi"
+            Write-Output "TRACE: Add-AppxPackage for OhMyPosh completed"
+            Write-Output "Installing OhMyPosh fonts"
+            Start-Process -Wait "oh-my-posh.exe" -ArgumentList "font install ${SETUP_PATH}\${WSDFIR_FONT_NAME}.zip" | Out-Null
+            Write-Output "TRACE: OhMyPosh font install completed"
+            Write-Output "Creating new shortcut"
+            Add-Shortcut -SourceLnk "${HOME}\Desktop\dfirws\Utilities\Oh-My-Posh.lnk" -DestinationPath "${POWERSHELL_EXE}" -WorkingDirectory "${HOME}\Desktop" -Arguments "-NoExit -command oh-my-posh.exe --help"
+            Write-Output "TRACE: OhMyPosh shortcut created"
+        }
+        catch {
+            Write-Output "ERROR in Install-OhMyPosh: $($_.Exception.GetType().FullName): $($_.Exception.Message)"
+            Write-Output "ERROR in Install-OhMyPosh: $($_.ScriptStackTrace)"
+        }
         New-Item -ItemType File -Path "${env:ProgramFiles}\dfirws" -Name "installed-ohmyposh.txt" | Out-Null
+        Write-Output "TRACE: OhMyPosh install marker written"
     } else {
         Write-Output "OhMyPosh is already installed"
     }


### PR DESCRIPTION
## Summary

Two changes, both surfaced by the diagnostic logging added in #415:

### 1. Fix `Install-ForensicTimeliner` Move-Item self-reference (confirmed, real bug)

`install_release.stderr.log` from a `-verify` run showed:

```
Move-Item: C:\Users\WDAGUtilityAccount\Documents\tools\wscommon.ps1:630
Destination path cannot be a subdirectory of the source or the source itself: C:\Program
Files\ForensicTimeliner\ForensicTimeliner.
```

`Install-ForensicTimeliner` already extracts `ForensicTimeliner.zip` directly into `${env:ProgramFiles}\ForensicTimeliner` via 7-Zip's `-o` flag. The following `Move-Item` glob-matches that same folder and tries to move it into itself, which PowerShell rejects. This crashed `install_release.ps1` (exit code 1) on every `-verify` run. No other 7z-based `Install-*` function in `setup/wscommon.ps1` has an equivalent post-extraction `Move-Item`, confirming this line is leftover/erroneous.

### 2. Diagnostic tracing for `Install-Obsidian` / `Install-OhMyPosh` (still investigating)

The winget `-verify` failures from #414/#415 turned out not to be the PATH-length cascade after all — `install_winget.stdout.log` from the latest run stops dead right after `Installing Obsidian` is printed: no further output, and `install_winget.stderr.log` is empty (no exception text). Every tool listed after Obsidian in `install_winget.ps1` (PuTTY, QEMU, Ruby, VLC, WinMerge, Google Earth, Wireshark, Firefox, Foxit Reader) then fails `-verify`, while Burp/Chrome/Obsidian itself/OhMyPosh's own tools succeed. The elapsed time for the whole script (~76s) roughly matches Burp + Chrome installing plus Obsidian's own up-to-60s desktop-shortcut retry loop, pointing at something in or right after that loop.

Added `try/catch` + `TRACE:`/`ERROR:` `Write-Output` lines around the risky steps in both `Install-Obsidian` and `Install-OhMyPosh` (the next tool in line, whose `Add-AppxPackage` call is a known source of hard, uncatchable Appx deployment failures inside Windows Sandbox) so the next `-verify` run's `install_winget.stdout.log` pinpoints exactly which line never returns. This is intentionally temporary/verbose instrumentation to be cleaned up once the actual root cause is found and fixed.

## Test plan

- [ ] Run `.\downloadFiles.ps1 -Release` then `.\downloadFiles.ps1 -Verify` and confirm ForensicTimeliner installs and `install_release.stderr.log` is empty.
- [ ] Run `.\downloadFiles.ps1 -Winget` then `.\downloadFiles.ps1 -Verify` and check `log\install-logs\install_winget.stdout.log` for the new `TRACE:`/`ERROR:` lines to identify exactly where execution stops.
