### PR TITLE
Clear stale install-logs at the start of downloadFiles.ps1

### DIFF
--- a/downloadFiles.ps1
+++ b/downloadFiles.ps1
@@ -355,6 +355,15 @@ Get-Date > ".\log\logboost.txt"
 Get-Date > ".\log\jobs.txt"
 Get-Date > ".\log\verify.txt"
 
+# install-logs is written from inside the sandbox (mapped via .\log), but the
+# error/warning/failed scan at the bottom of this script reads everything
+# under .\log recursively on every run, verify or not. Clear it here so a
+# stale error from an earlier run - or a run where the sandbox never got as
+# far as install_all.ps1 - can't be misread as coming from this run.
+if (Test-Path ".\log\install-logs") {
+    Remove-Item -Recurse -Force ".\log\install-logs" | Out-Null
+}
+
 if ($DebugDownloads.IsPresent) {
     Write-DateLog "Debug mode enabled."
     New-Item -ItemType Directory -Force -Path "${TOOLS}\Debug" 2>&1 | Out-Null

--- a/setup/install/install_all.ps1
+++ b/setup/install/install_all.ps1
@@ -13,9 +13,13 @@ $PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'
 # install commands (e.g. a COM/Appx deployment failure that takes down the
 # whole PowerShell host rather than raising a catchable .NET exception) is
 # invisible after the fact - only the numeric exit code survives.
-if (! (Test-Path "C:\log\install-logs")) {
-    New-Item -ItemType Directory -Force -Path "C:\log\install-logs" | Out-Null
+# C:\log is mapped back to the host and persists across sandbox runs, so stale
+# logs from a script that no longer exists (excluded source, skipped flag, ...)
+# would otherwise linger and could be mistaken for current output.
+if (Test-Path "C:\log\install-logs") {
+    Remove-Item -Recurse -Force "C:\log\install-logs" | Out-Null
 }
+New-Item -ItemType Directory -Force -Path "C:\log\install-logs" | Out-Null
 $INSTALL_SCRIPTS = Get-ChildItem -Path "${SETUP_PATH}\dfirws" -Filter "install_*.ps1" -ErrorAction SilentlyContinue
 foreach ($script in $INSTALL_SCRIPTS) {
     Write-SynchronizedLog "Started install script: $($script.Name)"

--- a/setup/install/install_all.ps1
+++ b/setup/install/install_all.ps1
@@ -13,13 +13,12 @@ $PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'
 # install commands (e.g. a COM/Appx deployment failure that takes down the
 # whole PowerShell host rather than raising a catchable .NET exception) is
 # invisible after the fact - only the numeric exit code survives.
-# C:\log is mapped back to the host and persists across sandbox runs, so stale
-# logs from a script that no longer exists (excluded source, skipped flag, ...)
-# would otherwise linger and could be mistaken for current output.
-if (Test-Path "C:\log\install-logs") {
-    Remove-Item -Recurse -Force "C:\log\install-logs" | Out-Null
+# install-logs itself is cleared by downloadFiles.ps1 on the host before the
+# sandbox starts (it needs to happen there regardless of whether the sandbox
+# reaches this script at all); just make sure the directory exists here.
+if (! (Test-Path "C:\log\install-logs")) {
+    New-Item -ItemType Directory -Force -Path "C:\log\install-logs" | Out-Null
 }
-New-Item -ItemType Directory -Force -Path "C:\log\install-logs" | Out-Null
 $INSTALL_SCRIPTS = Get-ChildItem -Path "${SETUP_PATH}\dfirws" -Filter "install_*.ps1" -ErrorAction SilentlyContinue
 foreach ($script in $INSTALL_SCRIPTS) {
     Write-SynchronizedLog "Started install script: $($script.Name)"


### PR DESCRIPTION
## Summary

Follow-up to the `install-logs\` diagnostic capture added in #415/#416. `C:\log\install-logs` is mapped back to the host and persists across sandbox runs.

Clearing it inside `install_all.ps1` (as this PR originally did) isn't enough: the error/warning/failed scan at the bottom of `downloadFiles.ps1` runs **unconditionally on every invocation**, not just `-Verify`, and reads everything under `.\log` recursively. So:

- A plain `.\downloadFiles.ps1 -Winget` run (no sandbox involved at all) could still flag stale `install-logs\*.stderr.log` content from a previous `-Verify` run.
- A standalone `.\downloadFiles.ps1 -ShowErrors` reads whatever's sitting in `install-logs\` regardless of when it was written.
- If the sandbox dies before ever reaching `install_all.ps1`, the clearing inside that script never runs, so stale logs linger indefinitely.

## Changes

- `downloadFiles.ps1`: clear `.\log\install-logs` on the host at the top of the script, alongside the existing `log.txt`/`logboost.txt`/`jobs.txt`/`verify.txt` resets.
- `setup/install/install_all.ps1`: reverted to just ensuring the directory exists for that sandbox run (clearing now happens on the host beforehand, so this no longer needs to do it itself).

## Test plan

- [ ] Run `.\downloadFiles.ps1 -Winget` (no `-Verify`) after a prior `-Verify` run left an error in `log\install-logs\`, and confirm that stale error is no longer reported.
- [ ] Run `.\downloadFiles.ps1 -Verify` twice with a different set of install flags between runs and confirm `log\install-logs\` only ever contains logs for scripts that ran in the most recent run.
