### PR TITLE
Export Windows Event Log entries to diagnose silent process deaths

### DIFF
--- a/setup/install/install_all.ps1
+++ b/setup/install/install_all.ps1
@@ -40,6 +40,34 @@ foreach ($script in $INSTALL_SCRIPTS) {
     }
 }
 
+# install_release.ps1 and install_winget.ps1 have both been observed to exit
+# non-zero with a completely empty stderr log and stdout that just stops mid-
+# script - no exception text, nothing our own try/catch wrappers can catch.
+# That pattern (silent death, no PowerShell-visible error) is consistent with
+# something external killing the process outright, e.g. Windows Sandbox's
+# Smart App Control / Defender reputation-based protection terminating a
+# newly downloaded, unsigned/unrecognized executable. The sandbox is
+# ephemeral, so any Event Viewer evidence of that is otherwise lost the
+# moment it closes - export the logs most likely to show it here instead.
+$eventLogSources = @(
+    "System"
+    "Application"
+    "Microsoft-Windows-Windows Defender/Operational"
+    "Microsoft-Windows-CodeIntegrity/Operational"
+)
+foreach ($logName in $eventLogSources) {
+    $safeName = $logName -replace "[\\/]", "-"
+    $outFile = "C:\log\install-logs\eventlog-${safeName}.txt"
+    try {
+        Get-WinEvent -LogName $logName -MaxEvents 100 -ErrorAction Stop |
+            Select-Object TimeCreated, LevelDisplayName, Id, ProviderName, Message |
+            Format-List | Out-File -FilePath $outFile -Encoding utf8
+    }
+    catch {
+        Write-SynchronizedLog "Could not export event log '$logName': $_"
+    }
+}
+
 Write-SynchronizedLog "Install all tools in the sandbox."
 Write-OutPut "Install all tools in the sandbox."
 if (Test-Path -Path C:\venv\visualstudio.txt) {


### PR DESCRIPTION
## Summary

Continuing the `downloadFiles.ps1 -verify` investigation (#414-#417). After fixing the confirmed `Install-ForensicTimeliner` bug in #416, a fresh `-verify` run shows **both** `install_release.ps1` and `install_winget.ps1` still exiting with code 1, each with a completely **empty** stderr log:

- `install_winget.stdout.log` still stops dead right after `Installing Obsidian` is printed - none of the `TRACE:`/`ERROR in Install-Obsidian:` lines added in #416 appear at all, meaning whatever kills it isn't a normal catchable PowerShell exception.
- `install_release.stderr.log` is now empty too (previously it had the ForensicTimeliner `Move-Item` error, which is fixed), yet the script still exits non-zero.

Two independent, unrelated scripts silently dying the same way - no exception text, nothing our `try/catch` wrappers can catch, output just stopping mid-stream - points away from a bug in either script's own logic and toward something *external* killing the process outright. The leading suspect is Windows Sandbox's Smart App Control / Defender reputation-based protection terminating a newly downloaded, unsigned/unrecognized executable (`start_sandbox.ps1` already has a "Ugly fix for Code Integrity blocking unsigned binaries" workaround at the top, suggesting this class of issue is known). Windows Sandbox's 8GB memory cap is a secondary candidate.

We currently have no way to confirm this: Windows Sandbox is ephemeral, so any Event Viewer evidence disappears the moment it closes.

## Changes

- `setup/install/install_all.ps1`: after running all `install_*.ps1` scripts, export recent `System`, `Application`, `Microsoft-Windows-Windows Defender/Operational`, and `Microsoft-Windows-CodeIntegrity/Operational` event log entries to `C:\log\install-logs\eventlog-*.txt` (mapped back to the host), so this evidence survives the sandbox closing.

## Test plan

- [ ] Run `.\downloadFiles.ps1 -Winget` then `.\downloadFiles.ps1 -Verify` and confirm `log\install-logs\eventlog-*.txt` files are created.
- [ ] Inspect them (particularly `eventlog-Microsoft-Windows-Windows Defender-Operational.txt` and `eventlog-Microsoft-Windows-CodeIntegrity-Operational.txt`) around the timestamp where `install_winget.stdout.log` stops, to confirm or rule out an external process kill.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JLikoRPNQVEd6yAzXhHFKw)_