### PR TITLE
Run the DNS-fix netsh commands once per sandbox session, not per tool

### DIFF
--- a/setup/wscommon.ps1
+++ b/setup/wscommon.ps1
@@ -42,13 +42,27 @@ $SEVENZIP = Get-SevenZip
 $null = $SEVENZIP
 
 # Check if C:\log exists, indicating running downloadFiles.ps1
-# Fix DNS servers if needed
-if (Test-Path -Path "C:\log") {
+# Fix DNS servers if needed - guarded to run at most once per sandbox session.
+# wscommon.ps1 is dot-sourced on every dfirws-install.ps1 invocation (once per
+# tool, so many times per install_*.ps1 file). Re-running a network-stack
+# -modifying netsh command that often is wasteful at best, and if it lands
+# while another process (e.g. an app installer's own update/connectivity
+# check) is mid-network-operation, is a plausible source of hangs.
+# C:\Tools is mapped read-only in the verify sandbox, so the marker has to live
+# somewhere actually writable - use the same ${env:ProgramFiles}\dfirws
+# directory every Install-* function already uses for its own installed-*.txt
+# marker.
+$dnsFixMarker = "${env:ProgramFiles}\dfirws\dns-fixed.txt"
+if ((Test-Path -Path "C:\log") -and -not (Test-Path -Path $dnsFixMarker)) {
     $dns = C:\Windows\System32\ipconfig /all | Select-String -Pattern "8.8.8.8"
     if ($null -eq $dns) {
         C:\Windows\System32\netsh interface ipv4 add dnsserver "Ethernet" address=8.8.8.8 index=1 | Out-Null
         C:\Windows\System32\netsh interface ipv4 add dnsserver "Ethernet" address=1.1.1.1 index=2 | Out-Null
     }
+    if (! (Test-Path -Path "${env:ProgramFiles}\dfirws")) {
+        New-Item -ItemType Directory -Force -Path "${env:ProgramFiles}\dfirws" | Out-Null
+    }
+    New-Item -ItemType File -Path $dnsFixMarker -Force | Out-Null
 }
 
 foreach ($dir in @("${WSDFIR_TEMP}\msys2", "${HOME}\Documents\WindowsPowerShell", "${HOME}\Documents\PowerShell", "${env:ProgramFiles}\PowerShell\Modules\PSDecode", "${env:ProgramFiles}\dfirws", "${HOME}\Documents\jupyter")) {


### PR DESCRIPTION
## Summary

Continuing the `downloadFiles.ps1 -verify` investigation (#414-#418). Using the Event Log export added in #418, the exported logs from a `-verify` run show:

- **No Defender detections** (`eventlog-Microsoft-Windows-Windows_Defender-Operational.txt` is empty).
- **No Code Integrity blocks** - just routine policy-refresh informational events.
- **No crash or hang events anywhere** in `Application`/`System` logs across the whole ~9-minute window.

That rules out the "something external kills the process" theory from #418. Instead, the `Application` log (via Fibratus, one of the tools installed as part of the run) shows `netsh interface ipv4 add dnsserver ...` commands actively firing right in the window where `install_winget.ps1` silently dies, right around Obsidian's own installer.

The actual bug: `setup/wscommon.ps1` has a DNS-server-fixing block at **top-level script scope**:

```powershell
if (Test-Path -Path "C:\log") {
    $dns = C:\Windows\System32\ipconfig /all | Select-String -Pattern "8.8.8.8"
    if ($null -eq $dns) {
        C:\Windows\System32\netsh interface ipv4 add dnsserver "Ethernet" address=8.8.8.8 index=1 | Out-Null
        C:\Windows\System32\netsh interface ipv4 add dnsserver "Ethernet" address=1.1.1.1 index=2 | Out-Null
    }
}
```

`wscommon.ps1` is dot-sourced by `dfirws-install.ps1` on **every** invocation - i.e. once per tool. So this network-stack-modifying `netsh` command was firing repeatedly throughout an entire `-verify` run (once per tool, in every `install_<source>.ps1` file), not once per sandbox session as clearly intended. Re-running it while another process (e.g. an installer's own update/connectivity check, as Electron/Squirrel-based Obsidian likely does) is mid network-operation is a plausible source of a hang.

## Changes

- `setup/wscommon.ps1`: guard the DNS-fix block with a marker file so it runs at most once per sandbox session. `C:\Tools` is mapped read-only in the verify sandbox, so the marker lives in `${env:ProgramFiles}\dfirws` - the same writable directory every `Install-*` function already uses for its own `installed-*.txt` marker.

## Test plan

- [ ] Run `.\downloadFiles.ps1 -Winget` then `.\downloadFiles.ps1 -Verify` and confirm PuTTY/QEMU/Ruby/VLC/WinMerge/Google Earth/Wireshark/Firefox/Foxit Reader now verify successfully.
- [ ] Confirm `netsh interface ipv4 add dnsserver` only runs once per sandbox session (e.g. check `C:\Program Files\dfirws\dns-fixed.txt` exists after the run).


---
_Generated by [Claude Code](https://claude.ai/code/session_01JLikoRPNQVEd6yAzXhHFKw)_