### PR TITLE
Cap Install-Obsidian's installer wait instead of blocking forever

### DIFF
--- a/setup/wscommon.ps1
+++ b/setup/wscommon.ps1
@@ -951,13 +951,25 @@ function Install-Node {
 function Install-Obsidian {
     if (!(Test-Path "${env:ProgramFiles}\dfirws\installed-obsidian.txt")) {
         Write-Output "Installing Obsidian"
-        # Diagnostic tracing (temporary): install_winget.ps1 has been observed to stop
-        # producing any further output right after this function starts, with an empty
-        # stderr log, so every tool after Obsidian in that file silently fails to run.
-        # These trace lines + try/catch pinpoint exactly which step never returns/throws.
+        # install_winget.ps1 has been observed to silently stop producing any
+        # further output right after this function starts - no exception, no
+        # crash/hang event anywhere in Event Viewer, stderr log empty - which
+        # blocks every tool listed after Obsidian in that file. Diagnostic
+        # tracing (added while narrowing this down, left in place) confirmed
+        # `Start-Process -Wait` on the installer itself never returns control.
+        # Obsidian's installer is Squirrel/Electron-based (see comment below),
+        # not an MSI/Inno-style installer, so it may not honor - or may be
+        # confused by - the `/V"/qn REBOOT=ReallySuppress"` MSI-passthrough
+        # flag, and Squirrel installers are known to auto-launch the app after
+        # a silent install completes. Cap the wait instead of blocking forever
+        # so a misbehaving installer here can't take down the rest of the run.
         try {
-            Start-Process -Wait "${SETUP_PATH}\obsidian.exe" -ArgumentList '/S /V"/qn REBOOT=ReallySuppress"'
-            Write-Output "TRACE: Obsidian installer process exited"
+            $obsidianProc = Start-Process -PassThru "${SETUP_PATH}\obsidian.exe" -ArgumentList '/S /V"/qn REBOOT=ReallySuppress"'
+            if (-not $obsidianProc.WaitForExit(120000)) {
+                Write-Output "WARNING: Obsidian installer (PID $($obsidianProc.Id)) did not exit within 120s; continuing without waiting further."
+            } else {
+                Write-Output "TRACE: Obsidian installer process exited (code $($obsidianProc.ExitCode))"
+            }
             # Obsidian uses a Squirrel/Electron installer that spawns a child process
             # (Update.exe) to perform the actual installation. Start-Process -Wait only
             # waits for the parent process, so the desktop shortcut may not exist yet.


### PR DESCRIPTION
## Summary

Continuing the `downloadFiles.ps1 -verify` investigation (#414-#419). #419 guarded the DNS-fix `netsh` calls to run once per sandbox session instead of once per tool, on the theory that repeated network reconfiguration was interfering with Obsidian's install. Two more `-verify` runs (one before, one after #419) show the `netsh` calls are indeed gone now, but the **exact same hang persists** - `install_winget.stdout.log` still stops dead right after `Installing Obsidian`, with no exception, no crash/hang event anywhere in Event Viewer, and an empty stderr log. That rules out the DNS theory too.

The diagnostic `TRACE:` line placed immediately after `Start-Process -Wait "${SETUP_PATH}\obsidian.exe" ...` (added in #416) never prints in either run - confirming `Start-Process -Wait` on the installer itself is simply never returning control. Since this blocks every tool listed after Obsidian in `install_winget.ps1` (PuTTY, QEMU, Ruby, VLC, WinMerge, Google Earth, Wireshark, Firefox, Foxit Reader), that's the actual root cause of the whole investigation.

Obsidian's installer is Squirrel/Electron-based (per the existing comment in `Install-Obsidian`), not an MSI/Inno-style installer, so it may not honor - or may be confused by - the `/V"/qn REBOOT=ReallySuppress"` MSI-passthrough flag currently being passed to it, and Squirrel installers are known to auto-launch the app after a silent install completes. I can't verify Obsidian's exact correct silent flags without documentation access, so rather than guess, this fixes the actual observed symptom directly.

## Changes

- `setup/wscommon.ps1`: `Install-Obsidian` now launches the installer with `Start-Process -PassThru` and waits via `Process.WaitForExit(120000)` (2 minutes) instead of `Start-Process -Wait`. `WaitForExit` returns `false` on timeout instead of throwing, so a misbehaving installer here logs a warning and lets the rest of `install_winget.ps1` continue instead of blocking it indefinitely.

## Test plan

- [ ] Run `.\downloadFiles.ps1 -Winget` then `.\downloadFiles.ps1 -Verify` and confirm PuTTY/QEMU/Ruby/VLC/WinMerge/Google Earth/Wireshark/Firefox/Foxit Reader now verify successfully.
- [ ] Check `log\install-logs\install_winget.stdout.log` for either `TRACE: Obsidian installer process exited (code ...)` or the new `WARNING: Obsidian installer ... did not exit within 120s` line, confirming the wait no longer hangs indefinitely either way.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JLikoRPNQVEd6yAzXhHFKw)_